### PR TITLE
Fix bug in Protocol selection widget

### DIFF
--- a/modules/mukurtu_protocol/src/Plugin/Field/FieldWidget/CulturalProtocolWidget.php
+++ b/modules/mukurtu_protocol/src/Plugin/Field/FieldWidget/CulturalProtocolWidget.php
@@ -58,7 +58,15 @@ class CulturalProtocolWidget extends WidgetBase {
     $label = FieldFilteredMarkup::create($label);
   }
 
-  protected function getOptions() {
+  /**
+   * Fetch community/protocol options.
+   *
+   * @return mixed[]
+   *   Array of all community/protocol options, indexed by ID.
+   */
+  protected function getOptions(): array {
+    $options = [];
+
     // Get the protocol options for the user.
     $protocolIds = CulturalProtocols::getProtocolsByUserPermission(['apply protocol']);
 


### PR DESCRIPTION
We spotted this exception on the Create Person page on a fresh Mukurtu 4 instance when no protocols were defined.

```bash
NOTICE: PHP message: TypeError: array_walk_recursive(): Argument #1 ($array) must be of type array, null given in /data/app/profiles/contrib/mukurtu-cms/modules/mukurtu_protocol/src/Plugin/Field/FieldWidget/CulturalProtocolWidget.php on line 99 #0 /data/app/profiles/contrib/mukurtu-cms/modules/mukurtu_protocol/src/Plugin/Field/FieldWidget/CulturalProtocolWidget.php(99): array_walk_recursive()
#1 /data/app/profiles/contrib/mukurtu-cms/modules/mukurtu_protocol/src/Plugin/Field/FieldWidget/CulturalProtocolWidget.php(130): Drupal\mukurtu_protocol\Plugin\Field\FieldWidget\CulturalProtocolWidget->getOptions()
#2 /data/app/core/lib/Drupal/Core/Field/WidgetBase.php(353): Drupal\mukurtu_protocol\Plugin\Field\FieldWidget\CulturalProtocolWidget->formElement()
#3 /data/app/core/lib/Drupal/Core/Field/WidgetBase.php(220): Drupal\Core\Field\WidgetBase->formSingleElement()
#4 /data/app/core/lib/Drupal/Core/Field/WidgetBase.php(111): Drupal\Core\Field\WidgetBase->formMultipleElements()
#5 /data/app/core/lib/Drupal/Core/Entity/Entity/EntityFormDisplay.php(183): Drupal\Core\Field\WidgetBase->form()
#6 /data/app/core/lib/Drupal/Core/Entity/ContentEntityForm.php(121): Drupal\Core\Entity\Entity\EntityFormDisplay->buildForm()
#7 /data/app/core/modules/node/src/NodeForm.php(127): Drupal\Core\Entity\ContentEntityForm->form()
...
```

The proposed change ensures that we will be returning an array from `CulturalProtocolWidget::getOptions`, even if it's empty, therefore not risking the change of ending up with a NULL.