### PR TITLE
992: Improve path structure for managing Local Contexts. Fix saving Local Contexts projects.

### DIFF
--- a/modules/mukurtu_local_contexts/README.md
+++ b/modules/mukurtu_local_contexts/README.md
@@ -15,7 +15,7 @@ This module provides forms to manage (add, remove) supported projects at the fol
 A given user's supported projects consists of the site projects plus all group projects the user has membership in.
 
 ## Hub Data
-All actual project/label/notice data lives on the Hub and can only be modified on the Hub. This data cannot be modified from within Mukurtu CMS. At the time of writing, the Hub API endpoint response time is too slow to query in real time, so we cache the results to custom tables in the database. See `mukurtu_local_contexts_schema` in `mukurtu_local_contexts.install` for the table schemas.
+All actual project/label/notice data lives on the Hub and can only be modified on the Hub. This data cannot be modified from within Mukurtu CMS. To avoid overwhelming the Hub API endpoint, Local Context projects are synced to custom tables in the database. See `mukurtu_local_contexts_schema` in `mukurtu_local_contexts.install` for the table schemas.
 
 ## Legacy Label Support
 On some sites, there are some projects with IDs that reference "legacy" such as `default_tk` or `sitewide_tk`. These are a result of migrating from Mukurtu CMS version 3 to version 4. In version 3, users could customize their own versions of labels within their own Mukurtu CMS site. This is no longer supported, in an effort to encourage people to utilize the Local Contexts Hub. However, to smooth the transition, version 4 provides "legacy" support that will migrate their old version 3 labels and allow them to continue to use them with version 4 content. However in version 4 they will not be able to alter those legacy labels or add new legacy labels.

--- a/modules/mukurtu_local_contexts/mukurtu_local_contexts.install
+++ b/modules/mukurtu_local_contexts/mukurtu_local_contexts.install
@@ -321,7 +321,7 @@ function mukurtu_local_contexts_schema() {
         'default' => 0,
       ],
     ],
-    'primary key' => ['locale'],
+    'primary key' => ['project_id', 'type', 'locale'],
     'indexes' => [
       'updated' => ['updated'],
     ],

--- a/modules/mukurtu_local_contexts/mukurtu_local_contexts.links.action.yml
+++ b/modules/mukurtu_local_contexts/mukurtu_local_contexts.links.action.yml
@@ -1,0 +1,17 @@
+mukurtu_local_contexts_add_site_supported_project_action:
+  route_name: mukurtu_local_contexts.add_site_supported_project
+  title: 'Add project'
+  appears_on:
+    - mukurtu_local_contexts.manage_site_supported_projects
+
+mukurtu_local_contexts_add_community_supported_project_action:
+  route_name: mukurtu_local_contexts.add_community_supported_project
+  title: 'Add project'
+  appears_on:
+    - mukurtu_local_contexts.manage_community_supported_projects
+
+mukurtu_local_contexts_add_protocol_supported_project_action:
+  route_name: mukurtu_local_contexts.add_site_supported_project
+  title: 'Add project'
+  appears_on:
+    - mukurtu_local_contexts.manage_protocol_supported_projects

--- a/modules/mukurtu_local_contexts/mukurtu_local_contexts.links.menu.yml
+++ b/modules/mukurtu_local_contexts/mukurtu_local_contexts.links.menu.yml
@@ -10,10 +10,3 @@ mukurtu_local_contexts.site_projects_directory:
   description: 'View the directory of Local Contexts Projects specific to this site.'
   menu_name: mukurtu
   route_name: mukurtu_local_contexts.site_project_directory
-
-mukurtu_local_contexts.manage_site_projects_directory:
-  title: 'Manage Site Local Contexts Projects Directory'
-  description: 'Configure the site Local Contexts Projects Directory page.'
-  parent: mukurtu_core.site_configuration
-  menu_name: mukurtu
-  route_name: mukurtu_local_contexts.manage_site_project_directory

--- a/modules/mukurtu_local_contexts/mukurtu_local_contexts.links.task.yml
+++ b/modules/mukurtu_local_contexts/mukurtu_local_contexts.links.task.yml
@@ -1,0 +1,38 @@
+##
+# Local tasks for Site-wide LC projects:
+##
+mukurtu_local_contexts.manage_site_supported_projects:
+  route_name: mukurtu_local_contexts.manage_site_supported_projects
+  title: 'Manage Projects'
+  base_route: mukurtu_local_contexts.manage_site_supported_projects
+
+mukurtu_local_contexts.site_project_directory_settings:
+  route_name: mukurtu_local_contexts.site_project_directory_settings
+  title: 'Project Directory Settings'
+  base_route: mukurtu_local_contexts.manage_site_supported_projects
+
+##
+# Local tasks for Communities:
+##
+mukurtu_local_contexts.manage_community_supported_projects:
+  route_name: mukurtu_local_contexts.manage_community_supported_projects
+  title: 'Manage Projects'
+  base_route: mukurtu_local_contexts.manage_community_supported_projects
+
+mukurtu_local_contexts.community_project_directory_settings:
+  route_name: mukurtu_local_contexts.community_project_directory_settings
+  title: 'Project Directory Settings'
+  base_route: mukurtu_local_contexts.manage_community_supported_projects
+
+##
+# Local tasks for Contexts:
+##
+mukurtu_local_contexts.manage_protocol_supported_projects:
+  route_name: mukurtu_local_contexts.manage_protocol_supported_projects
+  title: 'Manage Projects'
+  base_route: mukurtu_local_contexts.manage_protocol_supported_projects
+
+mukurtu_local_contexts.protocol_project_directory_settings:
+  route_name: mukurtu_local_contexts.protocol_project_directory_settings
+  title: 'Project Directory Settings'
+  base_route: mukurtu_local_contexts.manage_protocol_supported_projects

--- a/modules/mukurtu_local_contexts/mukurtu_local_contexts.routing.yml
+++ b/modules/mukurtu_local_contexts/mukurtu_local_contexts.routing.yml
@@ -1,19 +1,6 @@
-mukurtu_local_contexts.manage_site_supported_projects:
-  path: '/admin/local-contexts/projects/site/manage'
-  defaults:
-    _title: 'Manage site-wide Local Contexts projects'
-    _form: 'Drupal\mukurtu_local_contexts\Form\ManageSiteSupportedProjects'
-  requirements:
-    _permission: 'administer site configuration'
-
-mukurtu_local_contexts.add_site_supported_project:
-  path: '/admin/local-contexts/projects/site/add'
-  defaults:
-    _title: 'Add a site-wide Local Contexts project'
-    _form: 'Drupal\mukurtu_local_contexts\Form\AddSiteSupportedProject'
-  requirements:
-    _permission: 'administer site configuration'
-
+##
+# Site-wide LC projects (front-end):
+##
 mukurtu_local_contexts.site_project_directory:
   path: '/local-contexts/projects'
   defaults:
@@ -22,27 +9,36 @@ mukurtu_local_contexts.site_project_directory:
   requirements:
     _custom_access: '\Drupal\mukurtu_local_contexts\Controller\ProjectDirectoryController::siteDirectoryAccess'
 
-mukurtu_local_contexts.manage_site_project_directory:
-  path: '/admin/local-contexts/projects/manage'
+##
+# Site-wide LC projects (admin pages):
+##
+mukurtu_local_contexts.manage_site_supported_projects:
+  path: '/admin/local-contexts/projects'
   defaults:
-    _title: 'Manage site-wide Local Contexts projects directory'
+    _title: 'Manage site-wide Local Contexts projects'
+    _form: 'Drupal\mukurtu_local_contexts\Form\ManageSiteSupportedProjects'
+  requirements:
+    _permission: 'administer site configuration'
+
+mukurtu_local_contexts.site_project_directory_settings:
+  path: '/admin/local-contexts/projects/settings'
+  defaults:
+    _title: 'Site-wide Local Contexts projects directory settings'
     _form: 'Drupal\mukurtu_local_contexts\Form\ManageSiteProjectsDirectory'
   requirements:
     _permission: 'administer site configuration'
 
-mukurtu_local_contexts.manage_community_supported_projects:
-  path: '/communities/{group}/local-contexts-projects/manage'
+mukurtu_local_contexts.add_site_supported_project:
+  path: '/admin/local-contexts/projects/add'
   defaults:
-    _title_callback: '\Drupal\mukurtu_local_contexts\Controller\ManageGroupSupportedProjectsController::title'
-    _form: 'Drupal\mukurtu_local_contexts\Form\ManageGroupSupportedProjects'
+    _title: 'Add a site-wide Local Contexts project'
+    _form: 'Drupal\mukurtu_local_contexts\Form\AddSiteSupportedProject'
   requirements:
-    _custom_access: '\Drupal\mukurtu_local_contexts\Controller\ManageGroupSupportedProjectsController::access'
-  options:
-    _admin_route: TRUE
-    parameters:
-      group:
-        type: entity:community
+    _permission: 'administer site configuration'
 
+##
+# Community LC projects (front-end):
+##
 mukurtu_local_contexts.community_projects_directory:
   path: '/communities/{group}/local-contexts/projects'
   defaults:
@@ -55,18 +51,32 @@ mukurtu_local_contexts.community_projects_directory:
   requirements:
     _custom_access: '\Drupal\mukurtu_local_contexts\Controller\ProjectDirectoryController::groupDirectoryAccess'
 
-mukurtu_local_contexts.manage_community_project_directory:
-  path: '/communities/{group}/local-contexts/projects/manage'
+
+##
+# Community LC projects (admin pages):
+##
+mukurtu_local_contexts.manage_community_supported_projects:
+  path: '/admin/communities/{group}/local-contexts/projects'
   defaults:
-    _title: 'Manage community-based Local Contexts projects directory'
+    _title_callback: '\Drupal\mukurtu_local_contexts\Controller\ManageGroupSupportedProjectsController::title'
+    _form: 'Drupal\mukurtu_local_contexts\Form\ManageGroupSupportedProjects'
+  requirements:
+    _custom_access: '\Drupal\mukurtu_local_contexts\Controller\ManageGroupSupportedProjectsController::access'
+  options:
+    parameters:
+      group:
+        type: entity:community
+
+mukurtu_local_contexts.community_project_directory_settings:
+  path: '/admin/communities/{group}/local-contexts/projects/settings'
+  defaults:
+    _title: 'Community-based Local Contexts projects directory settings'
     _form: 'Drupal\mukurtu_local_contexts\Form\ManageCommunityProjectsDirectory'
   requirements:
     _permission: 'update group'
-  options:
-    _admin_route: TRUE
 
 mukurtu_local_contexts.add_community_supported_project:
-  path: '/communities/{group}/local-contexts-projects/add'
+  path: '/admin/communities/{group}/local-contexts/projects/add'
   defaults:
     _title: 'Add a community-based Local Contexts project'
     _form: 'Drupal\mukurtu_local_contexts\Form\AddGroupSupportedProject'
@@ -76,18 +86,10 @@ mukurtu_local_contexts.add_community_supported_project:
     parameters:
       group:
         type: entity:community
-    _admin_route: TRUE
 
-mukurtu_local_contexts.manage_protocol_project_directory:
-  path: '/protocols/{group}/local-contexts/projects/manage'
-  defaults:
-    _title: 'Manage protocol-based Local Contexts projects directory'
-    _form: 'Drupal\mukurtu_local_contexts\Form\ManageProtocolProjectsDirectory'
-  requirements:
-    _permission: 'update group'
-  options:
-    _admin_route: TRUE
-
+##
+# Protocol LC projects (front-end):
+##
 mukurtu_local_contexts.protocol_projects_directory:
   path: '/protocols/{group}/local-contexts/projects'
   defaults:
@@ -100,8 +102,11 @@ mukurtu_local_contexts.protocol_projects_directory:
   requirements:
     _custom_access: '\Drupal\mukurtu_local_contexts\Controller\ProjectDirectoryController::groupDirectoryAccess'
 
+##
+# Protocol LC projects (admin pages):
+##
 mukurtu_local_contexts.manage_protocol_supported_projects:
-  path: '/protocols/{group}/local-contexts-projects/manage'
+  path: '/admin/protocols/{group}/local-contexts/projects'
   defaults:
     _title_callback: '\Drupal\mukurtu_local_contexts\Controller\ManageGroupSupportedProjectsController::title'
     _form: 'Drupal\mukurtu_local_contexts\Form\ManageGroupSupportedProjects'
@@ -111,10 +116,17 @@ mukurtu_local_contexts.manage_protocol_supported_projects:
     parameters:
       group:
         type: entity:protocol
-    _admin_route: TRUE
+
+mukurtu_local_contexts.protocol_project_directory_settings:
+  path: '/admin/protocols/{group}/local-contexts/projects/settings'
+  defaults:
+    _title: 'Configure settings for protocol-based Local Contexts projects directory'
+    _form: 'Drupal\mukurtu_local_contexts\Form\ManageProtocolProjectsDirectory'
+  requirements:
+    _permission: 'update group'
 
 mukurtu_local_contexts.add_protocol_supported_project:
-  path: '/protocols/{group}/local-contexts-projects/add'
+  path: '/admin/protocols/{group}/local-contexts/projects/add'
   defaults:
     _title: 'Add a protocol-based Local Contexts project'
     _form: 'Drupal\mukurtu_local_contexts\Form\AddGroupSupportedProject'
@@ -124,6 +136,5 @@ mukurtu_local_contexts.add_protocol_supported_project:
     parameters:
       group:
         type: entity:protocol
-    _admin_route: TRUE
 
 

--- a/modules/mukurtu_local_contexts/src/Controller/ProjectDirectoryController.php
+++ b/modules/mukurtu_local_contexts/src/Controller/ProjectDirectoryController.php
@@ -102,8 +102,13 @@ class ProjectDirectoryController extends ControllerBase {
     $projects = $this->localContextsProjectManager->getGroupSupportedProjects($group);
     if ($projects) {
       $description = $this->config('mukurtu_local_contexts.settings')->get('mukurtu_local_contexts_manage_community_' . $group->id() . '_projects_directory_description');
-      // Exception throws if translated string is null, so check for this.
-      $description = ($description == NULL ? '' : $this->t($description));
+      if ($description != NULL) {
+        $description = [
+          '#type' => 'processed_text',
+          '#text' => $description['value'],
+          '#format' => $description['format'],
+        ];
+      }
     }
     else {
       $description = $this->t("There are currently no Local Contexts projects for this community.");
@@ -140,9 +145,15 @@ class ProjectDirectoryController extends ControllerBase {
     $projects = $this->localContextsProjectManager->getGroupSupportedProjects($group);
     if ($projects) {
       $description = $this->config('mukurtu_local_contexts.settings')->get('mukurtu_local_contexts_manage_protocol_' . $group->id() . '_projects_directory_description');
-      // Exception throws if translated string is null, so check for this.
-      $description = ($description == NULL ? '' : $this->t($description));
-    } else {
+      if ($description != NULL) {
+        $description = [
+          '#type' => 'processed_text',
+          '#text' => $description['value'],
+          '#format' => $description['format'],
+        ];
+      }
+    }
+    else {
       $description = $this->t("There are currently no Local Contexts projects for this cultural protocol.");
     }
     foreach ($projects as &$projectInfo) {

--- a/modules/mukurtu_local_contexts/src/EventSubscriber/MukurtuLocalContextsProjectReferenceUpdatedSubscriber.php
+++ b/modules/mukurtu_local_contexts/src/EventSubscriber/MukurtuLocalContextsProjectReferenceUpdatedSubscriber.php
@@ -30,7 +30,7 @@ class MukurtuLocalContextsProjectReferenceUpdatedSubscriber implements EventSubs
 
   public function onProjectReferenceUpdated(LocalContextsProjectReferenceUpdatedEvent $event) {
     $project_id = $event->getProjectId();
-    // Check if project cache exists, in which case exit.
+    // Check if project exists in database, in which case exit.
 
     // Project does not exist. We need to request it from the hub outside of
     // the normal refresh cycle.

--- a/modules/mukurtu_local_contexts/src/Form/ManageGroupSupportedProjects.php
+++ b/modules/mukurtu_local_contexts/src/Form/ManageGroupSupportedProjects.php
@@ -4,6 +4,7 @@ namespace Drupal\mukurtu_local_contexts\Form;
 
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
 use Drupal\mukurtu_local_contexts\LocalContextsProject;
 use Drupal\mukurtu_local_contexts\LocalContextsSupportedProjectManager;
 use Drupal\Core\Entity\ContentEntityInterface;
@@ -33,22 +34,14 @@ class ManageGroupSupportedProjects extends FormBase {
     $form_state->set('group', $group);
     $projects = $this->supportedProjectManager->getGroupSupportedProjects($group);
 
-    $form['add_project_link'] = [
-      '#title' => $this->t('Add Project'),
-      '#type' => 'link',
-      '#url' => \Drupal\Core\Url::fromRoute("mukurtu_local_contexts.add_{$group->getEntityTypeId()}_supported_project", ['group' => $group->id()]),
-    ];
-
     if (!empty($projects)) {
       $form['projects'] = array(
         '#type' => 'table',
-        '#caption' => $this->t('Local Contexts Projects available for members of %group', ['%group' => $group->getName()]),
+        '#caption' => $this->t('The following Local Contexts Projects are available to members of %group.', ['%group' => $group->getName()]),
         '#header' => array(
           '',
-          $this
-            ->t('Title'),
-          $this
-            ->t('Project ID'),
+          $this->t('Title'),
+          $this->t('Project ID'),
         ),
       );
       foreach ($projects as $id => $project) {
@@ -78,12 +71,16 @@ class ManageGroupSupportedProjects extends FormBase {
         '#type' => 'submit',
         '#value' => $this->t('Remove Selected Projects'),
       ];
-    } else {
+    }
+    else {
+      $add_url = Url::fromRoute("mukurtu_local_contexts.add_{$group->getEntityTypeId()}_supported_project", ['group' => $group->id()]);
       $form['empty'] = [
-        '#type' => 'processed_text',
-        '#text' => $this->t('No projects have been added.')
+        '#markup' => $this->t('No Local Contexts projects have been added yet. <a href=":url">Add a project</a>.', [
+          ':url' => $add_url->toString(),
+        ]),
       ];
     }
+
 
     return $form;
   }

--- a/modules/mukurtu_local_contexts/src/Form/ManageSiteSupportedProjects.php
+++ b/modules/mukurtu_local_contexts/src/Form/ManageSiteSupportedProjects.php
@@ -4,6 +4,7 @@ namespace Drupal\mukurtu_local_contexts\Form;
 
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
 use Drupal\mukurtu_local_contexts\LocalContextsProject;
 use Drupal\mukurtu_local_contexts\LocalContextsSupportedProjectManager;
 
@@ -31,22 +32,14 @@ class ManageSiteSupportedProjects extends FormBase {
   public function buildForm(array $form, FormStateInterface $form_state) {
     $projects = $this->supportedProjectManager->getSiteSupportedProjects();
 
-    $form['add_project_link'] = [
-      '#title' => $this->t('Add Project'),
-      '#type' => 'link',
-      '#url' => \Drupal\Core\Url::fromRoute('mukurtu_local_contexts.add_site_supported_project'),
-    ];
-
     if (!empty($projects)) {
       $form['projects'] = array(
         '#type' => 'table',
-        '#caption' => $this->t('Local Contexts Projects available for all users'),
+        '#caption' => $this->t('The following Local Contexts Projects are available to all users.'),
         '#header' => array(
           '',
-          $this
-            ->t('Title'),
-          $this
-            ->t('Project ID'),
+          $this->t('Title'),
+          $this->t('Project ID'),
         ),
       );
       foreach ($projects as $id => $project) {
@@ -75,6 +68,14 @@ class ManageSiteSupportedProjects extends FormBase {
       $form['actions']['submit'] = [
         '#type' => 'submit',
         '#value' => $this->t('Remove Selected Projects'),
+      ];
+    }
+    else {
+      $add_url = Url::fromRoute('mukurtu_local_contexts.add_site_supported_project');
+      $form['empty'] = [
+        '#markup' => $this->t('No site-wide Local Contexts projects have been added yet. <a href=":url">Add a project</a>.', [
+          ':url' => $add_url->toString(),
+        ]),
       ];
     }
 

--- a/modules/mukurtu_local_contexts/src/LocalContextsHubBase.php
+++ b/modules/mukurtu_local_contexts/src/LocalContextsHubBase.php
@@ -2,6 +2,8 @@
 
 namespace Drupal\mukurtu_local_contexts;
 
+use Drupal\Core\Database\Connection;
+
 class LocalContextsHubBase {
   /**
    * The settings configuration key.
@@ -29,9 +31,21 @@ class LocalContextsHubBase {
    *
    * @var string
    */
-  protected $endpointUrl;
+  protected string $endpointUrl;
 
-  protected $db;
+  /**
+   * The Drupal database connection.
+   *
+   * @var \Drupal\Core\Database\Connection
+   */
+  protected Connection $db;
+
+  /**
+   * The HTTP request timestamp.
+   *
+   * @var int
+   */
+  protected int $requestTime;
 
   /**
    * Constructs a LocalContextsHubManager object.
@@ -44,6 +58,7 @@ class LocalContextsHubBase {
   public function __construct() {
     $this->configFactory = \Drupal::service('config.factory');
     $this->db = \Drupal::database();
+    $this->requestTime = \Drupal::time()->getRequestTime();
     $endpointUrl = $this->configFactory->get(self::SETTINGS_CONFIG_KEY)->get('hub_endpoint') ?? self::DEFAULT_HUB_URL;
 
     if (str_ends_with($endpointUrl, '/')) {

--- a/modules/mukurtu_local_contexts/src/LocalContextsProject.php
+++ b/modules/mukurtu_local_contexts/src/LocalContextsProject.php
@@ -2,8 +2,6 @@
 
 namespace Drupal\mukurtu_local_contexts;
 
-use PHPUnit\Framework\Error\Notice;
-
 class LocalContextsProject extends LocalContextsHubBase {
   protected $title;
   protected $privacy;
@@ -13,15 +11,24 @@ class LocalContextsProject extends LocalContextsHubBase {
   public function __construct($id) {
     parent::__construct();
     $this->id = $id;
-    $project = $this->fetch($id);
+    $project = $this->load($id);
     $this->valid = $project !== FALSE;
     $this->title = $project['title'] ?? NULL;
     $this->privacy = $project['privacy'] ?? NULL;
   }
 
-  protected function fetch($id) {
+  /**
+   * Loads a Local Contexts project from the API by its LC ID.
+   *
+   * @param string $id
+   *   The 36 character Local Contexts project ID.
+   *
+   * @return array|bool
+   *   The title and privacy information if found. FALSE if not found.
+   */
+  protected function load($id) {
     if (!$id) {
-      return NULL;
+      return FALSE;
     }
 
     $query = $this->db->select('mukurtu_local_contexts_projects', 'project')
@@ -33,8 +40,11 @@ class LocalContextsProject extends LocalContextsHubBase {
     if ($project === FALSE) {
       if ($hubProject = $this->fetchProjectFromHub($id)) {
         return [
+          'id' => $hubProject['unique_id'],
+          'provider_id' => $hubProject['providers_id'],
           'title' => $hubProject['title'],
           'privacy' => $hubProject['project_privacy'],
+          'updated' => $this->requestTime,
         ];
       }
     }
@@ -42,19 +52,25 @@ class LocalContextsProject extends LocalContextsHubBase {
     return $project;
   }
 
+  /**
+   * @param $id
+   *
+   * @return array|mixed
+   * @throws \Exception
+   */
   protected function fetchProjectFromHub($id) {
     if ($project = $this->get("projects/{$id}")) {
       if (empty($project['unique_id'])) {
         return $project;
       }
 
-      // Update our local cache of this project.
+      // Update our local copy of this project.
       $projectFields = [
         'id' => $project['unique_id'],
         'provider_id' => $project['providers_id'],
         'title' => $project['title'],
         'privacy' => $project['project_privacy'],
-        'updated' => time(),
+        'updated' => $this->requestTime,
       ];
 
       $query = $this->db->update('mukurtu_local_contexts_projects')
@@ -62,40 +78,40 @@ class LocalContextsProject extends LocalContextsHubBase {
         ->fields($projectFields);
       $result = $query->execute();
 
-      // Project doesn't exist in our local cache, insert it.
+      // Project doesn't exist in our local copy, insert it.
       if (!$result) {
         $query = $this->db->insert('mukurtu_local_contexts_projects')->fields($projectFields);
-        $result = $query->execute();
-        $prior_cached_labels = [];
-        $prior_cached_notices = [];
+        $query->execute();
+        $prior_saved_labels = [];
+        $prior_saved_notices = [];
       } else {
-        // Get any existing cached tk labels, bc labels, and notices so we can
+        // Get any existing saved tk labels, bc labels, and notices so we can
         // compare to the response from the hub and delete any that are no
         // longer there.
-        $prior_cached_labels = array_merge($this->getLabels("tk"), $this->getLabels("bc"));
-        $prior_cached_notices = $this->getNotices();
+        $prior_saved_labels = array_merge($this->getLabels("tk"), $this->getLabels("bc"));
+        $prior_saved_notices = $this->getNotices();
       }
-      // Cache the tk labels and their translations.
+      // Save the tk labels and their translations.
       if (isset($project['tk_labels'])) {
-        $this->cacheLabels($project['tk_labels'], "tk", $project['unique_id'], $prior_cached_labels);
-        $this->cacheLabelTranslations($project['tk_labels']);
+        $this->saveLabels($project['tk_labels'], "tk", $project['unique_id'], $prior_saved_labels);
+        $this->saveLabelTranslations($project['tk_labels']);
       }
 
-      // Cache the bc labels and their translations.
+      // Save the bc labels and their translations.
       if (isset($project['bc_labels'])) {
-        $this->cacheLabels($project['bc_labels'], "bc", $project['unique_id'], $prior_cached_labels);
-        $this->cacheLabelTranslations($project['bc_labels']);
+        $this->saveLabels($project['bc_labels'], "bc", $project['unique_id'], $prior_saved_labels);
+        $this->saveLabelTranslations($project['bc_labels']);
       }
 
-      // Cache the notices and their translations.
+      // Save the notices and their translations.
       if (isset($project['notice'])) {
-        $this->cacheNoticesAndTranslations($project['notice'], $project['unique_id'], $prior_cached_notices);
+        $this->saveNoticesAndTranslations($project['notice'], $project['unique_id'], $prior_saved_notices);
       }
 
-      // Delete any cached tk, bc labels, notices, and their translations that
+      // Delete any saved tk, bc labels, notices, and their translations that
       // no longer exist.
-      $this->deleteCachedLabelsAndTranslations($prior_cached_labels, $project['unique_id']);
-      $this->deleteCachedNoticesAndTranslations($prior_cached_notices, $project['unique_id']);
+      $this->deleteSavedLabelsAndTranslations($prior_saved_labels, $project['unique_id']);
+      $this->deleteSavedNoticesAndTranslations($prior_saved_notices, $project['unique_id']);
     }
     return $project;
   }
@@ -141,7 +157,7 @@ class LocalContextsProject extends LocalContextsHubBase {
     return $notices;
   }
 
-  protected function cacheLabels($labels, $tk_or_bc, $id, &$prior_cached_labels) {
+  protected function saveLabels($labels, $tk_or_bc, $id, &$prior_saved_labels) {
     foreach ($labels as $label) {
       $labelFields = [
         'id' => $label['unique_id'],
@@ -168,18 +184,18 @@ class LocalContextsProject extends LocalContextsHubBase {
 
       // Track labels we've updated so we can compare versus our last result
       // from the hub and determine if any have been deleted.
-      if (isset($prior_cached_labels[$label['unique_id']])) {
-        unset($prior_cached_labels[$label['unique_id']]);
+      if (isset($prior_saved_labels[$label['unique_id']])) {
+        unset($prior_saved_labels[$label['unique_id']]);
       }
 
       if (!$result) {
         $query = $this->db->insert('mukurtu_local_contexts_labels')->fields($labelFields);
-        $result = $query->execute();
+        $query->execute();
       }
     }
   }
 
-  protected function cacheLabelTranslations($labels) {
+  protected function saveLabelTranslations($labels) {
     foreach ($labels as $label) {
       $translations = $label['translations'] ?? [];
       foreach ($translations as $translation) {
@@ -205,7 +221,7 @@ class LocalContextsProject extends LocalContextsHubBase {
     }
   }
 
-  protected function cacheNoticesAndTranslations($notices, $projectId, &$prior_cached_notices) {
+  protected function saveNoticesAndTranslations($notices, $projectId, &$prior_saved_notices) {
     // For our db storage, notice translations need notice_type and project_id,
     // so merging the caching of notices with translations makes more sense here.
     foreach ($notices as $notice) {
@@ -226,15 +242,15 @@ class LocalContextsProject extends LocalContextsHubBase {
         ->fields($noticeFields);
       $result = $query->execute();
 
-      // Cache any translations for this notice.
-      $this->cacheNoticeTranslations($notice, $projectId, $notice['notice_type']);
+      // Save any translations for this notice.
+      $this->saveNoticeTranslations($notice, $projectId, $notice['notice_type']);
 
       // Track notices we've updated so we can compare versus our last result
       // from the hub and determine if any have been deleted.
-      // The ids of prior cached notices are 'project_id:notice_type'.
+      // The ids of prior saved notices are 'project_id:notice_type'.
       $noticeId = $projectId . ':' . $notice['notice_type'];
-      if (isset($prior_cached_notices[$noticeId])) {
-        unset($prior_cached_notices[$noticeId]);
+      if (isset($prior_saved_notices[$noticeId])) {
+        unset($prior_saved_notices[$noticeId]);
       }
 
       if (!$result) {
@@ -244,7 +260,7 @@ class LocalContextsProject extends LocalContextsHubBase {
     }
   }
 
-  protected function cacheNoticeTranslations($notice, $projectId, $noticeType) {
+  protected function saveNoticeTranslations($notice, $projectId, $noticeType) {
     $translations = $notice['translations'] ?? [];
     foreach ($translations as $translation) {
       $translationFields = [
@@ -272,8 +288,8 @@ class LocalContextsProject extends LocalContextsHubBase {
 
   }
 
-  protected function deleteCachedLabelsAndTranslations(&$prior_cached_labels, $id) {
-    foreach ($prior_cached_labels as $deleted_label_id => $deleted_label) {
+  protected function deleteSavedLabelsAndTranslations(&$prior_saved_labels, $id) {
+    foreach ($prior_saved_labels as $deleted_label_id => $deleted_label) {
       $query = $this->db->delete('mukurtu_local_contexts_label_translations')
         ->condition('label_id', $deleted_label_id);
       $query->execute();
@@ -285,12 +301,12 @@ class LocalContextsProject extends LocalContextsHubBase {
     }
   }
 
-  protected function deleteCachedNoticesAndTranslations(&$prior_cached_notices, $id) {
+  protected function deleteSavedNoticesAndTranslations(&$prior_saved_notices, $id) {
     $id = '';
     $noticeType = '';
 
-    foreach ($prior_cached_notices as $deleted_notice_id => $deleted_notice) {
-      list($id, $noticeType) = explode(':', $deleted_notice_id);
+    foreach ($prior_saved_notices as $deleted_notice_id => $deleted_notice) {
+      [$id, $noticeType] = explode(':', $deleted_notice_id);
 
       // Delete all translations before deleting the corresponding notice.
       $query = $this->db->delete('mukurtu_local_contexts_notice_translations')


### PR DESCRIPTION
While working on #992, I was struggling to make sense of the URL structure and location of all of the Local Context settings. This PR adjusts the paths of Local Contexts project settings, and sets up local tasks (tabs) and actions (shown as buttons) for managing Local Contexts project settings. This applies to both site-wide Local Contexts projects, as well as Local Contexts projects for Protocols and Groups.

---

Site wide projects before (`/admin/local-contexts/projects/site/manage`):
<img width="1281" height="381" alt="image" src="https://github.com/user-attachments/assets/30ed6013-bec4-4c25-9cf2-75e7f4389aac" />

Site-wide projects after (`/admin/local-contexts/projects`):
<img width="1280" height="342" alt="image" src="https://github.com/user-attachments/assets/1ddd73c9-30ff-4f49-b645-cc510878aa14" />

---

Community projects before (`/communities/5/local-contexts-projects/manage`):
<img width="1281" height="381" alt="image" src="https://github.com/user-attachments/assets/f90f64e4-17f2-4433-bfdf-01338ca4b61b" />

Community projects after (`admin/communities/5/local-contexts/projects`):
<img width="1281" height="381" alt="image" src="https://github.com/user-attachments/assets/46ca5a76-7a5b-4ea0-9bd2-84de1c53c4f2" />

---

Protocol projects before (`/protocols/5/local-contexts-projects/manage`):
<img width="1280" height="341" alt="image" src="https://github.com/user-attachments/assets/1ed16658-2b9b-4f52-8bab-faa5dbe42fce" />

Protocol projects after (`/admin/protocols/5/local-contexts/projects`):
<img width="1280" height="341" alt="image" src="https://github.com/user-attachments/assets/07c1f612-d33b-4e4a-afd5-1a0c5c91e39a" />

---

This improves the UI in a few ways:

- Breadcrumbs now work to get back to managing the appropriate community or protocol.
- Manual links are removed and replaced with Drupal conventions like the Local Actions button (shown in the top-right of the Gin theme).
- Tabs and sub-tabs ("Local Tasks" in Drupal terminology) are used for managing the list of projects and modifying the project listing description.

Separately, this just preps the existing API to use more accurate terminology: using "sync" instead of "cache", since local copies of the data from the Local Contexts API are not cleared on cache rebuild. We're syncing a copy of the data between Local Contexts and Drupal, not caching it. It's a nuanced difference but hopefully it will save some confusion in the future.
