### PR TITLE
610: Use new mukurtu-template project in Testing

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -26,11 +26,6 @@ jobs:
         ports:
           - 3306:3306
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          path: web/profiles/mukurtu-cms
-
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -54,15 +49,27 @@ jobs:
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
           restore-keys: ${{ runner.os }}-composer-
 
+      # Install the mukurtu-template into the root, then remove the packaged
+      # version of mukurtu-cms, which will be replaced by the git checkout.
+      - name: Install Mukurtu Template
+        run: |
+          composer create mukurtu/mukurtu-template:dev-main . --no-install --no-interaction
+          rm web/profiles/contrib/mukurtu-cms -rf
+
+      # Usually checkout is the first action, but we set up the mukurtu-template
+      # first, then put the checkout inside of it.
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          path: web/profiles/contrib/mukurtu-cms
+
       - name: Install Mukurtu
         run: |
-          cp ./web/profiles/mukurtu-cms/phpunit.xml ./web/phpunit.xml
-          cp ./web/profiles/mukurtu-cms/mukurtu-gitpod-site.composer.json composer.json
-          composer require --dev phpspec/prophecy-phpunit:^2
-          composer --no-interaction --no-progress --prefer-dist --optimize-autoloader install
+          composer config repositories.local-dev path web/profiles/contrib/mukurtu-cms
+          composer install --no-interaction --optimize-autoloader
+          cp ./web/profiles/contrib/mukurtu-cms/phpunit.xml ./phpunit.xml
 
       - name: Mukurtu Tests
         run: |
-          cd ./web
-          ../vendor/bin/phpunit --verbose --testsuite "${{ matrix.test-suite }}"
+          ./vendor/bin/phpunit --verbose --testsuite "${{ matrix.test-suite }}"
         continue-on-error: false

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -6,15 +6,15 @@
  or your current system user. See core/tests/README.md and
  https://www.drupal.org/node/2116263 for details.
 -->
-<phpunit bootstrap="core/tests/bootstrap.php" colors="true"
+<phpunit bootstrap="web/core/tests/bootstrap.php" colors="true"
          beStrictAboutTestsThatDoNotTestAnything="true"
          beStrictAboutOutputDuringTests="true"
          beStrictAboutChangesToGlobalState="true"
          failOnWarning="true"
          printerClass="\Drupal\Tests\Listeners\HtmlOutputPrinter"
-	cacheResult="false"
-	verbose="true"
-	>
+         cacheResult="false"
+         verbose="true"
+>
   <php>
     <!-- Set error reporting to E_ALL. -->
     <ini name="error_reporting" value="32767"/>
@@ -42,22 +42,25 @@
   </php>
   <testsuites>
     <testsuite name="kernel">
-      <directory>./profiles/mukurtu-cms/modules/mukurtu_protocol/tests/src/Kernel</directory>
+      <directory>web/profiles/contrib/mukurtu-cms/modules/mukurtu_protocol/tests/src/Kernel</directory>
     </testsuite>
     <testsuite name="kernel">
-      <directory>./profiles/mukurtu-cms/modules/mukurtu_collection/tests/src/Kernel</directory>
+      <directory>web/profiles/contrib/mukurtu-cms/modules/mukurtu_collection/tests/src/Kernel</directory>
     </testsuite>
     <testsuite name="kernel">
-      <directory>./profiles/mukurtu-cms/modules/mukurtu_import/tests/src/Kernel</directory>
+      <directory>web/profiles/contrib/mukurtu-cms/modules/mukurtu_import/tests/src/Kernel</directory>
     </testsuite>
     <testsuite name="kernel">
-      <directory>./profiles/mukurtu-cms/modules/mukurtu_export/tests/src/Kernel</directory>
+      <directory>web/profiles/contrib/mukurtu-cms/modules/mukurtu_export/tests/src/Kernel</directory>
     </testsuite>
     <testsuite name="kernel">
-      <directory>./profiles/mukurtu-cms/modules/mukurtu_drafts/tests/src/Kernel</directory>
+      <directory>web/profiles/contrib/mukurtu-cms/modules/mukurtu_drafts/tests/src/Kernel</directory>
+    </testsuite>
+    <testsuite name="kernel">
+      <directory>web/profiles/contrib/mukurtu-cms/modules/original_date/tests/src/Kernel</directory>
     </testsuite>
     <testsuite name="functional">
-      <directory>./profiles/mukurtu-cms/modules/mukurtu_protocol/tests/src/Functional</directory>
+      <directory>web/profiles/contrib/mukurtu-cms/modules/mukurtu_protocol/tests/src/Functional</directory>
     </testsuite>
   </testsuites>
   <listeners>
@@ -83,6 +86,6 @@
         <directory>../modules/*/*/tests</directory>
       </exclude>
       <directory>../sites</directory>
-     </whitelist>
+    </whitelist>
   </filter>
 </phpunit>


### PR DESCRIPTION
Removes `mukurtu-gitpod-site.composer.json` and switches the installation of ~both GitPod and~ the `build-and-test.yml` to use the new [mukurtu-template](https://github.com/MukurtuCMS/mukurtu-template) project.

GitPod set up moved to https://github.com/MukurtuCMS/Mukurtu-CMS/pull/636