### PR TITLE
Installing WebP support within Tugboat (for Drupal 10.3 support).

### DIFF
--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -8,10 +8,10 @@ services:
       init:
         # Install dependencies for PHP extensions.
         # Add poppler-utils for the pdftotext executable.
-        - apt update && apt install -y libzip-dev libpng-dev libjpeg-dev libfreetype6-dev poppler-utils
+        - apt update && apt install -y libzip-dev libpng-dev libjpeg-dev libwebp-dev libfreetype6-dev poppler-utils
 
         # Add JPEG and FreeType support to GD.
-        - docker-php-ext-configure gd --with-jpeg --with-freetype
+        - docker-php-ext-configure gd --with-jpeg --with-webp --with-freetype
 
         # Install the PHP extensions all at once to minimize rebuilding.
         - docker-php-ext-install zip opcache gd


### PR DESCRIPTION
This installs WebP on Tugboat so that it is available for Drupal 10+, which uses WebP by default on the out-of-box image styles.