### PR TITLE
719: Exclude entities that do not have location data from Map browse.

### DIFF
--- a/modules/mukurtu_browse/config/install/views.view.mukurtu_browse.yml
+++ b/modules/mukurtu_browse/config/install/views.view.mukurtu_browse.yml
@@ -98,6 +98,7 @@ display:
         type: full
         options:
           offset: 0
+          pagination_heading_level: h4
           items_per_page: 20
           total_pages: null
           id: 0
@@ -115,7 +116,6 @@ display:
             offset: false
             offset_label: Offset
           quantity: 9
-          pagination_heading_level: h4
       exposed_form:
         type: basic
         options:
@@ -678,6 +678,145 @@ display:
             use_highlighting: false
             multi_type: separator
             multi_separator: ', '
+      filters:
+        search_api_fulltext:
+          id: search_api_fulltext
+          table: search_api_index_mukurtu_default_content_index
+          field: search_api_fulltext
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_fulltext
+          operator: and
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: search_api_fulltext_op
+            label: Search
+            description: ''
+            use_operator: false
+            operator: search_api_fulltext_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: search_api_fulltext
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+            expose_fields: false
+            placeholder: ''
+            searched_fields_id: search_api_fulltext_searched_fields
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          parse_mode: terms
+          min_length: null
+          fields: {  }
+        type:
+          id: type
+          table: search_api_index_mukurtu_default_content_index
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_options
+          operator: or
+          value:
+            collection: collection
+            dictionary_word: dictionary_word
+            digital_heritage: digital_heritage
+            person: person
+            word_list: word_list
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+        field_coverage:
+          id: field_coverage
+          table: search_api_index_mukurtu_default_content_index
+          field: field_coverage
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_text
+          operator: 'not empty'
+          value:
+            min: ''
+            max: ''
+            value: ''
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            min_placeholder: ''
+            max_placeholder: ''
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
       style:
         type: leaflet_map
         options:
@@ -690,14 +829,13 @@ display:
             field_coverage: field_coverage
           entity_source: __base_table
           name_field: title
-          description_field: '#rendered_view_fields'
           view_mode: full
           leaflet_map: 'OSM Mapnik'
           height: '600'
           height_unit: px
           hide_empty_map: false
-          gesture_handling: false
           disable_wheel: false
+          gesture_handling: false
           reset_map:
             control: false
             position: topright
@@ -738,6 +876,7 @@ display:
             control: false
             options: '{"position":"topleft","pseudoFullscreen":false}'
           path: '{"color":"#3388ff","opacity":"1.0","stroke":true,"weight":3,"fill":"depends","fillColor":"*","fillOpacity":"0.2","radius":"6"}'
+          description_field: '#rendered_view_fields'
       row:
         type: search_api
         options:
@@ -756,6 +895,8 @@ display:
         style: false
         row: false
         fields: false
+        filters: false
+        filter_groups: false
       css_class: 'browse-content map'
       display_description: ''
       exposed_block: true


### PR DESCRIPTION
Fixes https://github.com/MukurtuCMS/Mukurtu-CMS/issues/719

This adds a filter to the `/browse` page Map to check that entities have a location value before attempting to show them on the map. Some entity types like People and Collections do not yet have location values, and can not show up on the Map. However, this content should still show up on the Grid and List tabs, so this filter is only applied to the Map display of the view.

![Image](https://github.com/user-attachments/assets/7ccdf92d-4bc9-4ece-96c8-c755e21a6cb6)