### PR TITLE
672: Move mukurtu profile to expected location.

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -54,20 +54,20 @@ jobs:
       - name: Install Mukurtu Template
         run: |
           composer create mukurtu/mukurtu-template:dev-main . --no-install --no-interaction
-          rm web/profiles/contrib/mukurtu-cms -rf
+          rm web/profiles/mukurtu -rf
 
       # Usually checkout is the first action, but we set up the mukurtu-template
       # first, then put the checkout inside of it.
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          path: web/profiles/contrib/mukurtu-cms
+          path: web/profiles/mukurtu
 
       - name: Install Mukurtu
         run: |
-          composer config repositories.local-dev path web/profiles/contrib/mukurtu-cms
+          composer config repositories.local-dev path web/profiles/mukurtu
           composer install --no-interaction --optimize-autoloader
-          cp ./web/profiles/contrib/mukurtu-cms/phpunit.xml ./phpunit.xml
+          cp ./web/profiles/mukurtu/phpunit.xml ./phpunit.xml
 
       - name: Mukurtu Tests
         run: |

--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -39,6 +39,7 @@ services:
           # Add our own local checkout repository instead. This will use the
           # local directory as the source, copying it into the final location.
           composer config repositories.local-dev path $TUGBOAT_ROOT
+          composer update --no-install
           composer install --no-ansi --no-interaction --optimize-autoloader --no-progress
 
         # Symlink the web root and grant read access to the home directory.

--- a/composer.json
+++ b/composer.json
@@ -82,7 +82,7 @@
                 "Fix illegal choice on exposed sort error": "https://www.drupal.org/files/issues/2022-01-17/3259018-6-illegal-sort-choice.patch"
             },
             "drupal/paragraphs": {
-                "Ensure empty paragraphs register as empty": "web/profiles/contrib/mukurtu-cms/patches/paragraphs-118.patch"
+                "Ensure empty paragraphs register as empty": "web/profiles/mukurtu/patches/paragraphs-118.patch"
             }
         }
     }

--- a/phpunit.ddev.xml
+++ b/phpunit.ddev.xml
@@ -42,25 +42,25 @@
   </php>
   <testsuites>
     <testsuite name="kernel">
-      <directory>/var/www/html/web/profiles/contrib/mukurtu-cms/modules/mukurtu_protocol/tests/src/Kernel</directory>
+      <directory>/var/www/html/web/profiles/mukurtu/modules/mukurtu_protocol/tests/src/Kernel</directory>
     </testsuite>
     <testsuite name="kernel">
-      <directory>/var/www/html/web/profiles/contrib/mukurtu-cms/modules/mukurtu_collection/tests/src/Kernel</directory>
+      <directory>/var/www/html/web/profiles/mukurtu/modules/mukurtu_collection/tests/src/Kernel</directory>
     </testsuite>
     <testsuite name="kernel">
-      <directory>/var/www/html/web/profiles/contrib/mukurtu-cms/modules/mukurtu_import/tests/src/Kernel</directory>
+      <directory>/var/www/html/web/profiles/mukurtu/modules/mukurtu_import/tests/src/Kernel</directory>
     </testsuite>
     <testsuite name="kernel">
-      <directory>/var/www/html/web/profiles/contrib/mukurtu-cms/modules/mukurtu_export/tests/src/Kernel</directory>
+      <directory>/var/www/html/web/profiles/mukurtu/modules/mukurtu_export/tests/src/Kernel</directory>
     </testsuite>
     <testsuite name="kernel">
-      <directory>/var/www/html/web/profiles/contrib/mukurtu-cms/modules/mukurtu_drafts/tests/src/Kernel</directory>
+      <directory>/var/www/html/web/profiles/mukurtu/modules/mukurtu_drafts/tests/src/Kernel</directory>
     </testsuite>
     <testsuite name="kernel">
-      <directory>/var/www/html/web/profiles/contrib/mukurtu-cms/modules/original_date/tests/src/Kernel</directory>
+      <directory>/var/www/html/web/profiles/mukurtu/modules/original_date/tests/src/Kernel</directory>
     </testsuite>
     <testsuite name="functional">
-      <directory>/var/www/html/web/profiles/contrib/mukurtu-cms/modules/mukurtu_protocol/tests/src/Functional</directory>
+      <directory>/var/www/html/web/profiles/mukurtu/modules/mukurtu_protocol/tests/src/Functional</directory>
     </testsuite>
   </testsuites>
   <listeners>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -42,25 +42,25 @@
   </php>
   <testsuites>
     <testsuite name="kernel">
-      <directory>web/profiles/contrib/mukurtu-cms/modules/mukurtu_protocol/tests/src/Kernel</directory>
+      <directory>web/profiles/mukurtu/modules/mukurtu_protocol/tests/src/Kernel</directory>
     </testsuite>
     <testsuite name="kernel">
-      <directory>web/profiles/contrib/mukurtu-cms/modules/mukurtu_collection/tests/src/Kernel</directory>
+      <directory>web/profiles/mukurtu/modules/mukurtu_collection/tests/src/Kernel</directory>
     </testsuite>
     <testsuite name="kernel">
-      <directory>web/profiles/contrib/mukurtu-cms/modules/mukurtu_import/tests/src/Kernel</directory>
+      <directory>web/profiles/mukurtu/modules/mukurtu_import/tests/src/Kernel</directory>
     </testsuite>
     <testsuite name="kernel">
-      <directory>web/profiles/contrib/mukurtu-cms/modules/mukurtu_export/tests/src/Kernel</directory>
+      <directory>web/profiles/mukurtu/modules/mukurtu_export/tests/src/Kernel</directory>
     </testsuite>
     <testsuite name="kernel">
-      <directory>web/profiles/contrib/mukurtu-cms/modules/mukurtu_drafts/tests/src/Kernel</directory>
+      <directory>web/profiles/mukurtu/modules/mukurtu_drafts/tests/src/Kernel</directory>
     </testsuite>
     <testsuite name="kernel">
-      <directory>web/profiles/contrib/mukurtu-cms/modules/original_date/tests/src/Kernel</directory>
+      <directory>web/profiles/mukurtu/modules/original_date/tests/src/Kernel</directory>
     </testsuite>
     <testsuite name="functional">
-      <directory>web/profiles/contrib/mukurtu-cms/modules/mukurtu_protocol/tests/src/Functional</directory>
+      <directory>web/profiles/mukurtu/modules/mukurtu_protocol/tests/src/Functional</directory>
     </testsuite>
   </testsuites>
   <listeners>


### PR DESCRIPTION
Second step of https://github.com/MukurtuCMS/Mukurtu-CMS/issues/672.

We need to put the `mukurtu` profile where Features module expects it to be. The naming of the profile directory `mukurtu-cms` while the profile itself is named `mukurtu` is confusing it. Lining up this directory name to match the profile name will fix this problem and likely avoid others in the future.

As discussed last week, this also eliminates the unnecessarily nested `contrib` directory, so `web/profiles/contrib/mukurtu-cms` now becomes `web/profiles/mukurtu`.