### PR TITLE
Adding gin properties to submit button

### DIFF
--- a/modules/mukurtu_protocol/src/Form/ProtocolAddForm.php
+++ b/modules/mukurtu_protocol/src/Form/ProtocolAddForm.php
@@ -241,6 +241,7 @@ class ProtocolAddForm extends EntityForm {
         '::submitForm',
         '::save',
       ],
+      '#gin_action_item' => TRUE,
     ];
 
     $actions['submit_done'] = [
@@ -252,6 +253,7 @@ class ProtocolAddForm extends EntityForm {
         '::save',
         '::redirectToCommunity',
       ],
+      '#gin_action_item' => TRUE,
     ];
 
     return $actions;


### PR DESCRIPTION
### Description
This PR adds `'#gin_action_item' => TRUE` to add protocol submit buttons.

### Steps to test

1. Login to Tugboat
2. Create a community
3. On the create protocol form, validate that the "save and create another protocol" and "save" buttons are visible and not hidden behind a dropdown.