### PR TITLE
ensure paragraph types hide if empty

### DIFF
--- a/modules/mukurtu_dictionary/config/install/paragraphs.paragraphs_type.dictionary_word_entry.yml
+++ b/modules/mukurtu_dictionary/config/install/paragraphs.paragraphs_type.dictionary_word_entry.yml
@@ -2,8 +2,9 @@ langcode: en
 status: true
 dependencies: {  }
 id: dictionary_word_entry
-label: 'Dictionary Word Entry'
+label: 'Word Entry'
 icon_uuid: null
 icon_default: null
-description: ''
+description: 'A paragraph type that appears on the Dictionary Word content type. '
+save_empty: false
 behavior_plugins: {  }

--- a/modules/mukurtu_dictionary/config/install/paragraphs.paragraphs_type.sample_sentence.yml
+++ b/modules/mukurtu_dictionary/config/install/paragraphs.paragraphs_type.sample_sentence.yml
@@ -6,4 +6,5 @@ label: 'Sample Sentence'
 icon_uuid: null
 icon_default: null
 description: ''
+save_empty: false
 behavior_plugins: {  }

--- a/modules/mukurtu_dictionary/src/Entity/DictionaryWord.php
+++ b/modules/mukurtu_dictionary/src/Entity/DictionaryWord.php
@@ -274,7 +274,7 @@ class DictionaryWord extends Node implements DictionaryWordInterface, CulturalPr
         ]
       ])
       ->setCardinality(-1)
-      ->setRequired(TRUE)
+      ->setRequired(FALSE)
       ->setRevisionable(TRUE)
       ->setTranslatable(TRUE)
       ->setDisplayConfigurable('view', TRUE)

--- a/modules/mukurtu_dictionary/src/Entity/DictionaryWordEntry.php
+++ b/modules/mukurtu_dictionary/src/Entity/DictionaryWordEntry.php
@@ -123,7 +123,7 @@ class DictionaryWordEntry extends Paragraph implements DictionaryWordEntryInterf
         ]
       ])
       ->setCardinality(-1)
-      ->setRequired(TRUE)
+      ->setRequired(FALSE)
       ->setRevisionable(TRUE)
       ->setTranslatable(TRUE)
       ->setDisplayConfigurable('view', TRUE)

--- a/modules/mukurtu_digital_heritage/config/install/paragraphs.paragraphs_type.indigenous_knowledge_keepers.yml
+++ b/modules/mukurtu_digital_heritage/config/install/paragraphs.paragraphs_type.indigenous_knowledge_keepers.yml
@@ -6,5 +6,5 @@ label: 'Citing Indigenous Elders and Knowledge Keepers'
 icon_uuid: null
 icon_default: null
 description: 'A field to cite Indigenous elders and Knowledge Keepers.'
-save_empty: true
+save_empty: false
 behavior_plugins: {  }

--- a/modules/mukurtu_digital_heritage/config/install/paragraphs.paragraphs_type.indigenous_knowledge_keepers.yml
+++ b/modules/mukurtu_digital_heritage/config/install/paragraphs.paragraphs_type.indigenous_knowledge_keepers.yml
@@ -6,5 +6,5 @@ label: 'Citing Indigenous Elders and Knowledge Keepers'
 icon_uuid: null
 icon_default: null
 description: 'A field to cite Indigenous elders and Knowledge Keepers.'
-save_empty: false
+save_empty: true
 behavior_plugins: {  }

--- a/modules/mukurtu_person/config/install/paragraphs.paragraphs_type.formatted_text_with_title.yml
+++ b/modules/mukurtu_person/config/install/paragraphs.paragraphs_type.formatted_text_with_title.yml
@@ -1,9 +1,13 @@
+uuid: 5963a234-3e98-4f33-a922-c1ce2c75c8e8
 langcode: en
 status: true
 dependencies: {  }
+_core:
+  default_config_hash: UUj3_FRR5MBz2G9pVbRy0mi9koayi_RAYUooOqJT-AQ
 id: formatted_text_with_title
 label: 'Formatted Text with Title'
 icon_uuid: null
 icon_default: null
 description: ''
+save_empty: false
 behavior_plugins: {  }

--- a/modules/mukurtu_person/config/install/paragraphs.paragraphs_type.formatted_text_with_title.yml
+++ b/modules/mukurtu_person/config/install/paragraphs.paragraphs_type.formatted_text_with_title.yml
@@ -1,9 +1,6 @@
-uuid: 5963a234-3e98-4f33-a922-c1ce2c75c8e8
 langcode: en
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: UUj3_FRR5MBz2G9pVbRy0mi9koayi_RAYUooOqJT-AQ
 id: formatted_text_with_title
 label: 'Formatted Text with Title'
 icon_uuid: null

--- a/modules/mukurtu_person/config/install/paragraphs.paragraphs_type.related_person.yml
+++ b/modules/mukurtu_person/config/install/paragraphs.paragraphs_type.related_person.yml
@@ -6,4 +6,5 @@ label: 'Related Person'
 icon_uuid: null
 icon_default: null
 description: ''
+save_empty: false
 behavior_plugins: {  }


### PR DESCRIPTION
Closes #663 

To test, create a DH item and do not enter content in the indigenous knowledge keepers paragraph field. Save and note that there is no empty sidebar block.

Can also test with dictionary word nodes (leave paragraph field content empty, save, and view node).