### PR TITLE
110: Upgrade Leaflet to version 10.2, updating custom widget and formatter.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "drupal/flag": "*",
         "drupal/geofield": "^1.59",
         "drupal/geolocation": "*",
-        "drupal/leaflet": "^2.1",
+        "drupal/leaflet": "^10.2",
         "drupal/message": "^1.5",
         "drupal/message_digest": "^1.3",
         "drupal/message_digest_ui": "*",

--- a/modules/mukurtu_browse/src/Plugin/views/argument/MukurtuBoundingBox.php
+++ b/modules/mukurtu_browse/src/Plugin/views/argument/MukurtuBoundingBox.php
@@ -37,12 +37,6 @@ class MukurtuBoundingBox extends SearchApiStandard {
     // Parse argument into bottom/top/left/right.
     $bbox = $this->parseBoundingBox();
 
-    // Make sure our location fields exist.
-    $fields = $this->query->getIndex()->getFields();
-    if (isset($fields['field_coverage'])) {
-      //dpm($fields['field_mukurtu_geojson']);
-    }
-
     // Alter the query to restrict to our bounding box.
     if (!empty($bbox)) {
       $this->query->addCondition('centroid_lat', $bbox['bottom'], '>=');

--- a/modules/mukurtu_core/config/schema/mukurtu_core.schema.yml
+++ b/modules/mukurtu_core/config/schema/mukurtu_core.schema.yml
@@ -181,9 +181,6 @@ field.widget.settings.mukurtu_leaflet_formatter:
         height:
           type: integer
           label: 'Height'
-        locate:
-          type: integer
-          label: 'Locale'
         auto_center:
           type: integer
           label: 'Automatically center map'
@@ -204,6 +201,9 @@ field.widget.settings.mukurtu_leaflet_formatter:
                 lon:
                   type: float
                   label: 'Lon'
+            zoomControlPosition:
+              type: string
+              label: 'Position'
             zoom:
               type: integer
               label: 'Zoom'
@@ -277,14 +277,24 @@ field.widget.settings.mukurtu_leaflet_formatter:
           label: 'Rotate Mode'
     reset_map:
       type: mapping
-      label: 'Reset map'
+      label: 'Reset Map View'
       mapping:
-        position:
-          type: string
-          label: 'Position'
         control:
           type: boolean
           label: 'Control'
+        options:
+          type: text
+          label: 'Options'
+    map_scale:
+      type: mapping
+      label: 'Map Scale Control'
+      mapping:
+        control:
+          type: boolean
+          label: 'Control'
+        options:
+          type: text
+          label: 'Options'
     fullscreen:
       type: mapping
       label: 'Leaflet Fullscreen'
@@ -298,17 +308,46 @@ field.widget.settings.mukurtu_leaflet_formatter:
     path:
       type: text
       label: 'Path'
+    locate:
+      type: mapping
+      label: 'Locate User Position'
+      mapping:
+        control:
+          type: boolean
+          label: 'Control'
+        options:
+          type: text
+          label: 'Options'
+        automatic:
+          type: boolean
+          label: 'Automatically locate user current position'
     geocoder:
       type: mapping
-      label: 'Gecoder map control'
+      label: 'Geocoder'
       mapping:
         control:
           type: boolean
           label: 'Enable Geocoder map control'
         settings:
           type: mapping
-          label: 'Gecoder settings'
+          label: 'Geocoder settings'
           mapping:
+            set_marker:
+              type: boolean
+              label: 'Marker'
+            popup:
+              type: boolean
+              label: 'Popup'
+            autocomplete:
+              type: mapping
+              label: 'Autocomplete'
+              mapping:
+                placeholder:
+                  type: string
+                  label: 'Placeholder'
+                title:
+                  type: string
+                  label: 'Title'
             position:
               type: string
               label: 'Position'
@@ -337,9 +376,6 @@ field.widget.settings.mukurtu_leaflet_formatter:
             zoom:
               type: integer
               label: 'Zoom'
-            popup:
-              type: boolean
-              label: 'Popup'
             options:
               type: string
               label: 'Options'
@@ -353,7 +389,7 @@ field.formatter.settings.mukurtu_leaflet_formatter:
       label: 'Multiple map'
     leaflet_map:
       type: string
-      label: 'Leaflet map'
+      label: 'Leaflet Map Tiles Layer'
     height:
       type: integer
       label: 'Map height'
@@ -369,22 +405,73 @@ field.formatter.settings.mukurtu_leaflet_formatter:
     gesture_handling:
       type: boolean
       label: 'Gesture handling'
+    fitbounds_options:
+      type: text
+      label: 'FitBounds Options'
     reset_map:
       type: mapping
-      label: 'Reset map'
+      label: 'Reset Map View'
       mapping:
         control:
           type: boolean
           label: 'Control'
-        position:
+        options:
+          type: text
+          label: 'Options'
+    map_scale:
+      type: mapping
+      label: 'Map Scale Control'
+      mapping:
+        control:
+          type: boolean
+          label: 'Control'
+        options:
+          type: text
+          label: 'Options'
+    locate:
+      type: mapping
+      label: 'Locate User Position'
+      mapping:
+        control:
+          type: boolean
+          label: 'Control'
+        options:
+          type: text
+          label: 'Options'
+        automatic:
+          type: boolean
+          label: 'Automatically locate user current position'
+    leaflet_tooltip:
+      type: mapping
+      label: 'Tooltip Source'
+      mapping:
+        value:
           type: string
-          label: 'Position'
+          label: 'Value'
+        options:
+          type: text
+          label: 'Tooltip Options'
+    # @TODO Keep this for backword compatibility with Leaflet < 2.x.
     popup:
       type: boolean
-      label: 'Popup'
+      label: 'Leaflet Popup'
+    # @TODO Keep this for backword compatibility with Leaflet < 2.x.
     popup_content:
       type: text
       label: 'Popup Content'
+    leaflet_popup:
+      type: mapping
+      label: 'Leaflet Popup'
+      mapping:
+        control:
+          type: string
+          label: 'Enable'
+        content:
+          type: text
+          label: 'Popup content'
+        options:
+          type: text
+          label: 'Popup Options'
     map_position:
       type: mapping
       label: 'Map Position'
@@ -402,6 +489,9 @@ field.formatter.settings.mukurtu_leaflet_formatter:
             lon:
               type: float
               label: 'Longitude'
+        zoomControlPosition:
+          type: string
+          label: 'Position'
         zoom:
           type: integer
           label: 'Zoom'
@@ -414,6 +504,9 @@ field.formatter.settings.mukurtu_leaflet_formatter:
         zoomFiner:
           type: integer
           label: 'Zoom finer'
+    weight:
+      type: string
+      label: 'Weight'
     icon:
       type: mapping
       label: 'Map icon'
@@ -499,6 +592,9 @@ field.formatter.settings.mukurtu_leaflet_formatter:
         options:
           type: text
           label: 'Options'
+        excluded:
+          type: text
+          label: 'Exclude flag'
         include_path:
           type: boolean
           label: 'Include Path'
@@ -515,9 +611,16 @@ field.formatter.settings.mukurtu_leaflet_formatter:
     path:
       type: text
       label: 'Path'
+    feature_properties:
+      type: mapping
+      label: 'Feature Additional Properties'
+      mapping:
+        values:
+          type: text
+          label: 'Values'
     geocoder:
       type: mapping
-      label: 'Geocoder map control'
+      label: 'Geocoder'
       mapping:
         control:
           type: boolean
@@ -526,6 +629,19 @@ field.formatter.settings.mukurtu_leaflet_formatter:
           type: mapping
           label: 'Geocoder settings'
           mapping:
+            popup:
+              type: boolean
+              label: 'Popup'
+            autocomplete:
+              type: mapping
+              label: 'Autocomplete'
+              mapping:
+                placeholder:
+                  type: string
+                  label: 'Placeholder'
+                title:
+                  type: string
+                  label: 'Title'
             position:
               type: string
               label: 'Position'
@@ -554,12 +670,16 @@ field.formatter.settings.mukurtu_leaflet_formatter:
             zoom:
               type: integer
               label: 'Zoom'
-            popup:
-              type: boolean
-              label: 'Popup'
             options:
               type: string
               label: 'Options'
+    map_lazy_load:
+      type: mapping
+      label: Map lazy load
+      mapping:
+        lazy_load:
+          type: boolean
+          label: Lazy load
 
 block.settings.mukurtu_core_example:
   type: block_settings

--- a/modules/mukurtu_core/css/mukurtu-leaflet-widget.css
+++ b/modules/mukurtu_core/css/mukurtu-leaflet-widget.css
@@ -1,0 +1,7 @@
+/**
+ * CSS additions for the Mukurtu Leaflet input widget.
+ */
+.mukurtu-leaflet-description-field {
+  max-width: 100%;
+  margin: 1em auto;
+}

--- a/modules/mukurtu_core/js/mukurtu-leaflet-widget.js
+++ b/modules/mukurtu_core/js/mukurtu-leaflet-widget.js
@@ -77,7 +77,7 @@
     // Mukurtu Location Description.
     const containerId = $(layer._map._container).attr('id');
     const popupId = "location-popup-" + layer._leaflet_id;
-    layer.bindPopup('<label for="' + popupId + '">' + Drupal.t('Location Description') + '</label><input type="text" size="60" maxlength="255" id="' + popupId + '"></input><button type="button" onclick="Drupal.mukurtuSetLocationDescription(\'' + containerId + '\',' + layer._leaflet_id + ')">' + Drupal.t('Save') + '</button>');
+    layer.bindPopup('<label for="' + popupId + '">' + Drupal.t('Location Description') + '</label><input class="mukurtu-leaflet-description-field" type="text" size="60" maxlength="255" id="' + popupId + '" onblur="Drupal.mukurtuSetLocationDescription(\'' + containerId + '\',' + layer._leaflet_id + ')"></input>');
     layer.on('popupclose', function (event) {
       this.update_text();
     }, this);

--- a/modules/mukurtu_core/js/mukurtu-leaflet-widget.js
+++ b/modules/mukurtu_core/js/mukurtu-leaflet-widget.js
@@ -1,29 +1,4 @@
-(function ($, Drupal, drupalSettings) {
-  Drupal.behaviors.mukurtu_core_leaflet_widget = {
-    attach: function (context, settings) {
-      $(document).ready(function () {
-        var refresh = function () {
-
-          $.each(settings.leaflet_widget, function (map_id, widgetSettings) {
-            $('#' + map_id, context).each(function () {
-              let map = $(this);
-              let lMap = drupalSettings.leaflet[map_id].lMap;
-
-              // Refreshes map data to load with correct size and bounds.
-              lMap.invalidateSize();
-              map.data('leaflet_widget', new Drupal.leaflet_widget(map, lMap, widgetSettings));
-            });
-
-          });
-        };
-
-        // Bind refresh function when changing horizontal tab.
-        $('.horizontal-tabs-list').find('.horizontal-tab-button').each(function (key, tab) {
-          $(tab).find('a').bind('click', refresh);
-        });
-      });
-    }
-  };
+(function ($, Drupal) {
 
   /**
    * Save location description.
@@ -31,18 +6,20 @@
   Drupal.mukurtuSetLocationDescription = function (containerId, popupId) {
     Drupal.Leaflet[containerId].lMap._layers[popupId].feature.properties['location_description'] = $("#location-popup-" + popupId)[0].value;
     Drupal.Leaflet[containerId].lMap._layers[popupId].closePopup();
-  }
-
+  };
 
   /**
    * Set the leaflet map object.
    */
-  Drupal.leaflet_widget.prototype.set_leaflet_map = function (map) {
+  Drupal.Leaflet_Widget.prototype.set_leaflet_widget_map = function (map) {
     if (map !== undefined) {
+
+      /* Copied from leaflet.widget.js begin: */
+
       this.map = map;
       map.addLayer(this.drawnItems);
 
-      if (this.settings.scrollZoomEnabled) {
+      if (this.widgetsettings.scrollZoomEnabled) {
         map.on('focus', function () {
           map.scrollWheelZoom.enable();
         });
@@ -52,14 +29,14 @@
       }
 
       // Adjust toolbar to show defaultMarker or circleMarker.
-      this.settings.toolbarSettings.drawMarker = false;
-      this.settings.toolbarSettings.drawCircleMarker = false;
-      if (this.settings.toolbarSettings.marker === "defaultMarker") {
-        this.settings.toolbarSettings.drawMarker = 1;
-      } else if (this.settings.toolbarSettings.marker === "circleMarker") {
-        this.settings.toolbarSettings.drawCircleMarker = 1;
+      this.widgetsettings.toolbarSettings.drawMarker = false;
+      this.widgetsettings.toolbarSettings.drawCircleMarker = false;
+      if (this.widgetsettings.toolbarSettings.marker === "defaultMarker") {
+        this.widgetsettings.toolbarSettings.drawMarker = 1;
+      } else if (this.widgetsettings.toolbarSettings.marker === "circleMarker") {
+        this.widgetsettings.toolbarSettings.drawCircleMarker = 1;
       }
-      map.pm.addControls(this.settings.toolbarSettings);
+      map.pm.addControls(this.widgetsettings.toolbarSettings);
 
       map.on('pm:create', function (event) {
         let layer = event.layer;
@@ -69,7 +46,13 @@
         // Listen to changes on the new layer
         this.add_layer_listeners(layer);
       }, this);
-      this.update_map();
+
+      // Start updating the Leaflet Map.
+      this.update_leaflet_widget_map();
+
+      /* Copied from leaflet.widget.js end. */
+
+      /* Mukurtu additions begin: */
 
       // Mukurtu Location Description pop-up.
       map.on('popupopen', function (event) {
@@ -81,13 +64,16 @@
         const locationDescription = event.popup._source.feature.properties['location_description'] ?? '';
         $('#location-popup-' + event.popup._source._leaflet_id).val(locationDescription);
       }, this);
+
     }
   };
 
   /**
    * Add/Set Listeners to the Drawn Map Layers.
    */
-  Drupal.leaflet_widget.prototype.add_layer_listeners = function (layer) {
+  Drupal.Leaflet_Widget.prototype.add_layer_listeners = function (layer) {
+    /* Mukurtu additions begin: */
+
     // Mukurtu Location Description.
     const containerId = $(layer._map._container).attr('id');
     const popupId = "location-popup-" + layer._leaflet_id;
@@ -95,6 +81,10 @@
     layer.on('popupclose', function (event) {
       this.update_text();
     }, this);
+
+    /* Mukurtu additions end. */
+
+    /* Copied from leaflet.widget.js begin: */
 
     // Listen to changes on the layer.
     layer.on('pm:edit', function (event) {
@@ -124,6 +114,7 @@
       this.update_text();
     }, this);
 
+    /* Copied from leaflet.widget.js end. */
   };
 
-})(jQuery, Drupal, drupalSettings);
+})(jQuery, Drupal);

--- a/modules/mukurtu_core/mukurtu_core.libraries.yml
+++ b/modules/mukurtu_core/mukurtu_core.libraries.yml
@@ -1,5 +1,8 @@
 mukurtu-leaflet-widget:
   version: 1.x
+  css:
+    component:
+      css/mukurtu-leaflet-widget.css: {}
   js:
     js/mukurtu-leaflet-widget.js: {}
   dependencies:

--- a/modules/mukurtu_core/src/Plugin/Field/FieldFormatter/MukurtuLeafletFormatter.php
+++ b/modules/mukurtu_core/src/Plugin/Field/FieldFormatter/MukurtuLeafletFormatter.php
@@ -3,11 +3,9 @@
 namespace Drupal\mukurtu_core\Plugin\Field\FieldFormatter;
 
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
-use Drupal\Core\Render\BubbleableMetadata;
-use Drupal\Core\Render\RenderContext;
 use Drupal\Core\Field\FieldItemListInterface;
-use Drupal\Component\Utility\Html;
 use Drupal\leaflet\Plugin\Field\FieldFormatter\LeafletDefaultFormatter;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Plugin implementation of the 'mukurtu_leaflet_formatter' formatter.
@@ -20,253 +18,91 @@ use Drupal\leaflet\Plugin\Field\FieldFormatter\LeafletDefaultFormatter;
  *   }
  * )
  */
+
 class MukurtuLeafletFormatter extends LeafletDefaultFormatter implements ContainerFactoryPluginInterface {
+  /**
+   * {@inheritdoc}
+   *
+   * Because the parent class LeafletDefaultFormatter implements a create()
+   * method, this child class also needs to implement it in order to be picked
+   * up. See \Drupal\Core\Field\FormatterPluginManager::createInstance().
+   *
+   * This method should match LeafletDefaultFormatter::create() exactly.
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new self(
+      $plugin_id,
+      $plugin_definition,
+      $configuration['field_definition'],
+      $configuration['settings'],
+      $configuration['label'],
+      $configuration['view_mode'],
+      $configuration['third_party_settings'],
+      $container->get('leaflet.service'),
+      $container->get('entity_field.manager'),
+      $container->get('token'),
+      $container->get('renderer'),
+      $container->get('module_handler'),
+      $container->get('link_generator')
+    );
+  }
 
   /**
    * {@inheritdoc}
    *
-   * This function is called from parent::view().
+   * This custom Mukurtu formatter renders the "location_description" from the
+   * stored GeoJSON values within each Leaflet feature's popup.
    */
   public function viewElements(FieldItemListInterface $items, $langcode) {
-
-    /* @var \Drupal\Core\Entity\EntityInterface $entity */
-    $entity = $items->getEntity();
-    // Take the entity translation, if existing.
-    /* @var \Drupal\Core\TypedData\TranslatableInterface $entity */
-    if ($entity->hasTranslation($langcode)) {
-      $entity = $entity->getTranslation($langcode);
-    }
-
-    $entity_type = $entity->getEntityTypeId();
-    $bundle = $entity->bundle();
-    $entity_id = $entity->id();
-    /* @var \Drupal\Core\Field\FieldDefinitionInterface $field */
-    $field = $items->getFieldDefinition();
-
-    // Sets/consider possibly existing previous Zoom settings.
-    $this->setExistingZoomSettings();
-    $settings = $this->getSettings();
-
-    // Always render the map, even if we do not have any data.
-    $map = leaflet_map_get_info($settings['leaflet_map']);
-
-    // Add a specific map id.
-    $map['id'] = Html::getUniqueId("leaflet_map_{$entity_type}_{$bundle}_{$entity_id}_{$field->getName()}");
-
-    // Get and set the Geofield cardinality.
-    $map['geofield_cardinality'] = $this->fieldDefinition->getFieldStorageDefinition()->getCardinality();
-
-    // Set Map additional map Settings.
-    $this->setAdditionalMapOptions($map, $settings);
-
-    // Get token context.
-    $tokens = [
-      'field' => $items,
-      $this->fieldDefinition->getTargetEntityTypeId() => $items->getEntity(),
-    ];
-
-    $results = [];
-    $features = [];
+    // Collect all descriptions from all Leaflet features and split up multiple
+    // points from a single feature into separate features. This allows each
+    // point to have a different popup description.
+    $new_values = [];
+    $descriptions = [];
     foreach ($items as $delta => $item) {
-      // GeoJSON handling. Chop featurecollections into multiple features.
-      $geoFeatures = [];
-      $geoJson = json_decode($item->value, TRUE);
-      if (isset($geoJson['type']) && $geoJson['type'] == 'FeatureCollection') {
-        foreach ($geoJson['features'] as $g_delta => $geoFeature) {
-          $geometry = $geoFeature['geometry'] ?? NULL;
-          if ($geometry) {
-            $geoFeatures[$g_delta]['properties'] = $geoFeature['properties'] ?? [];
-            $geoFeatures[$g_delta]['geometry'] = $this->leafletService->leafletProcessGeofield(json_encode($geometry));
-          }
+      // GeoJSON handling. Chop FeatureCollections into multiple features.
+      $value = $item->getValue();
+      $geo_json = json_decode($value['value'], TRUE);
+      if (isset($geo_json['type']) && $geo_json['type'] == 'FeatureCollection') {
+        foreach ($geo_json['features'] as $g_delta => $geo_feature) {
+          $new_values_delta = count($new_values);
+          $new_geo_json = $geo_json;
+          $new_geo_json['features'] = [$geo_feature];
+          $value['value'] = json_encode($new_geo_json);
+          $descriptions[$new_values_delta] = $geo_feature['properties']['location_description'] ?? NULL;
+          $new_values[] = $value;
         }
       }
       else {
         // If not GeoJSON or the GeoJSON is in a format we weren't expecting,
         // default back to standard geofield/leaflet behavior.
-        $geoFeatures[] = ['geometry' => $this->leafletService->leafletProcessGeofield($item->value)];
-      }
-
-      foreach ($geoFeatures as $geoFeature) {
-        $feature = $geoFeature['geometry'][0];
-        $locationDescription = $geoFeature['properties']['location_description'] ?? NULL;
-        $feature['entity_id'] = $entity_id;
-
-        // Eventually set the popup content.
-        if ($settings['popup']) {
-          // Construct the renderable array for popup title / text. As we later
-          // convert that to plain text, losing attachments and cacheability, save
-          // them to $results.
-          $build = [];
-
-          if ($this->getSetting('popup_content')) {
-            $bubbleable_metadata = new BubbleableMetadata();
-            $popup_content = $this->token->replace($this->getSetting('popup_content'), $tokens, ['clear' => TRUE], $bubbleable_metadata);
-            $build[] = [
-              '#markup' => $popup_content,
-            ];
-            $bubbleable_metadata->applyTo($results);
-          }
-
-          // We need a string for using it inside the popup. Save attachments and
-          // cacheability to $results.
-          $render_context = new RenderContext();
-          $rendered = $this->renderer->executeInRenderContext($render_context, function () use (&$build) {
-            return $this->renderer->render($build, TRUE);
-          });
-          $feature['popup'] = !empty($rendered) ? $rendered : ($locationDescription ?? $entity->label());
-          if (!$render_context->isEmpty()) {
-            $render_context->update($results);
-          }
-        }
-
-        // Define the Popup Control and Popup Content with backward
-        // compatibility with Leaflet release < 2.x.
-        $popup_control = !empty($settings['popup']) ? $settings['popup'] : ($settings['leaflet_popup']['control'] ?? NULL);
-        $popup_content = !empty($settings['popup_content']) ? $settings['popup_content'] : ($settings['leaflet_popup']['content'] ?? NULL);
-
-        // Eventually set the popup content.
-        if ($popup_control) {
-          $feature['popup'] = $settings['leaflet_popup'];
-          // Generate the Popup Content render array transforming the
-          // 'popup_content' text area through replacements tokens.
-          $feature['popup']['value'] = $this->tokenResolvedContent($entity, $popup_content, $tokens, $results);
-
-          // Associate dynamic popup options (token based).
-          if (!empty($settings['leaflet_popup']['options'])) {
-            $feature['popup']['options'] = $this->tokenResolvedContent($entity, $settings['leaflet_popup']['options'], $tokens, $results);
-          }
-        }
-
-        // Add/merge eventual map icon definition from hook_leaflet_map_info.
-        if (!empty($map['icon'])) {
-          $settings['icon'] = $settings['icon'] ?: [];
-          // Remove empty icon options so thxat they might be replaced by the
-          // ones set by the hook_leaflet_map_info.
-          foreach ($settings['icon'] as $k => $icon_option) {
-            if (empty($icon_option) || (is_array($icon_option) && $this->leafletService->multipleEmpty($icon_option))) {
-              unset($settings['icon'][$k]);
-            }
-          }
-          $settings['icon'] = array_replace($map['icon'], $settings['icon']);
-        }
-
-        $icon_type = $settings['icon']['iconType'] ?? 'marker';
-
-        // Eventually set the custom Marker icon (DivIcon, Icon Url or
-        // Circle Marker).
-        if ($feature['type'] === 'point' && isset($settings['icon'])) {
-
-          // Set Feature Icon properties.
-          $feature['icon'] = $settings['icon'];
-
-          // Transforms Icon Options that support Replacement Patterns/Tokens.
-          if (!empty($settings["icon"]["iconSize"]["x"])) {
-            $feature['icon']["iconSize"]["x"] = intval($this->token->replace($settings["icon"]["iconSize"]["x"], $tokens));
-          }
-          if (!empty($settings["icon"]["iconSize"]["y"])) {
-            $feature['icon']["iconSize"]["y"] = intval($this->token->replace($settings["icon"]["iconSize"]["y"], $tokens));
-          }
-          if (!empty($settings["icon"]["iconAnchor"]["x"])) {
-            $feature['icon']["iconAnchor"]["x"] = $this->token->replace($settings["icon"]["iconAnchor"]["x"], $tokens);
-          }
-          if (!empty($settings["icon"]["iconAnchor"]["y"])) {
-            $feature['icon']["iconAnchor"]["y"] = $this->token->replace($settings["icon"]["iconAnchor"]["y"], $tokens);
-          }
-          if (!empty($settings["icon"]["popupAnchor"]["x"])) {
-            $feature['icon']["popupAnchor"]["x"] = $this->token->replace($settings["icon"]["popupAnchor"]["x"], $tokens);
-          }
-          if (!empty($settings["icon"]["popupAnchor"]["y"])) {
-            $feature['icon']["popupAnchor"]["y"] = $this->token->replace($settings["icon"]["popupAnchor"]["y"], $tokens);
-          }
-          if (!empty($settings["icon"]["shadowSize"]["x"])) {
-            $feature['icon']["shadowSize"]["x"] = intval($this->token->replace($settings["icon"]["shadowSize"]["x"], $tokens));
-          }
-          if (!empty($settings["icon"]["shadowSize"]["y"])) {
-            $feature['icon']["shadowSize"]["y"] = intval($this->token->replace($settings["icon"]["shadowSize"]["y"], $tokens));
-          }
-
-          switch ($icon_type) {
-            case 'html':
-              $feature['icon']['html'] = $this->token->replace($settings['icon']['html'], $tokens, ['clear' => TRUE]);
-              $feature['icon']['html_class'] = $settings['icon']['html_class'] ?? '';
-              break;
-
-            case 'circle_marker':
-              $feature['icon']['circle_marker_options'] = $this->token->replace($settings['icon']['circle_marker_options'], $tokens);
-              break;
-
-            default:
-              // Apply Token Replacements to iconUrl & shadowUrl.
-              if (!empty($settings['icon']['iconUrl'])) {
-                $feature['icon']['iconUrl'] = str_replace(["\n", "\r"], "", $this->token->replace($settings['icon']['iconUrl'], $tokens));
-                // Generate correct Absolute iconUrl,
-                // if not external.
-                if (!empty($feature['icon']['iconUrl'])) {
-                  $feature['icon']['iconUrl'] = $this->leafletService->generateAbsoluteString($feature['icon']['iconUrl']);
-                }
-              }
-              if (!empty($settings['icon']['shadowUrl'])) {
-                $feature['icon']['shadowUrl'] = str_replace(["\n", "\r"], "", $this->token->replace($settings['icon']['shadowUrl'], $tokens));
-                // Generate correct Absolute shadowUrl,
-                // if not external.
-                if (!empty($feature['icon']['shadowUrl'])) {
-                  $feature['icon']['shadowUrl'] = $this->leafletService->generateAbsoluteString($feature['icon']['shadowUrl']);
-                }
-              }
-              // Set the Feature IconSize and ShadowSize to the IconUrl or
-              // ShadowUrl Image sizes (if empty or invalid).
-              $this->leafletService->setFeatureIconSizesIfEmptyOrInvalid($feature);
-              break;
-          }
-        }
-
-        // Associate dynamic path properties (token based) to the feature,
-        // in case of not point.
-        if ($feature['type'] !== 'point') {
-          $feature['path'] = str_replace(["\n", "\r"], "", $this->token->replace($settings['path'], $tokens));
-        }
-
-        // Associate dynamic className property (token based) to icon.
-        $feature['className'] = !empty($settings['className']) ?
-          str_replace(["\n", "\r"], "", $this->token->replace($settings['className'], $tokens)) : '';
-
-        // Add Feature additional Properties (if present).
-        if (!empty($settings['feature_properties']['values'])) {
-          $feature['properties'] = str_replace([
-            "\n",
-            "\r",
-          ], "", $this->token->replace($settings['feature_properties']['values'], $tokens));
-        }
-
-        // Allow modules to adjust the marker.
-        $this->moduleHandler->alter('leaflet_formatter_feature', $feature, $item, $entity);
-        $features[] = $feature;
+        $new_values[] = $item->getValue();
       }
     }
 
-    $js_settings = [
-      'map' => $map,
-      'features' => $features,
-    ];
+    // Update the values used in the $items object, which we can then let
+    // LeafletDefaultFormatter render as normal.
+    $items->setValue($new_values);
+    $render = parent::viewElements($items, $langcode);
 
-    // Allow other modules to add/alter the map js settings.
-    $this->moduleHandler->alter('leaflet_default_map_formatter', $js_settings, $items);
-
-    $map_height = !empty($settings['height']) ? $settings['height'] . $settings['height_unit'] : '';
-
-    if (!empty($settings['multiple_map'])) {
-      foreach ($js_settings['features'] as $k => $feature) {
-        $map = $js_settings['map'];
-        $map['id'] = $map['id'] . "-{$k}";
-        $results[] = $this->leafletService->leafletRenderMap($map, [$feature], $map_height);
+    // Now take the finished render object and modify the JavaScript settings
+    // for the Leaflet map to render the descriptions in each popup, rather than
+    // repeating the entity label for every popup.
+    foreach ($render as $delta => &$item) {
+      $settings = &$item['#attached']['drupalSettings']['leaflet'];
+      $settings_key = key($settings);
+      $features = &$settings[$settings_key]['features'];
+      foreach ($features as $feature_delta => &$feature) {
+        // If a NULL description or an empty string, no modification is made,
+        // and the entity label continues being used as the popup value.
+        if (!empty($descriptions[$feature_delta])) {
+          // Note $feature is modified by reference.
+          $feature['popup']['value'] = $descriptions[$feature_delta];
+        }
       }
     }
-    // Render the map, if we do have data or the hide option is unchecked.
-    elseif (!empty($js_settings['features']) || empty($settings['hide_empty_map'])) {
-      $results[] = $this->leafletService->leafletRenderMap($js_settings['map'], $js_settings['features'], $map_height);
-    }
 
-    return $results;
+    return $render;
   }
 
 }


### PR DESCRIPTION
Fixes #110

Replaces https://github.com/MukurtuCMS/Mukurtu-CMS/pull/713

Unfortunately it looks like the customizations to Leaflet probably need to stay in place to support placing descriptions on individual points. Rather than remove the customizations, this updates them to work with Leaflet 10.2+.

Reconciling the code between Leaflet 2 and 10 was dizzying, so this takes an approach to reduce the amount of code directly copy/pasted out of the `LeafletDefaultFormatter` class.