### PR TITLE
Resolve fatal errors due to deprecated code resulting from D11 update

### DIFF
--- a/modules/mukurtu_migrate/src/Plugin/migrate/source/LegacyTkCommunityLabels.php
+++ b/modules/mukurtu_migrate/src/Plugin/migrate/source/LegacyTkCommunityLabels.php
@@ -151,7 +151,7 @@ class LegacyTkCommunityLabels extends SqlBase {
   /**
    * {@inheritdoc}
    */
-  public function count($refresh = FALSE)
+  public function count($refresh = FALSE): int
   {
     $count = $this->doCount();
     return $count;
@@ -160,7 +160,7 @@ class LegacyTkCommunityLabels extends SqlBase {
   /**
    * {@inheritdoc}
    */
-  public function next()
+  public function next(): void
   {
     SourcePluginBase::next();
   }

--- a/modules/mukurtu_migrate/src/Plugin/migrate/source/LegacyTkCommunityProjects.php
+++ b/modules/mukurtu_migrate/src/Plugin/migrate/source/LegacyTkCommunityProjects.php
@@ -87,7 +87,7 @@ class LegacyTkCommunityProjects extends SqlBase
   /**
    * {@inheritdoc}
    */
-  public function count($refresh = FALSE)
+  public function count($refresh = FALSE): int
   {
     $count = $this->doCount();
     return $count;
@@ -113,7 +113,7 @@ class LegacyTkCommunityProjects extends SqlBase
   /**
    * {@inheritdoc}
    */
-  public function next()
+  public function next(): void
   {
     SourcePluginBase::next();
   }

--- a/modules/mukurtu_migrate/src/Plugin/migrate/source/LegacyTkCommunityProjectsGroupSupported.php
+++ b/modules/mukurtu_migrate/src/Plugin/migrate/source/LegacyTkCommunityProjectsGroupSupported.php
@@ -98,7 +98,7 @@ class LegacyTkCommunityProjectsGroupSupported extends SqlBase
   /**
    * {@inheritdoc}
    */
-  public function count($refresh = FALSE)
+  public function count($refresh = FALSE): int
   {
     $count = $this->doCount();
     return $count;
@@ -107,7 +107,7 @@ class LegacyTkCommunityProjectsGroupSupported extends SqlBase
   /**
    * {@inheritdoc}
    */
-  public function next()
+  public function next(): void
   {
     SourcePluginBase::next();
   }

--- a/modules/mukurtu_migrate/src/Plugin/migrate/source/LegacyTkSitewideLabels.php
+++ b/modules/mukurtu_migrate/src/Plugin/migrate/source/LegacyTkSitewideLabels.php
@@ -133,7 +133,7 @@ class LegacyTkSitewideLabels extends SqlBase
   /**
    * {@inheritdoc}
    */
-  public function count($refresh = FALSE)
+  public function count($refresh = FALSE): int
   {
     $count = $this->doCount();
     return $count;
@@ -142,7 +142,7 @@ class LegacyTkSitewideLabels extends SqlBase
   /**
    * {@inheritdoc}
    */
-  public function next()
+  public function next(): void
   {
     SourcePluginBase::next();
   }


### PR DESCRIPTION
The custom migrate source plugins for TK labels needed to be updated post-D11.