### PR TITLE
610: Use new mukurtu-template project in Tugboat.

### DIFF
--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -34,13 +34,10 @@ services:
           chmod 755 ~
           mkdir ~/mukurtu
           cd ~/mukurtu
-          # @todo Replace with composer create-project. See #610.
-          wget https://raw.githubusercontent.com/MukurtuCMS/Mukurtu-CMS-v4-Project-Template/main/composer.json
-          # Remove the VCS-based repository.
-          composer config --unset repositories.5
+          composer create mukurtu/mukurtu-template:dev-main .
           # Add our own local checkout repository instead. This will use the
           # local directory as the source, copying it into the final location.
-          composer config repositories.local-mukurtu path $TUGBOAT_ROOT
+          composer config repositories.local-dev path $TUGBOAT_ROOT
           composer install --no-ansi --no-interaction --optimize-autoloader --no-progress
 
         # Symlink the web root and grant read access to the home directory.
@@ -60,6 +57,7 @@ services:
           # Copy in the settings.php file to set the database connection.
           cp $TUGBOAT_ROOT/.tugboat/settings.tugboat.php web/sites/default/settings.php
           # Update composer dependencies.
+          rm composer.lock
           composer update --no-ansi --no-interaction --optimize-autoloader --no-progress
           # Install Drupal with the Mukurtu installation profile.
           ./vendor/bin/drush site-install mukurtu -y --account-pass="admin" --site-name="Mukurtu CMS"

--- a/composer.json
+++ b/composer.json
@@ -12,43 +12,6 @@
         {
             "type": "composer",
             "url": "https://asset-packagist.org"
-        },
-        {
-            "type": "package",
-            "package": {
-                "name": "mukurtu/masonry",
-                "version": "4.2.2",
-                "dist": {
-                    "url": "https://github.com/desandro/masonry/archive/v4.2.2.zip",
-                    "type": "zip"
-                },
-                "type": "drupal-library"
-            }
-        },
-        {
-            "type": "package",
-            "package": {
-                "name": "mukurtu/colorbox",
-                "version": "1.6.4",
-                "dist": {
-                    "url": "https://github.com/jackmoore/colorbox/archive/master.zip",
-                    "type": "zip"
-                },
-                "type": "drupal-library"
-            }
-        },
-        {
-            "type": "package",
-            "package": {
-                "name": "mukurtu/og",
-                "version": "1.0.0",
-                "type": "drupal-module",
-                "source": {
-                    "url": "https://github.com/zerolab/og.git",
-                    "type": "git",
-                    "reference": "196-redux"
-                }
-            }
         }
     ],
     "require": {
@@ -110,13 +73,6 @@
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0"
     },
     "config": {
-        "allow-plugins": {
-            "cweagans/composer-patches": true,
-            "composer/installers": true,
-            "drupal/core-composer-scaffold": true,
-            "drupal/core-project-message": true,
-            "drupal/console-extend-plugin": true,
-            "dealerdirect/phpcodesniffer-composer-installer": true
-        }
+        "sort-packages": true
     }
 }


### PR DESCRIPTION
Relates to https://github.com/MukurtuCMS/Mukurtu-CMS/issues/610

Now that we have the new `mukurtu/mukurtu-template` [project registered with Packagist](https://packagist.org/packages/mukurtu/mukurtu-template), we should start using it in our Tugboat previews.

This should demonstrate the new template is working correctly.