### PR TITLE
Uncheck the checkbox to ensure empty paragraph doesn't render

### DIFF
--- a/modules/mukurtu_digital_heritage/config/install/paragraphs.paragraphs_type.indigenous_knowledge_keepers.yml
+++ b/modules/mukurtu_digital_heritage/config/install/paragraphs.paragraphs_type.indigenous_knowledge_keepers.yml
@@ -6,4 +6,5 @@ label: 'Citing Indigenous Elders and Knowledge Keepers'
 icon_uuid: null
 icon_default: null
 description: 'A field to cite Indigenous elders and Knowledge Keepers.'
+save_empty: false
 behavior_plugins: {  }


### PR DESCRIPTION
This took entirely too long, but I believe this piece of config is all that's needed to ensure the empty paragraph doesn't render. 

The patch is applying, and it provides a boolean on the edit paragraph screen. By default the box is checked, I think likely to not interfere with existing paragraphs on a production site. But in our case, we want the checkbox UNchecked. 