### PR TITLE
631: Remove custom Masonry dependency.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,6 @@
         "drupal/views_bulk_operations": "*",
         "drush/drush": "^13",
         "mukurtu/colorbox": "*",
-        "mukurtu/masonry": "*",
         "sibyx/phpgpx": "@RC"
     },
     "require-dev": {


### PR DESCRIPTION
Part of https://github.com/MukurtuCMS/Mukurtu-CMS/issues/631

While trying to consolidate all our dependencies into the main repository, I found that `masonry` may not be needed because it's now a dependency by the `mukurtu_v4` theme. See [package.json#L32](https://github.com/MukurtuCMS/Mukurtu-CMS/blob/main/themes/mukurtu_v4/package.json#L32).

I think that means we don't need to install it through composer at all, because the copy in `libraries/masonry` is not actually used.