### PR TITLE
Paragraphs are saving properly now

### DIFF
--- a/modules/mukurtu_dictionary/config/install/paragraphs.paragraphs_type.sample_sentence.yml
+++ b/modules/mukurtu_dictionary/config/install/paragraphs.paragraphs_type.sample_sentence.yml
@@ -6,5 +6,5 @@ label: 'Sample Sentence'
 icon_uuid: null
 icon_default: null
 description: ''
-save_empty: false
+save_empty: true
 behavior_plugins: {  }

--- a/modules/mukurtu_digital_heritage/config/install/paragraphs.paragraphs_type.indigenous_knowledge_keepers.yml
+++ b/modules/mukurtu_digital_heritage/config/install/paragraphs.paragraphs_type.indigenous_knowledge_keepers.yml
@@ -6,5 +6,5 @@ label: 'Citing Indigenous Elders and Knowledge Keepers'
 icon_uuid: null
 icon_default: null
 description: 'A field to cite Indigenous elders and Knowledge Keepers.'
-save_empty: false
+save_empty: true
 behavior_plugins: {  }

--- a/modules/mukurtu_person/config/install/paragraphs.paragraphs_type.formatted_text_with_title.yml
+++ b/modules/mukurtu_person/config/install/paragraphs.paragraphs_type.formatted_text_with_title.yml
@@ -6,5 +6,5 @@ label: 'Formatted Text with Title'
 icon_uuid: null
 icon_default: null
 description: ''
-save_empty: false
+save_empty: true
 behavior_plugins: {  }

--- a/modules/mukurtu_person/config/install/paragraphs.paragraphs_type.related_person.yml
+++ b/modules/mukurtu_person/config/install/paragraphs.paragraphs_type.related_person.yml
@@ -6,5 +6,5 @@ label: 'Related Person'
 icon_uuid: null
 icon_default: null
 description: ''
-save_empty: false
+save_empty: true
 behavior_plugins: {  }

--- a/modules/mukurtu_person/src/Entity/Person.php
+++ b/modules/mukurtu_person/src/Entity/Person.php
@@ -5,6 +5,7 @@ namespace Drupal\mukurtu_person\Entity;
 use Drupal\node\Entity\Node;
 use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\mukurtu_person\PersonInterface;
 use Drupal\mukurtu_protocol\CulturalProtocolControlledTrait;
 use Drupal\mukurtu_protocol\CulturalProtocolControlledInterface;

--- a/modules/mukurtu_person/src/Entity/Person.php
+++ b/modules/mukurtu_person/src/Entity/Person.php
@@ -5,7 +5,6 @@ namespace Drupal\mukurtu_person\Entity;
 use Drupal\node\Entity\Node;
 use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Entity\EntityTypeInterface;
-use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\mukurtu_person\PersonInterface;
 use Drupal\mukurtu_protocol\CulturalProtocolControlledTrait;
 use Drupal\mukurtu_protocol\CulturalProtocolControlledInterface;


### PR DESCRIPTION
The fix ended up being simple--in our paragraphs type config, set the `save_empty` flag to `true`. Unfortunately, this has the side effect that empty paragraphs will show up when viewing entities with paragraphs:
![image](https://github.com/user-attachments/assets/e0b674ac-f60b-4b52-a556-8db8c693b586)
@bronzehedwick, would you know how to address this issue of paragraphs showing up even when empty, while keeping this specific config? 