### PR TITLE
943: Fix unit test warnings.

### DIFF
--- a/modules/mukurtu_import/tests/src/Kernel/MukurtuImportTestBase.php
+++ b/modules/mukurtu_import/tests/src/Kernel/MukurtuImportTestBase.php
@@ -265,7 +265,10 @@ class MukurtuImportTestBase extends MigrateTestBase {
     // Run the import.
     $message = new MigrateMessage();
     $migration = \Drupal::getContainer()->get('plugin.manager.migration')->createStubMigration($definition);
-    $executable = new ImportBatchExecutable($migration, $message, []);
+    $time = \Drupal::getContainer()->get('datetime.time');
+    $translation = \Drupal::getContainer()->get('string_translation');
+    $migrationPluginManager = \Drupal::service('plugin.manager.migration');
+    $executable = new ImportBatchExecutable($migration, $message, $this->keyValue, $time, $translation, $migrationPluginManager, []);
     return $executable->import();
   }
 


### PR DESCRIPTION
Related to the current unit test failures as noted here: https://github.com/MukurtuCMS/Mukurtu-CMS/issues/943#issuecomment-3105690570

This PR fixes the 24 warnings we get while running unit tests. It does not actually fix the failing tests themselves. We might merge this right now to fix the warnings, as fixing the test failures could take a longer time.

To QA:

- Open any other PR https://github.com/MukurtuCMS/Mukurtu-CMS/pulls
- Click on the "Mukurtu CI Tests / Mukurtu v4 - PHP 8.3 (pull_request)" test coverage.
- Note that on all existing test failures ([like this one](https://github.com/MukurtuCMS/Mukurtu-CMS/actions/runs/16601673170/job/46962771404?pr=1023)), there are warnings such as:
>  1) Drupal\Tests\mukurtu_import\Kernel\ImportBooleanTest::testZeroAndOne
TypeError: Drupal\migrate_tools\MigrateBatchExecutable::__construct(): Argument #3 ($keyValue) must be of type Drupal\Core\KeyValueStore\KeyValueFactoryInterface, array given, called in /home/runner/work/Mukurtu-CMS/Mukurtu-CMS/web/profiles/mukurtu/modules/mukurtu_import/tests/src/Kernel/MukurtuImportTestBase.php on line 268
- Click the test coverage result for "Mukurtu CI Tests / Mukurtu v4 - PHP 8.3 (pull_request)" on this PR.
- Note that while 4 test failures are still occurring, there are no longer any warnings.