### PR TITLE
1161: Community record permissions issue

### DIFF
--- a/modules/mukurtu_community_records/src/CommunityRecordNodeViewBuilder.php
+++ b/modules/mukurtu_community_records/src/CommunityRecordNodeViewBuilder.php
@@ -189,6 +189,7 @@ class CommunityRecordNodeViewBuilder extends NodeViewBuilder {
     $original_record = $node->get('field_mukurtu_original_record')->referencedEntities()[0] ?? $node;
 
     // Check if the user can actually see the original record.
+    $allRecords = [];
     if ($original_record->access('view')) {
       $allRecords = [$original_record->id() => $original_record];
     }


### PR DESCRIPTION
Fixes https://github.com/MukurtuCMS/Mukurtu-CMS/issues/1161.

It wasn't a permissions issue, but a syntax issue. In the file `CommunityRecordNodeViewBuilder.php` at `modules/mukurtu_community_records/src`, the `getCommunityRecords()` method was trying to merge two arrays with this line: 
`$allRecords = $allRecords + $records;`
However, in this case, `$allRecords` was `NULL` . The `+` operator only works with `arrays` and `NULL` is not considered an array. I noticed upstream that `$allRecords` was not being initalized. When I added `$allRecords = [];` to the top of the function, the error went away.