### PR TITLE
343: Correct map visibility when polygons are present

### DIFF
--- a/themes/mukurtu_v4/css/leaflet-overrides.css
+++ b/themes/mukurtu_v4/css/leaflet-overrides.css
@@ -51,6 +51,6 @@
 
 /* Hide the Map on any page it appears if there are no location markers. */
 /* NOTE This is better handled in the View, however, clicking "Hide if empty" does not work for unknown reasons, as of this writing. */
-.browse-container:not(:has(.leaflet-marker-icon)) :is(#mukurtu-browse-map, .leaflet-container) {
+.browse-container:not(:has(.leaflet-marker-icon, .leaflet-interactive)) :is(#mukurtu-browse-map, .leaflet-container) {
   display: none;
 }


### PR DESCRIPTION
The map hide/show functionality only occurs when the Map Pin is present or not. This functionality should also work with the Map Polygons.