### PR TITLE
691: Fixing configuration of the 'search_api_db_mukurtu_browse_auto_index' Search API index to use fewer full text fields.

### DIFF
--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -79,10 +79,6 @@ services:
         - mariadb -e "SET GLOBAL max_allowed_packet = 536870912;"
         # Ensure this packet size persists even if MySQL restarts.
         - echo "max_allowed_packet = 536870912" >> /etc/mysql/conf.d/tugboat.cnf
-        # Disable strict mode to allow for longer table indexes needed by
-        # Search API.
-        - mariadb -e "SET GLOBAL innodb_strict_mode = 0;"
-        - echo "innodb_strict_mode = 0" >> /etc/mysql/conf.d/tugboat.cnf
       build:
         # Drop and re-create the database (needed when rebuilding/reinstalling).
         - mariadb-admin -f drop tugboat && mariadb-admin create tugboat

--- a/modules/mukurtu_search/config/install/search_api.index.mukurtu_browse_auto_index.yml
+++ b/modules/mukurtu_search/config/install/search_api.index.mukurtu_browse_auto_index.yml
@@ -38,7 +38,7 @@ field_settings:
     label: 'Category » Taxonomy term » UUID'
     datasource_id: 'entity:node'
     property_path: 'field_article_category:entity:uuid'
-    type: text
+    type: string
     dependencies:
       config:
         - field.storage.node.field_article_category
@@ -48,7 +48,7 @@ field_settings:
     label: 'Keywords » Taxonomy term » UUID'
     datasource_id: 'entity:node'
     property_path: 'field_article_keywords:entity:uuid'
-    type: text
+    type: string
     dependencies:
       config:
         - field.storage.node.field_article_keywords
@@ -58,7 +58,7 @@ field_settings:
     label: Category
     datasource_id: 'entity:node'
     property_path: 'field_category:entity:name'
-    type: string
+    type: text
     dependencies:
       module:
         - node
@@ -67,7 +67,7 @@ field_settings:
     label: 'Category » Taxonomy term » UUID'
     datasource_id: 'entity:node'
     property_path: 'field_category:entity:uuid'
-    type: text
+    type: string
     dependencies:
       module:
         - node
@@ -84,7 +84,7 @@ field_settings:
     label: 'Contributor » Taxonomy term » UUID'
     datasource_id: 'entity:node'
     property_path: 'field_contributor:entity:uuid'
-    type: text
+    type: string
     dependencies:
       module:
         - node
@@ -93,7 +93,7 @@ field_settings:
     label: 'Creator » Taxonomy term » UUID'
     datasource_id: 'entity:node'
     property_path: 'field_creator:entity:uuid'
-    type: text
+    type: string
     dependencies:
       module:
         - node
@@ -102,7 +102,7 @@ field_settings:
     label: 'Language » Taxonomy term » UUID'
     datasource_id: 'entity:node'
     property_path: 'field_dictionary_word_language:entity:uuid'
-    type: text
+    type: string
     dependencies:
       module:
         - node
@@ -111,7 +111,7 @@ field_settings:
     label: 'Format » Taxonomy term » UUID'
     datasource_id: 'entity:node'
     property_path: 'field_format:entity:uuid'
-    type: text
+    type: string
     dependencies:
       module:
         - node
@@ -129,7 +129,7 @@ field_settings:
     label: 'Keywords » Taxonomy term » UUID'
     datasource_id: 'entity:node'
     property_path: 'field_keywords:entity:uuid'
-    type: text
+    type: string
     dependencies:
       module:
         - node
@@ -138,7 +138,7 @@ field_settings:
     label: 'Language » Taxonomy term » UUID'
     datasource_id: 'entity:node'
     property_path: 'field_language:entity:uuid'
-    type: text
+    type: string
     dependencies:
       module:
         - node
@@ -147,7 +147,7 @@ field_settings:
     label: 'Location » Taxonomy term » UUID'
     datasource_id: 'entity:node'
     property_path: 'field_location:entity:uuid'
-    type: text
+    type: string
     dependencies:
       module:
         - node
@@ -156,7 +156,7 @@ field_settings:
     label: 'People » Taxonomy term » UUID'
     datasource_id: 'entity:node'
     property_path: 'field_people:entity:uuid'
-    type: text
+    type: string
     dependencies:
       module:
         - node
@@ -165,7 +165,7 @@ field_settings:
     label: 'Publisher » Taxonomy term » UUID'
     datasource_id: 'entity:node'
     property_path: 'field_publisher:entity:uuid'
-    type: text
+    type: string
     dependencies:
       module:
         - node
@@ -174,7 +174,7 @@ field_settings:
     label: 'Representative Terms » Taxonomy term » UUID'
     datasource_id: 'entity:node'
     property_path: 'field_representative_terms:entity:uuid'
-    type: text
+    type: string
     dependencies:
       module:
         - node
@@ -183,7 +183,7 @@ field_settings:
     label: 'Subject » Taxonomy term » UUID'
     datasource_id: 'entity:node'
     property_path: 'field_subject:entity:uuid'
-    type: text
+    type: string
     dependencies:
       module:
         - node
@@ -192,7 +192,7 @@ field_settings:
     label: 'Type » Taxonomy term » UUID'
     datasource_id: 'entity:node'
     property_path: 'field_type:entity:uuid'
-    type: text
+    type: string
     dependencies:
       module:
         - node
@@ -201,7 +201,7 @@ field_settings:
     label: 'Word Type » Taxonomy term » UUID'
     datasource_id: 'entity:node'
     property_path: 'field_word_type:entity:uuid'
-    type: text
+    type: string
     dependencies:
       module:
         - node
@@ -230,7 +230,7 @@ field_settings:
     type_locked: true
     hidden: true
   status:
-    label: null
+    label: Status
     datasource_id: 'entity:node'
     property_path: status
     type: boolean
@@ -240,7 +240,7 @@ field_settings:
       module:
         - node
   uid:
-    label: null
+    label: UID
     datasource_id: 'entity:node'
     property_path: uid
     type: integer
@@ -260,6 +260,7 @@ datasource_settings:
 processor_settings:
   add_url: {  }
   aggregated_field: {  }
+  auto_aggregated_fulltext_field: {  }
   content_access:
     weights:
       preprocess_query: -30
@@ -334,22 +335,7 @@ processor_settings:
       preprocess_query: -6
     all_fields: true
     fields:
-      - node__field_article_category__uuid
-      - node__field_article_keywords__uuid
-      - node__field_category__uuid
-      - node__field_contributor__uuid
-      - node__field_creator__uuid
-      - node__field_dictionary_word_language__uuid
-      - node__field_format__uuid
-      - node__field_keywords__uuid
-      - node__field_language__uuid
-      - node__field_location__uuid
-      - node__field_people__uuid
-      - node__field_publisher__uuid
-      - node__field_representative_terms__uuid
-      - node__field_subject__uuid
-      - node__field_type__uuid
-      - node__field_word_type__uuid
+      - node__field_category__name
       - node__title
     spaces: ''
     ignored: ._-


### PR DESCRIPTION
Fixes https://github.com/MukurtuCMS/Mukurtu-CMS/issues/691

This seems to fix installation issues with the `search_api_db_mukurtu_browse_auto_index` Search API index.

This index seemed to be configured almost exactly opposite the way it should be, with 16 fields that are UUIDs being "Fulltext" instead of "String", and the Taxonomy label being "String" instead of "Fulltext". This PR brings this index in line with the other indexes, using strings for UUIDs. By reducing the amount of data in a table, this seems to resolve the installation issues.