### PR TITLE
1055 Community browse on front page showing private communities

### DIFF
--- a/modules/mukurtu_protocol/mukurtu_protocol.module
+++ b/modules/mukurtu_protocol/mukurtu_protocol.module
@@ -620,7 +620,8 @@ function mukurtu_protocol_query_community_access_alter(AlterableInterface $query
     $conditions = $query->orConditionGroup();
 
     // Condition 1: Public communities (field_access_mode = 'public').
-    $conditions->condition("{$community_table}.field_access_mode", 'public');
+    // Since field_access_mode is a base field, it's stored in community_field_data
+    $conditions->condition("community_field_data.field_access_mode", 'public');
 
     // Condition 2: Private communities where user is a member.
     if ($account->isAuthenticated()) {
@@ -629,7 +630,7 @@ function mukurtu_protocol_query_community_access_alter(AlterableInterface $query
         "{$community_table}.id = ogm_community.entity_id AND ogm_community.entity_type = 'community' AND ogm_community.state = 'active'");
 
       $private_member_conditions = $query->andConditionGroup()
-        ->condition("{$community_table}.field_access_mode", 'community-only')
+        ->condition("community_field_data.field_access_mode", 'community-only')
         ->condition("{$membership_alias}.uid", $account->id());
 
       $conditions->condition($private_member_conditions);

--- a/modules/mukurtu_protocol/mukurtu_protocol.module
+++ b/modules/mukurtu_protocol/mukurtu_protocol.module
@@ -595,6 +595,51 @@ function mukurtu_protocol_query_protocol_members_alter(AlterableInterface $query
 }
 
 /**
+ * Implements hook_query_TAG_alter().
+ *
+ * Handle query access for community entities in Views.
+ * Only show public communities or communities where the user is a member.
+ */
+function mukurtu_protocol_query_community_access_alter(AlterableInterface $query) {
+  if (!$account = $query->getMetaData('account')) {
+    $account = \Drupal::currentUser();
+  }
+
+  // Get the community table alias from the query.
+  $tables = $query->getTables();
+  $community_table = '';
+  foreach ($tables as $alias => $table_info) {
+    if ($table_info['table'] === 'community_field_data' || $table_info['table'] === 'community') {
+      $community_table = $alias;
+      break;
+    }
+  }
+
+  if ($community_table) {
+    // Build conditions for public communities or communities where user is a member.
+    $conditions = $query->orConditionGroup();
+
+    // Condition 1: Public communities (field_access_mode = 'public').
+    $conditions->condition("{$community_table}.field_access_mode", 'public');
+
+    // Condition 2: Private communities where user is a member.
+    if ($account->isAuthenticated()) {
+      // Join with OG membership table for private communities.
+      $membership_alias = $query->leftJoin('og_membership', 'ogm_community',
+        "{$community_table}.id = ogm_community.entity_id AND ogm_community.entity_type = 'community' AND ogm_community.state = 'active'");
+
+      $private_member_conditions = $query->andConditionGroup()
+        ->condition("{$community_table}.field_access_mode", 'community-only')
+        ->condition("{$membership_alias}.uid", $account->id());
+
+      $conditions->condition($private_member_conditions);
+    }
+
+    $query->condition($conditions);
+  }
+}
+
+/**
  * Implements hook_field_widget_single_element_WIDGET_TYPE_form_alter().
  */
 function mukurtu_protocol_field_widget_single_element_entity_browser_entity_reference_form_alter(array &$element, \Drupal\Core\Form\FormStateInterface $form_state, array $context)


### PR DESCRIPTION
Issue #1055

### Description
This PR adds a query alter for altering the `browse_by_community` view and adding access restrictions.

The code is inspired on the existing function `mukurtu_protocol_query_protocol_members_alter()` but instead it will add conditions for showing only public communities or communities in which the active user is a member of.

### How to test

1. Login to Tugobat and create a few public and private communities.
2. Visit the homepage a logged in and anonymous users and validate that it works well.