### PR TITLE
Resolving extra space in "email us text" in footer

### DIFF
--- a/modules/mukurtu_footer/templates/mukurtu-footer.html.twig
+++ b/modules/mukurtu_footer/templates/mukurtu-footer.html.twig
@@ -16,8 +16,7 @@
   {% if email_us_text %}
     <div class="email-us-text">
       <a href="mailto:{{ contact_email_address }}">
-        <svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve" width="21" height="13" fill="#ccc" stroke="#ccc" aria-hidden="true" style="margin-right: 5px"><path d="M19.87.04 19.69 0H1.31L1.2.02l9.3 8.21zM20.91.86l-6.62 5.79 6.54 5.66c.1-.18.17-.39.17-.61V1.3c0-.15-.04-.3-.09-.44zM.1.8c-.06.15-.1.32-.1.5v10.4c0 .19.05.37.12.53l6.59-5.6z"/><path d="M10.5 9.97 7.7 7.5l-6.46 5.49.07.01h18.32L13.3 7.52z"/></svg>
-        {{ email_us_text }}
+        <svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve" width="21" height="13" fill="#ccc" stroke="#ccc" aria-hidden="true" style="margin-right: 5px"><path d="M19.87.04 19.69 0H1.31L1.2.02l9.3 8.21zM20.91.86l-6.62 5.79 6.54 5.66c.1-.18.17-.39.17-.61V1.3c0-.15-.04-.3-.09-.44zM.1.8c-.06.15-.1.32-.1.5v10.4c0 .19.05.37.12.53l6.59-5.6z"/><path d="M10.5 9.97 7.7 7.5l-6.46 5.49.07.01h18.32L13.3 7.52z"/></svg>{{ email_us_text }}
       </a>
     </div>
   {% endif %}


### PR DESCRIPTION
 caused by a line break between the icon and the attribute