### PR TITLE
709: Disable Solr integration out of the box.

### DIFF
--- a/modules/mukurtu_dictionary/config/install/search_api.index.mukurtu_dictionary_index.yml
+++ b/modules/mukurtu_dictionary/config/install/search_api.index.mukurtu_dictionary_index.yml
@@ -8,7 +8,6 @@ dependencies:
     - mukurtu_protocol
     - node
     - search_api_glossary
-    - search_api_solr
     - taxonomy
 id: mukurtu_dictionary_index
 name: 'Mukurtu Dictionary Index'

--- a/modules/mukurtu_dictionary/mukurtu_dictionary.info.yml
+++ b/modules/mukurtu_dictionary/mukurtu_dictionary.info.yml
@@ -34,5 +34,4 @@ dependencies:
   - 'paragraphs:paragraphs'
   - 'search_api:search_api'
   - 'search_api_glossary:search_api_glossary'
-  - 'search_api_solr:search_api_solr'
 version: 4.x-dev

--- a/mukurtu.install
+++ b/mukurtu.install
@@ -29,7 +29,7 @@ function mukurtu_install() {
   \Drupal::service('module_installer')->install(['message_digest_ui']);
 
   // @todo: Make an installation option to enable this module.
-  \Drupal::service('module_installer')->install(['mukurtu_solr']);
+  // \Drupal::service('module_installer')->install(['mukurtu_solr']);
 
   // Rebuild node access permissions.
   node_access_rebuild();


### PR DESCRIPTION
Fixes https://github.com/MukurtuCMS/Mukurtu-CMS/issues/709.

To test:

- Log into sandbox as `admin`
- Visit `/admin/modules`
- Confirm that neither "Mukurtu Solr" nor any of the "Search API Solr" modules are enabled.