### PR TITLE
741: Hide browse map when empty

### DIFF
--- a/modules/mukurtu_browse/src/Controller/MukurtuBrowseController.php
+++ b/modules/mukurtu_browse/src/Controller/MukurtuBrowseController.php
@@ -54,8 +54,8 @@ class MukurtuBrowseController extends ControllerBase {
       '#value' => $this->t('Map'),
       '#attributes' => [
         'id' => 'mukurtu-browse-map',
-        'aria-label' => t('Switch to Map'),
-      ], 
+        'aria-label' => $this->t('Switch to Map'),
+      ],
     ];
 
     // Render the browse view block. This is the list display.

--- a/modules/mukurtu_browse/src/Controller/MukurtuDigitalHeritageBrowseController.php
+++ b/modules/mukurtu_browse/src/Controller/MukurtuDigitalHeritageBrowseController.php
@@ -53,8 +53,8 @@ class MukurtuDigitalHeritageBrowseController extends ControllerBase {
       '#value' => $this->t('Map'),
       '#attributes' => [
         'id' => 'mukurtu-browse-map',
-        'aria-label' => t('Switch to Map'),
-      ], 
+        'aria-label' => $this->t('Switch to Map'),
+      ],
     ];
 
     // Render the browse view block. This is the list display.

--- a/tests/playwright/tests/browse.spec.ts
+++ b/tests/playwright/tests/browse.spec.ts
@@ -7,6 +7,7 @@ test('Browse tests - Digital Heritage', async ({ page, browserName }) => {
   await page.goto('/digital-heritage');
   await page.getByText('Grid', { exact: true }).click();
   await page.getByText('List', { exact: true }).click();
-  await page.getByText('Map', { exact: true }).click();
+  // @todo Re-enable Map clicks when there's default content with location data.
+  //await page.getByText('Map', { exact: true }).click();
   // @todo Check default content within each tab.
 });

--- a/themes/mukurtu_v4/css/leaflet-overrides.css
+++ b/themes/mukurtu_v4/css/leaflet-overrides.css
@@ -48,3 +48,9 @@
 .path-browse .vertical-card__eyebrow + h2 {
   margin-block-start: 0.25em;
 }
+
+/* Hide the Map on any page it appears if there are no location markers. */
+/* NOTE This is better handled in the View, however, clicking "Hide if empty" does not work for unknown reasons, as of this writing. */
+.browse-container:not(:has(.leaflet-marker-icon)) :is(#mukurtu-browse-map, .leaflet-container) {
+  display: none;
+}


### PR DESCRIPTION
Investigated fixing in the view, but the options to hide the map if empty don't work for some reason. I investigated that issue more, but felt I was spending too much time and not getting anywhere. 

Instead, I wrote an, I think, pretty durable solution in CSS. 

Fixes #741