### PR TITLE
683: Set Composer dependencies to use Drupal 10.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,12 +20,11 @@
         "drupal/blazy": "^2.24",
         "drupal/colorbox": "2.0.2",
         "drupal/config_pages": "^2.15",
-        "drupal/console": "~1.0",
         "drupal/content_browser": "*",
-        "drupal/core": "^9.5.3",
-        "drupal/core-composer-scaffold": "^9.5.3",
-        "drupal/core-project-message": "^9.5.3",
-        "drupal/core-recommended": "^9.5.3",
+        "drupal/core": "^10.4.1",
+        "drupal/core-composer-scaffold": "^10.4.1",
+        "drupal/core-project-message": "^10.4.1",
+        "drupal/core-recommended": "^10.4.1",
         "drupal/csv_serialization": "*",
         "drupal/ctools": "*",
         "drupal/embed": "*",
@@ -62,14 +61,14 @@
         "drupal/twig_tweak": "^3.2",
         "drupal/views_bulk_operations": "*",
         "mukurtu/colorbox": "*",
-        "drush/drush": "^10",
+        "drush/drush": "^13",
         "mukurtu/masonry": "*",
         "sibyx/phpgpx": "@RC"
     },
     "require-dev": {
         "drupal/devel": "*",
         "drupal/core-dev": "*",
-        "drupal/coder": "^8.3",
+        "drupal/coder": "*",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0"
     },
     "config": {


### PR DESCRIPTION
Part of https://github.com/MukurtuCMS/Mukurtu-CMS/issues/683.

In my testing, Drupal 10 can actually mostly run (after https://github.com/MukurtuCMS/Mukurtu-CMS/pull/698 is merged). I'll come back to this PR once other prerequisite D10 issues are completed.