### PR TITLE
Improve Gulp task

### DIFF
--- a/themes/mukurtu_v4/gulpfile.js
+++ b/themes/mukurtu_v4/gulpfile.js
@@ -90,16 +90,23 @@ function minifyImages() {
 }
 
 function watchFiles() {
-  return watch([
-    "./components/**/*.scss",
-    "./js/**/*.js",
-    "./css/**/*.css",
-    "./components/**/*.js"
-  ],
-    (cb) => {
-      series(minifyImages, lintScripts, lintStyles, buildStyles);
+  watch("./components/**/*.scss", function watchScss(cb) {
+    series(lintStyles, buildStyles)((err) => {
+      if (err) {
+        console.error(err);
+      }
       cb();
     });
+  });
+  watch([
+    "./js/**/*.js",
+    "./components/**/*.js",
+  ], lintScripts);
+  watch([
+    "./css/00-base/**/*.css",
+    "./css/content-warnings.css",
+    "./css/leaflet-overrides.css"
+  ], lintStyles)
 }
 
 exports.imagemin = minifyImages;


### PR DESCRIPTION
Noticed a few issues with the upgraded Gulp tasks.

1. The watch job doesn't actually write it's files.
2. All jobs are run, even if a different file type change occurs. For example, if a SCSS change is made, the JS tasks are run as well.

This PR fixes these issues.