### PR TITLE
899: Add a primary key for the mukurtu_protocol_access table

### DIFF
--- a/modules/mukurtu_protocol/mukurtu_protocol.install
+++ b/modules/mukurtu_protocol/mukurtu_protocol.install
@@ -90,6 +90,7 @@ function mukurtu_protocol_schema() {
         'unsigned' => TRUE,
       ],
     ],
+    'primary key' => ['id', 'entity_type_id', 'protocol_set_id', 'langcode'],
   ];
 
   return $schema;


### PR DESCRIPTION
Resolves #899

Adds a primary key to the `mukurtu_protocol_access` table in `hook_schema`. Models the key after the key used in the `node_access` table.