### PR TITLE
Fix permissions on Tugboat base preview build.

### DIFF
--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -65,8 +65,10 @@ services:
           # Update composer dependencies.
           rm composer.lock
           composer update --no-ansi --no-interaction --optimize-autoloader --no-progress
-          # Install Drupal with the Mukurtu installation profile.
-          ./vendor/bin/drush site-install mukurtu -y --account-pass="admin" --site-name="Mukurtu CMS"
+          # Install Drupal with the Mukurtu installation profile. Run as web
+          # user to create files with the right permissions. Pass in the
+          # environment variables from Tugboat using the -E option.
+          sudo -E -u www-data ./vendor/bin/drush site-install mukurtu -y --account-pass="admin" --site-name="Mukurtu CMS"
   mariadb:
     image: tugboatqa/mariadb:lts
     commands:

--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -62,6 +62,7 @@ services:
           cd ~/mukurtu
           # Copy in the settings.php file to set the database connection.
           cp $TUGBOAT_ROOT/.tugboat/settings.tugboat.php web/sites/default/settings.php
+          chown www-data:www-data web/sites/default/settings.php
           # Update composer dependencies.
           rm composer.lock
           composer update --no-ansi --no-interaction --optimize-autoloader --no-progress

--- a/.tugboat/settings.tugboat.php
+++ b/.tugboat/settings.tugboat.php
@@ -32,3 +32,6 @@ $settings['skip_permissions_hardening'] = TRUE;
 
 // Specify a private files path.
 $settings['file_private_path'] = '../private_files';
+
+// Specify a config directory.
+$settings['config_sync_directory'] = 'sites/default/files/sync';


### PR DESCRIPTION
@michael-wynne-wsu noted during our meeting Wednesday that the Tugboat base preview was failing after automatically building most mornings.

I got a chance to see the failed build today and it had this error in the log:

```
  :<br /><br />The directory &lt;em class=&quot;placeholder&quot;&gt;public:/  
  /media-icons/generic&lt;/em&gt; is not writable. An automated attempt to cr  
  eate this directory failed, possibly due to a permissions problem. To proce  
  ed with the installation, either create the directory and modify its permis  
  sions manually or ensure that the installer has the permissions to create i  
  t automatically. For more information, see INSTALL.txt or the &lt;a href=&q  
  uot;https://www.drupal.org/server-permissions&quot;&gt;online handbook&lt;/  
  a&gt;.
```

Looking at the Terminal, it looks like the `sites/default/files/media-icons/generic` directory was being created and owned by the "root" user, which then made it so that the PHP user could not further update those files.

I think this problem is solved by running the installer as the web user, via `sudo`. Let's try this change and see if it fixes the base preview rebuild problem.