### PR TITLE
703: Fix playwright test coverage (Gin updates, label changes).

### DIFF
--- a/tests/playwright/src/helpers/submit-entity-form.ts
+++ b/tests/playwright/src/helpers/submit-entity-form.ts
@@ -1,0 +1,12 @@
+import {Page} from "@playwright/test";
+
+/**
+ * Submit an entity form on the given page.
+ *
+ * @param page
+ */
+export default async function submitEntityForm(page) {
+  // The Gin theme makes multiple Save buttons, select the visible one.
+  const actionsWrapper = page.locator('[data-drupal-selector="edit-gin-sticky-actions"]');
+  await actionsWrapper.getByRole('button', { name: 'Save', exact: true }).click();
+}

--- a/tests/playwright/tests/default-content.spec.ts
+++ b/tests/playwright/tests/default-content.spec.ts
@@ -2,7 +2,7 @@ import { test, expect, Page } from '@playwright/test';
 import path = require("path");
 import { Login } from '~components/login';
 import { Ckeditor5 } from "~components/ckeditor5";
-import { LogMessage } from '~components/log-message';
+import submitEntityForm from '~helpers/submit-entity-form';
 import waitForAjax from '~helpers/ajax';
 
 const defaultContentSpec = {
@@ -25,31 +25,31 @@ const defaultContentSpec = {
 /* Define default Community content. */
 defaultContentSpec.community.push({
   name: 'Tribal community',
-  field_access_mode: 'community-only',
+  field_access_mode: 'Community only',
   // These protocols are created on the follow-up page after creating a
   // community. Always associated only with the newly created community.
   protocols: [
     {
       name: 'Tribal members only',
-      field_access_mode: 'strict',
+      field_access_mode: 'Strict',
     },
     {
       name: 'Tribal community public access',
-      field_access_mode: 'open',
+      field_access_mode: 'Open',
     },
   ],
 });
 defaultContentSpec.community.push({
   name: 'Repository community',
-  field_access_mode: 'community-only',
+  field_access_mode: 'Community only',
   protocols: [
     {
       name: 'Repository under review',
-      field_access_mode: 'strict',
+      field_access_mode: 'Strict',
     },
     {
       name: 'Repository public access',
-      field_access_mode: 'open',
+      field_access_mode: 'Open',
     },
   ],
 });
@@ -58,7 +58,7 @@ defaultContentSpec.community.push({
 /* Define additional protocols. */
 defaultContentSpec.protocol.push({
   name: 'Shared protocol',
-  field_access_mode: 'open',
+  field_access_mode: 'Open',
   // This entity reference field is matched by the community name.
   field_communities: ['Tribal community', 'Repository community'],
 });
@@ -186,7 +186,7 @@ test('Default Content: Community', async ({ page, browserName }) => {
     for (const protocol of community.protocols) {
       await page.getByRole('textbox', { name: 'Protocol Name' }).fill(protocol.name);
       await page
-        .getByRole('group', { name: 'Sharing Protocol' })
+        .getByRole('group', { name: 'Cultural Protocol Type' })
         .getByRole('radio', { name: protocol.field_access_mode })
         .check();
       await page.getByRole('button', { name: 'Save and Create Another Protocol' }).click();
@@ -202,7 +202,7 @@ test('Default Content: Category', async ({ page, browserName }) => {
   // Loop through all Digital Heritage items and create each one.
   for (const category of defaultContentSpec.category) {
     // Create through the custom admin URL.
-    await page.goto('/admin/categories');
+    await page.goto('/admin/categories/manage');
 
     // Expand the Details element to populate a new category value.
     await page.getByRole('button', { name: 'Add a new category' }).click();
@@ -272,7 +272,7 @@ test('Default Content: Person', async ({ page, browserName }) => {
       await page.getByRole('checkbox', { name: 'Deceased' }).check();
     }
 
-    await page.getByRole('button', { name: 'Save', exact: true }).click();
+    await submitEntityForm(page);
   }
 });
 
@@ -299,7 +299,7 @@ test('Default Content: Digital Heritage', async ({ page, browserName }) => {
         .check();
     }
 
-    await page.getByRole('button', { name: 'Save', exact: true }).click();
+    await submitEntityForm(page);
   }
 });
 
@@ -386,7 +386,7 @@ test('Default Content: Dictionary Word', async ({ page, browserName }) => {
       await waitForAjax(page);
     }
 
-    await page.getByRole('button', { name: 'Save', exact: true }).click();
+    await submitEntityForm(page);
     await expect(page.getByRole('contentinfo', { name: 'Status message' })).toContainText(`Dictionary Word ${word.term} has been created.`)
   }
 


### PR DESCRIPTION
I tried running Playwright tests locally and found they were not passing. This appears to be caused by switching to the Gin admin theme and some label and path changes. After this change, Playwright tests should be working again.

To test locally:

```
ddev drush si --site-name=Mukurtu --account-name=admin --account-pass=admin
cd web/profiles/mukurtu/tests/playwright
npx playwright install
npx playwright test
```

All tests should pass. This should also fix our Tugboat Playwright tests, which seem to be failing on every PR. It does not yet fix the unit tests, which also seem to be failing.