### PR TITLE
678: Disable Tour module, which is removed from Drupal 11.

### DIFF
--- a/modules/mukurtu_core/mukurtu_core.features.yml
+++ b/modules/mukurtu_core/mukurtu_core.features.yml
@@ -16,7 +16,6 @@ excluded:
   - core.entity_view_mode.node.token
   - core.entity_view_mode.path_alias.token
   - core.entity_view_mode.shortcut.token
-  - core.entity_view_mode.tour.token
   - core.entity_view_mode.flagging.token
   - core.entity_view_mode.media.token
   - core.entity_view_mode.taxonomy_term.token

--- a/modules/mukurtu_dev/config/install/features.bundle.default.yml
+++ b/modules/mukurtu_dev/config/install/features.bundle.default.yml
@@ -77,7 +77,6 @@ assignments:
         configurable_language: configurable_language
         migration: migration
         shortcut_set: shortcut_set
-        tour: tour
     enabled: true
     weight: 10
   site:

--- a/mukurtu.info.yml
+++ b/mukurtu.info.yml
@@ -40,7 +40,6 @@ install:
   - file
   - views
   - views_ui
-  - tour
   - automated_cron
   - google_analytics
   - twig_tweak
@@ -77,7 +76,6 @@ dependencies:
   - 'drupal:taxonomy'
   - 'drupal:text'
   - 'drupal:toolbar'
-  - 'drupal:tour'
   - 'drupal:user'
   - 'drupal:views'
   - 'embed:embed'


### PR DESCRIPTION
Part of #678: We should disable Tour module, as it is removed from Drupal 11. Tour module provides the ability to show popup hints, walking through steps to introduce software. This may actually be useful for Mukurtu, but we would pivot to the contrib module: https://www.drupal.org/project/tour

For the sake of upgrading to Drupal 11, we just need to turn this module off for the time being. There does not seem to be any existing integrations in Mukurtu.

![image](https://github.com/user-attachments/assets/41b311aa-6e75-42c1-87a2-3bba888fe49d)
