### PR TITLE
Community and protocol images

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Access control in Mukurtu depends on the Drupal private file system. You must co
 * Open `web/sites/default/settings.php` and modify the `$settings['file_private_path']` line, such as the following:
 ```php
 // Specify a private files path.
-$settings['file_private_path'] = '../private_files';
+$settings['file_private_path'] = '../../private_files';
 ```
 * Clear your site cache by visiting `admin/config/development/performance` within your Mukurtu site and clicking "Clear all caches".
 * Confirm the private files directory is found by visiting `admin/config/media/file-system` within your Mukurtu site.

--- a/modules/mukurtu_protocol/src/Entity/Community.php
+++ b/modules/mukurtu_protocol/src/Entity/Community.php
@@ -772,7 +772,7 @@ class Community extends EditorialContentEntityBase implements CommunityInterface
         'target_bundles' => ['image' => 'image'],
       ])
       ->setRequired(FALSE)
-      ->setCardinality(-1)
+      ->setCardinality(1)
       ->setTranslatable(FALSE)
       ->setDisplayOptions('view', [
         'label' => 'visible',
@@ -792,7 +792,7 @@ class Community extends EditorialContentEntityBase implements CommunityInterface
         'target_bundles' => ['image' => 'image'],
       ])
       ->setRequired(FALSE)
-      ->setCardinality(-1)
+      ->setCardinality(1)
       ->setTranslatable(FALSE)
       ->setDisplayOptions('view', [
         'label' => 'visible',

--- a/modules/mukurtu_protocol/src/Entity/Protocol.php
+++ b/modules/mukurtu_protocol/src/Entity/Protocol.php
@@ -636,7 +636,7 @@ class Protocol extends EditorialContentEntityBase implements ProtocolInterface {
         'target_bundles' => ['image' => 'image'],
       ])
       ->setRequired(FALSE)
-      ->setCardinality(-1)
+      ->setCardinality(1)
       ->setTranslatable(FALSE)
       ->setDisplayOptions('view', [
         'label' => 'visible',
@@ -681,7 +681,7 @@ class Protocol extends EditorialContentEntityBase implements ProtocolInterface {
         'target_bundles' => ['image' => 'image'],
       ])
       ->setRequired(FALSE)
-      ->setCardinality(-1)
+      ->setCardinality(1)
       ->setTranslatable(FALSE)
       ->setDisplayOptions('view', [
         'label' => 'visible',


### PR DESCRIPTION
Cardinality of protocol and community banners and thumbnails was -1. Changing that to 1 so that each can only have a single image selected.

Fixes #1156 