### PR TITLE
1123: Custom Gin theme overrides

### DIFF
--- a/modules/mukurtu_gin_custom/css/mukurtu-gin-custom.css
+++ b/modules/mukurtu_gin_custom/css/mukurtu-gin-custom.css
@@ -1,0 +1,13 @@
+/* todo: when Claro is officially replaced by Gin (see https://www.drupal.org/about/core/blog/drupal-core-will-adopt-gin-admin-theme-to-replace-claro),
+remove the .claro-details__description class and replace it with its Gin
+counterpart, if one exists. */
+.form-item__description, .fieldset__description, .claro-details__description {
+  /* For form description text, force the line length to fill the width of its
+  container. */
+
+  /* I would rather not use !important here, but just setting max-width: 100%
+  wasn't getting the changes to show up. I know it's possible to override the
+  Gin variable --gin-max-line-length, however, I don't want to override that
+  for the entire site, I just need it for forms. So !important it is. */
+  max-width: 100% !important;
+}

--- a/modules/mukurtu_gin_custom/mukurtu_gin_custom.info.yml
+++ b/modules/mukurtu_gin_custom/mukurtu_gin_custom.info.yml
@@ -1,0 +1,8 @@
+name: 'Mukurtu Gin Custom'
+type: module
+description: 'Provides custom Mukurtu overrides to the Gin theme.'
+core_version_requirement: '^10 || ^11'
+package: 'Mukurtu CMS'
+version: 4.x-dev
+libraries:
+  - mukurtu_gin_custom/mukurtu-gin-custom

--- a/modules/mukurtu_gin_custom/mukurtu_gin_custom.libraries.yml
+++ b/modules/mukurtu_gin_custom/mukurtu_gin_custom.libraries.yml
@@ -1,0 +1,5 @@
+mukurtu-gin-custom:
+  version: 1.x
+  css:
+    base:
+      css/mukurtu-gin-custom.css: {}

--- a/modules/mukurtu_gin_custom/mukurtu_gin_custom.module
+++ b/modules/mukurtu_gin_custom/mukurtu_gin_custom.module
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * @file
+ * Provide Mukurtu Gin Custom.
+ */
+
+/**
+ * Implements hook_page_attachments()
+ */
+function mukurtu_gin_custom_page_attachments(array &$attachments) {
+  $attachments['#attached']['library'][] = 'mukurtu_gin_custom/mukurtu-gin-custom';
+}

--- a/mukurtu.info.yml
+++ b/mukurtu.info.yml
@@ -105,6 +105,7 @@ dependencies:
   - 'mukurtu_digital_heritage:mukurtu_digital_heritage'
   - 'mukurtu_export:mukurtu_export'
   - 'mukurtu_footer:mukurtu_footer'
+  - 'mukurtu_gin_custom:mukurtu_gin_custom'
   - 'mukurtu_import:mukurtu_import'
   - 'mukurtu_landing_page:mukurtu_landing_page'
   - 'mukurtu_local_contexts:mukurtu_local_contexts'


### PR DESCRIPTION
Addresses https://github.com/MukurtuCMS/Mukurtu-CMS/issues/1123.

This PR creates a module to contain the Mukurtu overrides to the Gin theme and adds one override to force the description text inside of forms to take up the full width of their container. 