### PR TITLE
678: Remove the Tour module permission.

### DIFF
--- a/mukurtu.install
+++ b/mukurtu.install
@@ -193,7 +193,6 @@ function mukurtu_install() {
     'access site-wide contact form',
     'access taxonomy overview',
     'access toolbar',
-    'access tour',
     'access user contact forms',
     'access user profiles',
     'add JS snippets for google analytics',


### PR DESCRIPTION
Follow-up to https://github.com/MukurtuCMS/Mukurtu-CMS/pull/706

When I disabled Tour module I forgot to remove the associated permission, which is causing a warning during installation that the permission no longer exists:

![image](https://github.com/user-attachments/assets/eda02bc8-7194-40c2-ba11-2d291539851b)

This removes the no longer existing permission from the install process.