### PR TITLE
724: Set a minimum zoom level on Leaflet to prevent placing invalid markers.

### DIFF
--- a/modules/mukurtu_collection/config/install/core.entity_form_display.node.collection.default.yml
+++ b/modules/mukurtu_collection/config/install/core.entity_form_display.node.collection.default.yml
@@ -127,7 +127,7 @@ content:
         scroll_zoom_enabled: '1'
         map_position:
           zoom: '12'
-          minZoom: '1'
+          minZoom: '3'
           maxZoom: '18'
           zoomFiner: '0'
           force: 0

--- a/modules/mukurtu_collection/config/install/core.entity_view_display.node.collection.browse_collections.yml
+++ b/modules/mukurtu_collection/config/install/core.entity_view_display.node.collection.browse_collections.yml
@@ -49,6 +49,7 @@ hidden:
   field_in_collection: true
   field_items_in_collection: true
   field_keywords: true
+  field_location: true
   field_multipage_page_of: true
   field_parent_collection: true
   field_related_content: true

--- a/modules/mukurtu_collection/config/install/core.entity_view_display.node.collection.teaser.yml
+++ b/modules/mukurtu_collection/config/install/core.entity_view_display.node.collection.teaser.yml
@@ -41,6 +41,7 @@ hidden:
   field_in_collection: true
   field_items_in_collection: true
   field_keywords: true
+  field_location: true
   field_multipage_page_of: true
   field_parent_collection: true
   field_related_content: true

--- a/modules/mukurtu_dictionary/config/install/core.entity_form_display.node.dictionary_word.default.yml
+++ b/modules/mukurtu_dictionary/config/install/core.entity_form_display.node.dictionary_word.default.yml
@@ -188,18 +188,18 @@ content:
       map:
         leaflet_map: 'OSM Mapnik'
         height: '400'
-        locate: '1'
         auto_center: '1'
         scroll_zoom_enabled: '1'
         map_position:
           zoom: '12'
-          minZoom: '1'
+          minZoom: '3'
           maxZoom: '18'
           zoomFiner: '0'
           force: 0
           center:
             lat: '0'
             lon: '0'
+          zoomControlPosition: topleft
       toolbar:
         position: topright
         marker: defaultMarker
@@ -214,8 +214,8 @@ content:
         cutPolygon: 0
         rotateMode: 0
       reset_map:
-        position: topright
         control: 0
+        options: '{"position":"topleft","title":"Reset View"}'
       fullscreen:
         options: '{"position":"topleft","pseudoFullscreen":false}'
         control: 0
@@ -227,13 +227,22 @@ content:
         control: false
         settings:
           position: topright
-          input_size: 25
+          input_size: 20
           providers: {  }
           min_terms: 4
           delay: 800
           zoom: 16
           popup: false
           options: ''
+      map_scale:
+        options: '{"position":"bottomright","maxWidth":100,"metric":true,"imperial":false,"updateWhenIdle":false}'
+        control: 0
+      locate:
+        options: '{"position":"topright","setView":"untilPanOrZoom","returnToPrevBounds":true,"keepCurrentZoomLevel":true,"strings":{"title":"Locate my position"}}'
+        automatic: '1'
+        control: 0
+      feature_properties:
+        values: ''
     third_party_settings: {  }
   field_coverage_description:
     type: text_textarea

--- a/modules/mukurtu_dictionary/config/install/core.entity_form_display.node.word_list.default.yml
+++ b/modules/mukurtu_dictionary/config/install/core.entity_form_display.node.word_list.default.yml
@@ -116,7 +116,7 @@ content:
         scroll_zoom_enabled: '1'
         map_position:
           zoom: '12'
-          minZoom: '1'
+          minZoom: '3'
           maxZoom: '18'
           zoomFiner: '0'
           force: 0

--- a/modules/mukurtu_dictionary/config/install/core.entity_view_display.node.word_list.browse.yml
+++ b/modules/mukurtu_dictionary/config/install/core.entity_view_display.node.word_list.browse.yml
@@ -53,6 +53,7 @@ hidden:
   field_description: true
   field_in_collection: true
   field_keywords: true
+  field_location: true
   field_media_assets: true
   field_multipage_page_of: true
   field_related_content: true

--- a/modules/mukurtu_dictionary/config/install/core.entity_view_display.node.word_list.content_browser.yml
+++ b/modules/mukurtu_dictionary/config/install/core.entity_view_display.node.word_list.content_browser.yml
@@ -42,6 +42,7 @@ hidden:
   field_description: true
   field_in_collection: true
   field_keywords: true
+  field_location: true
   field_media_assets: true
   field_multipage_page_of: true
   field_protocol_control: true

--- a/modules/mukurtu_dictionary/config/install/core.entity_view_display.node.word_list.default.yml
+++ b/modules/mukurtu_dictionary/config/install/core.entity_view_display.node.word_list.default.yml
@@ -36,6 +36,7 @@ hidden:
   field_description: true
   field_in_collection: true
   field_keywords: true
+  field_location: true
   field_media_assets: true
   field_multipage_page_of: true
   field_protocol_control: true

--- a/modules/mukurtu_dictionary/config/install/core.entity_view_display.node.word_list.taxonomy_record.yml
+++ b/modules/mukurtu_dictionary/config/install/core.entity_view_display.node.word_list.taxonomy_record.yml
@@ -42,6 +42,7 @@ hidden:
   field_description: true
   field_in_collection: true
   field_keywords: true
+  field_location: true
   field_media_assets: true
   field_multipage_page_of: true
   field_protocol_control: true

--- a/modules/mukurtu_dictionary/config/install/core.entity_view_display.node.word_list.teaser.yml
+++ b/modules/mukurtu_dictionary/config/install/core.entity_view_display.node.word_list.teaser.yml
@@ -49,6 +49,7 @@ hidden:
   field_description: true
   field_in_collection: true
   field_keywords: true
+  field_location: true
   field_media_assets: true
   field_multipage_page_of: true
   field_protocol_control: true

--- a/modules/mukurtu_digital_heritage/config/install/core.entity_form_display.node.digital_heritage.default.yml
+++ b/modules/mukurtu_digital_heritage/config/install/core.entity_form_display.node.digital_heritage.default.yml
@@ -245,18 +245,18 @@ content:
       map:
         leaflet_map: 'OSM Mapnik'
         height: '400'
-        locate: '1'
         auto_center: '1'
         scroll_zoom_enabled: '1'
         map_position:
           zoom: '12'
-          minZoom: '1'
+          minZoom: '3'
           maxZoom: '18'
           zoomFiner: '0'
           force: 0
           center:
             lat: '0'
             lon: '0'
+          zoomControlPosition: topleft
       toolbar:
         position: topright
         marker: defaultMarker
@@ -271,8 +271,8 @@ content:
         cutPolygon: 0
         rotateMode: 0
       reset_map:
-        position: topright
         control: 0
+        options: '{"position":"topleft","title":"Reset View"}'
       fullscreen:
         options: '{"position":"topleft","pseudoFullscreen":false}'
         control: 0
@@ -284,13 +284,22 @@ content:
         control: false
         settings:
           position: topright
-          input_size: 25
+          input_size: 20
           providers: {  }
           min_terms: 4
           delay: 800
           zoom: 16
           popup: false
           options: ''
+      map_scale:
+        options: '{"position":"bottomright","maxWidth":100,"metric":true,"imperial":false,"updateWhenIdle":false}'
+        control: 0
+      locate:
+        options: '{"position":"topright","setView":"untilPanOrZoom","returnToPrevBounds":true,"keepCurrentZoomLevel":true,"strings":{"title":"Locate my position"}}'
+        automatic: '1'
+        control: 0
+      feature_properties:
+        values: ''
     third_party_settings: {  }
   field_coverage_description:
     type: text_textarea

--- a/modules/mukurtu_person/config/install/core.entity_form_display.node.person.default.yml
+++ b/modules/mukurtu_person/config/install/core.entity_form_display.node.person.default.yml
@@ -122,18 +122,18 @@ content:
       map:
         leaflet_map: 'OSM Mapnik'
         height: '400'
-        locate: '1'
         auto_center: '1'
         scroll_zoom_enabled: '1'
         map_position:
           zoom: '12'
-          minZoom: '1'
+          minZoom: '3'
           maxZoom: '18'
           zoomFiner: '0'
           force: 0
           center:
             lat: '0'
             lon: '0'
+          zoomControlPosition: topleft
       toolbar:
         position: topright
         marker: defaultMarker
@@ -148,8 +148,8 @@ content:
         cutPolygon: 0
         rotateMode: 0
       reset_map:
-        position: topright
         control: 0
+        options: '{"position":"topleft","title":"Reset View"}'
       fullscreen:
         options: '{"position":"topleft","pseudoFullscreen":false}'
         control: 0
@@ -161,13 +161,22 @@ content:
         control: false
         settings:
           position: topright
-          input_size: 25
+          input_size: 20
           providers: {  }
           min_terms: 4
           delay: 800
           zoom: 16
           popup: false
           options: ''
+      map_scale:
+        options: '{"position":"bottomright","maxWidth":100,"metric":true,"imperial":false,"updateWhenIdle":false}'
+        control: 0
+      locate:
+        options: '{"position":"topright","setView":"untilPanOrZoom","returnToPrevBounds":true,"keepCurrentZoomLevel":true,"strings":{"title":"Locate my position"}}'
+        automatic: '1'
+        control: 0
+      feature_properties:
+        values: ''
     third_party_settings: {  }
   field_coverage_description:
     type: text_textarea
@@ -352,4 +361,5 @@ content:
     third_party_settings: {  }
 hidden:
   field_content_type: true
+  field_location: true
   field_sequence_collection: true

--- a/modules/mukurtu_person/config/install/core.entity_view_display.node.person.browse.yml
+++ b/modules/mukurtu_person/config/install/core.entity_view_display.node.person.browse.yml
@@ -55,6 +55,7 @@ hidden:
   field_deceased: true
   field_in_collection: true
   field_keywords: true
+  field_location: true
   field_media_assets: true
   field_multipage_page_of: true
   field_protocol_control: true

--- a/modules/mukurtu_person/config/install/core.entity_view_display.node.person.content_browser.yml
+++ b/modules/mukurtu_person/config/install/core.entity_view_display.node.person.content_browser.yml
@@ -45,6 +45,7 @@ hidden:
   field_deceased: true
   field_in_collection: true
   field_keywords: true
+  field_location: true
   field_media_assets: true
   field_multipage_page_of: true
   field_protocol_control: true

--- a/modules/mukurtu_person/config/install/core.entity_view_display.node.person.default.yml
+++ b/modules/mukurtu_person/config/install/core.entity_view_display.node.person.default.yml
@@ -57,6 +57,7 @@ hidden:
   field_deceased: true
   field_in_collection: true
   field_keywords: true
+  field_location: true
   field_media_assets: true
   field_multipage_page_of: true
   field_protocol_control: true

--- a/modules/mukurtu_person/config/install/core.entity_view_display.node.person.taxonomy_record.yml
+++ b/modules/mukurtu_person/config/install/core.entity_view_display.node.person.taxonomy_record.yml
@@ -60,6 +60,7 @@ hidden:
   field_date_died: true
   field_deceased: true
   field_in_collection: true
+  field_location: true
   field_multipage_page_of: true
   field_protocol_control: true
   field_related_content: true

--- a/modules/mukurtu_person/config/install/core.entity_view_display.node.person.teaser.yml
+++ b/modules/mukurtu_person/config/install/core.entity_view_display.node.person.teaser.yml
@@ -48,6 +48,7 @@ hidden:
   field_deceased: true
   field_in_collection: true
   field_keywords: true
+  field_location: true
   field_media_assets: true
   field_multipage_page_of: true
   field_protocol_control: true


### PR DESCRIPTION
Fixes https://github.com/MukurtuCMS/Mukurtu-CMS/issues/724 by setting a minimum zoom on location input.

To test:

- Create a word, collection, DH, or person.
- Under "Additional Fields", scroll down to the map field.
- Try to zoom out the map in a way that the entire world is visible. Should not be possible.
- Try to place a marker on the same content on both the left and right side of the map. Should not be possible.
- View the saved content. Note that the map can be zoomed out to the global level on view.