### PR TITLE
1152: Cannot create CR on site-initial DH item

### DIFF
--- a/mukurtu.install
+++ b/mukurtu.install
@@ -14,6 +14,8 @@ use Drupal\node\Entity\Node;
 use Drupal\layout_builder\Section;
 use Drupal\layout_builder\SectionComponent;
 use Drupal\Component\Uuid\Php;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\field\Entity\FieldConfig;
 
 /**
  * Implements hook_install().
@@ -443,6 +445,21 @@ function mukurtu_install() {
       $flag->delete();
     }
   }
+
+  // Create the community records field on digital heritage by default.
+  FieldConfig::create([
+    'entity_type' => 'node',
+    'bundle' => 'digital_heritage',
+    'field_name' => 'field_mukurtu_original_record',
+    'label' => 'Original Record',
+    'settings' => [
+      'handler' => 'default:node',
+      'handler_settings' => [
+        'target_bundles' => ['digital_heritage'],
+        'auto_create' => FALSE,
+      ],
+    ],
+  ])->save();
 
   // Configure user roles. These are not managed by Mukurtu because any change
   // in permissions would cause an override. Instead these are provided as


### PR DESCRIPTION
Addresses https://github.com/MukurtuCMS/Mukurtu-CMS/issues/1152

The problem was that the community record field was only being loaded and attached to digital heritage upon saving the Community Records Content Types settings form. However, since digital heritage is enabled by default, no user would think to save the form again. To solve this, I created the community record field and attached it to digital heritage on site install. 