### PR TITLE
716: Make contextual links clickable on category terms.

### DIFF
--- a/themes/mukurtu_v4/templates/misc/taxonomy-term--category.html.twig
+++ b/themes/mukurtu_v4/templates/misc/taxonomy-term--category.html.twig
@@ -25,9 +25,9 @@
 #}
 
 <div{{ attributes.addClass('category-teaser') }}>
+  {{ title_prefix }}
+  {{ title_suffix }}
   <a href="/digital-heritage?f%5B0%5D=category%3A{{ name.0 }}">
-    {{ title_prefix }}
-    {{ title_suffix }}
     {{ content }}
     <h2>{{ name }}</h2>
   </a>


### PR DESCRIPTION
Fixes https://github.com/MukurtuCMS/Mukurtu-CMS/issues/716.

This works by moving the `{{ title_suffix }}` outside of the `<a>` tag. The contextual links are added in the `title_suffix`, and embedding the links inside another link is what caused the problem.