### PR TITLE
1004 - Displaying protocol and community main region if empty

### DIFF
--- a/modules/mukurtu_protocol/config/install/core.entity_view_display.protocol.protocol.default.yml
+++ b/modules/mukurtu_protocol/config/install/core.entity_view_display.protocol.protocol.default.yml
@@ -18,7 +18,7 @@ third_party_settings:
       format_type: html_element
       format_settings:
         classes: 'protocol__content layout-right-sidebar__content'
-        show_empty_fields: false
+        show_empty_fields: true
         id: ''
         label_as_html: false
         element: div

--- a/themes/mukurtu_v4/templates/field/field-group-html-element--group-community-content.html.twig
+++ b/themes/mukurtu_v4/templates/field/field-group-html-element--group-community-content.html.twig
@@ -1,0 +1,32 @@
+{#
+/**
+ * @file
+ * Default theme implementation for a fieldgroup html element.
+ *
+ * Available variables:
+ * - title: Title of the group.
+ * - title_element: Element to wrap the title.
+ * - children: The children of the group.
+ * - wrapper_element: The html element to use
+ * - attributes: A list of HTML attributes for the group wrapper.
+ *
+ * @see template_preprocess_field_group_html_element()
+ *
+ * @ingroup themeable
+ */
+#}
+
+{% set children_rendered = children|render %}
+
+<{{ wrapper_element }} {{ attributes }}>
+{% if title %}
+  <{{ title_element }}{{ title_attributes }}>{{ title }}</{{ title_element }}>
+{% endif %}
+  {% if collapsible %}
+<div class="field-group-wrapper">
+  {% endif %}
+  {{children_rendered|raw}}
+  {% if collapsible %}
+</div>
+{% endif %}
+</{{ wrapper_element }}>

--- a/themes/mukurtu_v4/templates/field/field-group-html-element--protocol.html.twig
+++ b/themes/mukurtu_v4/templates/field/field-group-html-element--protocol.html.twig
@@ -1,0 +1,32 @@
+{#
+/**
+ * @file
+ * Default theme implementation for a fieldgroup html element.
+ *
+ * Available variables:
+ * - title: Title of the group.
+ * - title_element: Element to wrap the title.
+ * - children: The children of the group.
+ * - wrapper_element: The html element to use
+ * - attributes: A list of HTML attributes for the group wrapper.
+ *
+ * @see template_preprocess_field_group_html_element()
+ *
+ * @ingroup themeable
+ */
+#}
+
+{% set children_rendered = children|render %}
+
+<{{ wrapper_element }} {{ attributes }}>
+{% if title %}
+  <{{ title_element }}{{ title_attributes }}>{{ title }}</{{ title_element }}>
+{% endif %}
+  {% if collapsible %}
+<div class="field-group-wrapper">
+  {% endif %}
+  {{children_rendered|raw}}
+  {% if collapsible %}
+</div>
+{% endif %}
+</{{ wrapper_element }}>


### PR DESCRIPTION
Issue #1004 

### Description
This PR adjust protocol and community so it shows the main region even if empty.

### How To Test

1. Login to Tugboat
2. Create a community and a protocol with empty content, validate that the sidebar is in the correct location.