### PR TITLE
690: Stubbing out GitHub Action for running Playwright.

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,65 @@
+name: "Tugboat Playwright Tests"
+
+on:
+  # Run on pull requests against the main branch, to match Tugboat builds.
+  branches:
+    - main
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  wait-for-tugboat:
+    runs-on: ubuntu-latest
+    outputs:
+      preview_url: ${{ steps.get-preview-url.outputs.preview_url }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Wait for Tugboat Preview
+        id: wait-for-preview
+        run: |
+          # Define the maximum wait time (5 minutes).
+          MAX_WAIT=300
+          INTERVAL=30
+          ELAPSED=0
+          while [ $ELAPSED -lt $MAX_WAIT ]; do
+            PREVIEW_URL=$(gh pr view --json comments | jq -r '.comments[].body' | grep -o 'https://[a-zA-Z0-9.-]*\.tugboatqa.com' | head -n 1 || true)
+            if [[ ! -z "$PREVIEW_URL" ]]; then
+              echo "Preview is ready: $PREVIEW_URL"
+              echo "preview_url=$PREVIEW_URL" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            echo "Waiting for Tugboat preview..."
+            sleep $INTERVAL
+            ELAPSED=$((ELAPSED + INTERVAL))
+          done
+          echo "Tugboat preview did not become ready in time."
+          exit 1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  playwright-tests:
+    needs: wait-for-tugboat
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+#      - name: Install Dependencies
+#        run: cd tests/playwright && npm ci
+#
+#      - name: Install Playwright Browsers
+#        run: cd tests/playwright && npx playwright install --with-deps
+#
+#      - name: Run Playwright Tests
+#        # Note this needs process.env.PLAYWRIGHT_BASE_URL to be evaluated in
+#        # as the baseURL in playwright.config.ts.
+#        run: |
+#          cd tests/playwright
+#          PLAYWRIGHT_BASE_URL="${{ needs.wait-for-tugboat.outputs.preview_url }}" npx playwright test


### PR DESCRIPTION
This just stubs out a GitHub Action file for running Playwright tests. Because actions need to be merged into `main` before they can be executed, this just creates the file but doesn't execute any actual tests. That will be added in https://github.com/MukurtuCMS/Mukurtu-CMS/pull/720