### PR TITLE
176: Improve error handling and media lookup with the media_embed process plugin

### DIFF
--- a/modules/mukurtu_migrate/src/Plugin/migrate/process/MediaEmbed.php
+++ b/modules/mukurtu_migrate/src/Plugin/migrate/process/MediaEmbed.php
@@ -110,7 +110,7 @@ class MediaEmbed extends MigrationLookup {
     }
 
     // Note that the HTML parser underlying DOMDocument is very liberal and will
-    // accept a wide range of strings that are not valid HTML. We somtimes get
+    // accept a wide range of strings that are not valid HTML. We sometimes get
     // JSON data as $value here. There is no harm here, as it will load, but
     // fail the xpath query.
     $doc = new DOMDocument();


### PR DESCRIPTION
Resolves issues related to #176.

The main issue found with the scald atom embed migration was that it had potential to load the wrong media when there was overlap in ids. We need to be specific about the `sid` and `type` to ensure we are loading the correct asset. You can have situations in the source data where the `sid` of `1` is shared between two different types, image and audio, so you would end up always getting the image b/c that is the migration looked at first.

We also had a bug where the return from `mediaLookup` (eg. `return intval($mediaIdArray);`), always returned `1`, b/c any non-empty array run through `intval` returns `1`.

## Steps to Test

This assumes the test database provided by @michael-wynne-wsu 

- [ ] `ddev drush si mukurtu --site-name=Mukurtu --yes`
- [ ] Login and delete any existing content
- [ ] Go to `/admin/migrate`
- [ ] Run the migration
- [ ] Verify that any content that had a scald atom embedded has been migrated correctly. Pay careful attention to the specific media in the formatted text field to make sure it matches the media embedded in v3.
- [ ] Note that in my experience, with the test database and files given, there was a file missing on the file system for `/sites/default/files/private/atoms/file/Interior Salish KBGuide.pdf`. Once I placed a dummy file in this spot in the v3 files, migration was totally successful.

Pages in the v3 test database where there are media embeds:

`/basic-page/about`
`/digital-heritage/field-complete-basic-dh-item`

Note: The latter page has a Vimeo embed in the "Traditional Knowledge" field. That corresponds to the video "Considering Cats", which is migrated into a media record, and is referenced properly in the media embed migration, but it seems to have an empty value for the Video URL field, which would signal some issue with the `mukurtu_cms_v3_media_video`, which is out of scope for this issue.

<img width="1992" height="2936" alt="image" src="https://github.com/user-attachments/assets/116e4e0d-65fa-44f1-ab0a-2002331ec40e" />
