### PR TITLE
1180: Translate media content warnings

### DIFF
--- a/modules/mukurtu_content_warnings/config/install/mukurtu_content_warnings.settings.yml
+++ b/modules/mukurtu_content_warnings/config/install/mukurtu_content_warnings.settings.yml
@@ -1,0 +1,5 @@
+people_warnings:
+  enabled: false
+  warning_single: 'Warning: [name] is deceased. Click through to access content.'
+  warning_multiple: 'Warning: The following people are deceased. Click through to access content. [names]'
+taxonomy_warnings: {}

--- a/modules/mukurtu_content_warnings/config/schema/mukurtu_content_warnings.schema.yml
+++ b/modules/mukurtu_content_warnings/config/schema/mukurtu_content_warnings.schema.yml
@@ -1,0 +1,33 @@
+mukurtu_content_warnings.settings:
+  type: config_object
+  label: 'Mukurtu Content Warnings settings'
+  mapping:
+    people_warnings:
+      type: mapping
+      label: 'People Warnings'
+      mapping:
+        enabled:
+          type: boolean
+          label: 'Enable People Warnings'
+        warning_single:
+          type: label
+          label: 'Warning Text: Single Person'
+        warning_multiple:
+          type: label
+          label: 'Warning Text: Multiple People'
+    taxonomy_warnings:
+      type: sequence
+      label: 'Taxonomy Triggered Warnings'
+      sequence:
+        type: mukurtu_content_warnings.taxonomy_warning
+
+mukurtu_content_warnings.taxonomy_warning:
+  type: mapping
+  label: 'Taxonomy Triggered Warning'
+  mapping:
+    term:
+      type: integer
+      label: 'Term'
+    warning:
+      type: label
+      label: 'Warning Text'

--- a/modules/mukurtu_content_warnings/mukurtu_content_warnings.config_translation.yml
+++ b/modules/mukurtu_content_warnings/mukurtu_content_warnings.config_translation.yml
@@ -1,0 +1,5 @@
+mukurtu_content_warnings.settings:
+  title: 'Mukurtu Content Warnings Settings'
+  base_route_name: mukurtu_content_warnings.settings
+  names:
+    - mukurtu_content_warnings.settings

--- a/modules/mukurtu_content_warnings/mukurtu_content_warnings.links.task.yml
+++ b/modules/mukurtu_content_warnings/mukurtu_content_warnings.links.task.yml
@@ -1,5 +1,4 @@
-# mukurtu_content_warnings.manage_content_warnings:
-#   title: Content Warnings
-#   route_name: mukurtu_content_warnings.manage_community_content_warnings
-#   base_route: entity.node.canonical
-#   weight: 30
+mukurtu_content_warnings.mukurtu_content_warnings_settings_tab:
+  route_name: mukurtu_content_warnings.settings
+  title: Settings
+  base_route: mukurtu_content_warnings.settings

--- a/modules/mukurtu_content_warnings/src/Form/MukurtuContentWarningsSettingsForm.php
+++ b/modules/mukurtu_content_warnings/src/Form/MukurtuContentWarningsSettingsForm.php
@@ -72,7 +72,7 @@ class MukurtuContentWarningsSettingsForm extends ConfigFormBase {
       '#description' => $this->t('This is a site-wide setting.'),
       '#type' => 'checkbox',
       '#return_value' => TRUE,
-      '#default_value' => $config->get('people_warnings.enabled') ?? 0,
+      '#default_value' => $config->get('people_warnings.enabled') ?? FALSE,
     ];
 
     $form['people_warnings']['single_person_text'] = [

--- a/modules/mukurtu_content_warnings/src/Form/MukurtuContentWarningsSettingsForm.php
+++ b/modules/mukurtu_content_warnings/src/Form/MukurtuContentWarningsSettingsForm.php
@@ -8,8 +8,8 @@ use Drupal\Core\Form\FormStateInterface;
 /**
  * Configure Mukurtu content warnings settings for this site.
  */
-class MukurtuContentWarningsSettingsForm extends ConfigFormBase
-{
+class MukurtuContentWarningsSettingsForm extends ConfigFormBase {
+
   /**
    * Config settings.
    *
@@ -64,34 +64,35 @@ class MukurtuContentWarningsSettingsForm extends ConfigFormBase
 
     $form['people_warnings']['info'] = [
       '#type' => 'item',
-      '#title' => 'Configure warnings for media pertaining to a person who is deceased.'
+      '#title' => $this->t('Configure warnings for media pertaining to a person who is deceased.'),
     ];
 
     $form['people_warnings']['toggle'] = [
-      '#title' => 'Enable People Warnings',
+      '#title' => $this->t('Enable People Warnings'),
       '#description' => $this->t('This is a site-wide setting.'),
-      '#type'          => 'checkbox',
+      '#type' => 'checkbox',
       '#return_value' => TRUE,
       '#default_value' => $config->get('people_warnings.enabled') ?? 0,
     ];
 
     $form['people_warnings']['single_person_text'] = [
-      '#title' => 'Warning Text: Single Person',
+      '#title' => $this->t('Warning Text: Single Person'),
       '#description' => $this->t('The text that will be displayed on the media overlay for a single deceased person. Use the replacement token "[name]" to insert the person\'s name in the message.'),
-      '#type'          => 'textfield',
-      '#default_value' => $config->get('people_warnings.warning_single') ?? "Warning: [name] is deceased. Click through to access content.",
+      '#type' => 'textfield',
+      '#default_value' => $config->get('people_warnings.warning_single') ?? $this->t('Warning: [name] is deceased. Click through to access content.'),
     ];
 
     $form['people_warnings']['multiple_people_text'] = [
-      '#title' => 'Warning Text: Multiple People',
+      '#title' => $this->t('Warning Text: Multiple People'),
       '#description' => $this->t('The text that will be displayed on the media overlay for multiple deceased people. Use the replacement token "[names]" to insert the names in the message.'),
-      '#type'          => 'textfield',
+      '#type' => 'textfield',
       '#default_value' => $config->get('people_warnings.warning_multiple') ?? $this->t('Warning: The following people are deceased. Click through to access content. [names]'),
     ];
 
     $form['#tree'] = TRUE;
 
-    # todo: The description part is not placed well, but I need to move on for now.
+    // @todo The description part is not placed well, but I need to move on
+    //   for now.
     $form['taxonomy_warnings'] = [
       '#type' => 'fieldset',
       '#title' => $this->t('Taxonomy Triggered Warnings'),
@@ -123,8 +124,8 @@ class MukurtuContentWarningsSettingsForm extends ConfigFormBase
       $removed_widgets = $form_state->get('removed_widgets');
     }
 
-    // Todo: the num_widgets form state value is not being retained between
-    // form reloads. Not sure if caching is allowed or useful.
+    // @todo The num_widgets form state value is not being retained between
+    //   form reloads. Not sure if caching is allowed or useful.
     $rendered = [];
     for ($i = 0; $i < $num_widgets; $i++) {
       // Check if term was removed.
@@ -133,24 +134,25 @@ class MukurtuContentWarningsSettingsForm extends ConfigFormBase
         continue;
       }
 
-      // We should hopefully not have more taxonomy warnings to render
-      // than we have widgets to render...
+      // We should hopefully not have more taxonomy warnings to render than we
+      // have widgets to render...
       $id = NULL;
       $text = NULL;
-      // If we have taxonomy warnings from config, attempt to render them one at a time.
+      // If we have taxonomy warnings from config, attempt to render them one
+      // at a time.
       if ($taxonomyWarnings && isset($taxonomyWarnings[$i]) && $taxonomyWarnings[$i]) {
         $warning = $taxonomyWarnings[$i];
         if (!in_array($warning['term'], $rendered)) {
           $id = $warning['term'];
           $text = $warning['warning'];
-          // Mark this warning's term as being rendered (is this even necessary?)
-          array_push($rendered, $id);
+          // Mark this warning's term as being rendered (is this even
+          // necessary?).
+          $rendered[] = $id;
         }
       }
 
-      /* Create a new fieldset for each taxonomy term warning
-       * where we can add the term and warning text.
-       */
+      // Create a new fieldset for each taxonomy term warning where we can add
+      // the term and warning text.
       // Fieldset title.
       $form['taxonomy_warnings'][$i] = [
         '#type' => 'fieldset',
@@ -179,7 +181,7 @@ class MukurtuContentWarningsSettingsForm extends ConfigFormBase
         '#name' => $i,
         '#submit' => ['::removeCallback'],
         '#ajax' => [
-          'callback' => '::addmoreCallback',
+          'callback' => '::addMoreCallback',
           'wrapper' => 'taxonomy-warnings-fieldset-wrapper',
         ],
       ];
@@ -194,18 +196,12 @@ class MukurtuContentWarningsSettingsForm extends ConfigFormBase
       '#value' => $this->t('Add taxonomy warning'),
       '#submit' => ['::addOne'],
       '#ajax' => [
-        'callback' => '::addmoreCallback',
+        'callback' => '::addMoreCallback',
         'wrapper' => 'taxonomy-warnings-fieldset-wrapper',
       ],
     ];
 
-    $form['actions']['submit'] = [
-      '#type' => 'submit',
-      '#value' => $this->t('Submit'),
-    ];
-
-    return $form;
-    //return parent::buildForm($form, $form_state);
+    return parent::buildForm($form, $form_state);
   }
 
   /**
@@ -213,10 +209,9 @@ class MukurtuContentWarningsSettingsForm extends ConfigFormBase
    *
    * Selects and returns the fieldset with the names in it.
    */
-  public function addmoreCallback(array &$form, FormStateInterface $form_state) {
+  public function addMoreCallback(array &$form, FormStateInterface $form_state) {
     return $form['taxonomy_warnings'];
   }
-
 
   /**
    * Submit handler for the "add-one-more" button.
@@ -236,11 +231,8 @@ class MukurtuContentWarningsSettingsForm extends ConfigFormBase
    * Removes the corresponding line.
    */
   public function removeCallback(array &$form, FormStateInterface $form_state) {
-    /*
-     * We use the name of the remove button to find
-     * the element we want to remove
-     * Line 72: '#name' => $i,.
-     */
+    // We use the name of the remove button to find the element we want to
+    // remove.
     $trigger = $form_state->getTriggeringElement();
     $indexToRemove = $trigger['#name'];
 
@@ -298,7 +290,6 @@ class MukurtuContentWarningsSettingsForm extends ConfigFormBase
 
     $config->save();
     $form_state->setRebuild();
-
-    //parent::submitForm($form, $form_state);
   }
+
 }

--- a/modules/mukurtu_content_warnings/src/Form/MukurtuContentWarningsSettingsForm.php
+++ b/modules/mukurtu_content_warnings/src/Form/MukurtuContentWarningsSettingsForm.php
@@ -268,7 +268,6 @@ class MukurtuContentWarningsSettingsForm extends ConfigFormBase {
     $config->set('people_warnings.warning_multiple', $values['people_warnings']['multiple_people_text']);
 
     // Taxonomy warnings settings.
-
     $taxonomyWarningsConfig = [];
     foreach ($values['taxonomy_warnings'] as $i => $warning) {
 
@@ -283,7 +282,7 @@ class MukurtuContentWarningsSettingsForm extends ConfigFormBase {
           'term' => $warning['term'],
           'warning' => $warning['text'],
         ];
-        array_push($taxonomyWarningsConfig, $temp);
+        $taxonomyWarningsConfig[] = $temp;
       }
     }
     $config->set('taxonomy_warnings', $taxonomyWarningsConfig);

--- a/themes/mukurtu_v4/mukurtu_v4.theme
+++ b/themes/mukurtu_v4/mukurtu_v4.theme
@@ -99,7 +99,7 @@ function mukurtu_v4_preprocess_field(&$variables)
     ) {
       $variables['media'] = $variables['element'][0]['#media'];
       $media = $variables['media'];
-      $config = \Drupal::service('config.factory')->getEditable('mukurtu_content_warnings.settings');
+      $config = \Drupal::config('mukurtu_content_warnings.settings');
 
       if ($config->get('people_warnings.enabled')) {
         $names = [];


### PR DESCRIPTION
Resolves #1180 

### Description

Makes adjustments to the Media Content Warnings form to allow for it to be translated. Also makes slight adjustments to the front-end where the theme pulls these values for display to make sure that the correct translations, if they exist, are used.

### Testing Instructions

- [ ] Install Mukurtu v4 profile, eg. ` ddev drush si mukurtu --site-name=Mukurtu --yes`
- [ ] Enable `mukurtu_multilingual`, eg. `ddev drush en -y mukurtu_multilingual`
- [ ] Add a language at `/admin/config/regional/language`
- [ ] Add one or more Media tags at `/admin/structure/taxonomy/manage/media_tag/add`
- [ ] Visit `/admin/config/mukurtu/content-warnings`, set "Enable People Warnings", configure warning text (default is fine), and add one or more "Taxonomy Triggered Warnings".
- [ ] Click Save configuration
- [ ] After Save you should see a "Translate mukurtu content warnings settings" local task / tab appear beside "Settings". Click it!
- [ ] Add a translation, change the text values for the various warning types and Save

Next we'll ensure that the translated text is actually being displayed on the site

- [ ] Create a new Community and Protocol
- [ ] Add a Language term
- [ ] Add a People term
- [ ] Add a Person content, make sure to set a Date Died value and mark as "Deceased". Make sure to also select the People term from the last step under "Other Names"
- [ ] Create an Image Media. Make sure to select the People term from the previous step as a value for "People"
- [ ] Create a Dictionary Word. Under Additional Fields > Media Assets, select the Image Media created in the previous step
- [ ] View the Dictionary Word. Note that the front-end display of the warning isn't great, however, we're just concerned with the text itself, search the HTML source for your configured content warning.
- [ ] Translate the Dictionary Word.
- [ ] View the Dictionary Word again in the translated language. Search the HTML source for the translated content warning.