### PR TITLE
1141: Fix the empty state for the grid/list view switcher

### DIFF
--- a/modules/mukurtu_browse/js/mukurtu-browse-view-switch.js
+++ b/modules/mukurtu_browse/js/mukurtu-browse-view-switch.js
@@ -1,54 +1,53 @@
 // JS functionality to toggle active class on map/grid/list buttons
-// and toggle visibility of map/list/grid contents. 
+// and toggle visibility of map/list/grid contents.
 
 ((Drupal, once) => {
   "use strict";
-   let gridLink, listLink, mapLink, mapContent, listContent, gridContent, browseLinks, button;
+
+  const browseModes = ["list", "grid", "map"];
+  const DEFAULT_BROWSE_MODE = "list";
+  let gridLink, listLink, mapLink, mapContent, listContent, gridContent, browseLinks;
+
+  function getBrowseMode() {
+    const browseMode = localStorage.getItem("browseMode");
+    if (browseModes.includes(browseMode)) {
+      return browseMode;
+    }
+    return DEFAULT_BROWSE_MODE;
+  }
+
+  function setBrowseMode(mode) {
+    if (!browseModes.includes(mode)) {
+      mode = DEFAULT_BROWSE_MODE;
+    }
+    localStorage.setItem("browseMode", mode);
+  }
 
   function listCheck() {
-
-    if (localStorage.getItem("browseMode") == "list") {
-      return true;
-    } else {
-      return false;
-    }
+    return getBrowseMode() === "list";
   }
 
   function gridCheck() {
-    if (localStorage.getItem("browseMode") == "grid") {
-      return true;
-    } else {
-      return false;
-    }
+    return getBrowseMode() === "grid";
   }
 
   function mapCheck() {
-    if (localStorage.getItem("browseMode") == "map") {
-      return true;
-    } else {
-      return false;
-    }
+    return getBrowseMode() === "map";
   }
 
-  function toggleBrowseMode(e) {
+  function handleToggleBrowseMode(e) {
+    toggleBrowseMode(e.target.dataset.browseMode);
+  }
 
-    button = e.target.getAttribute('id');
+  function toggleBrowseMode(browseMode) {
+    setBrowseMode(browseMode);
 
-    // First set the cookie. 
-    if (button == "mukurtu-browse-list") {
-      localStorage.setItem("browseMode", "list");
-    } else if (button == "mukurtu-browse-grid") {
-      localStorage.setItem("browseMode", "grid");
-    } else if (button == "mukurtu-browse-map"){
-      localStorage.setItem("browseMode", "map");
-    }
-
-    // Then perform class toggling/content visibility 
-    // toggling based on which cookie set.
+    // Then perform class toggling/content visibility toggling based on which
+    // browse mode was set.
     if (listCheck()) {
       listLink.classList.add("active-toggle");
-      gridLink.classList.remove("active-toggle");
-      mapLink.classList.remove("active-toggle");
+      gridLink?.classList.remove("active-toggle");
+      mapLink?.classList.remove("active-toggle");
 
       listContent.hidden = false;
       mapContent.hidden = true;
@@ -57,8 +56,8 @@
 
     if (gridCheck()) {
       gridLink.classList.add("active-toggle");
-      listLink.classList.remove("active-toggle");
-      mapLink.classList.remove("active-toggle");
+      listLink?.classList.remove("active-toggle");
+      mapLink?.classList.remove("active-toggle");
 
       gridContent.hidden = false;
       mapContent.hidden = true;
@@ -67,8 +66,8 @@
 
     if (mapCheck()) {
       mapLink.classList.add("active-toggle");
-      listLink.classList.remove("active-toggle");
-      gridLink.classList.remove("active-toggle");
+      listLink?.classList.remove("active-toggle");
+      gridLink?.classList.remove("active-toggle");
 
       mapContent.hidden = false;
       listContent.hidden = true;
@@ -76,33 +75,18 @@
     }
   }
 
-
   function init() {
     listContent = document.querySelector(".list");
     mapContent = document.querySelector(".map");
     gridContent = document.querySelector(".grid");
     browseLinks = document.querySelector(".browse-links");
 
-    gridLink = document.getElementById("mukurtu-browse-grid");
-    listLink = document.getElementById("mukurtu-browse-list");
-    mapLink = document.getElementById("mukurtu-browse-map");
+    gridLink = document.querySelector("[data-browse-mode=grid]");
+    listLink = document.querySelector("[data-browse-mode=list]");
+    mapLink = document.querySelector("[data-browse-mode=map]");
 
-    browseLinks.addEventListener("click", toggleBrowseMode);
-
-    let cookie = localStorage.getItem("browseMode");
-
-    // If cookie exists already, read it and 
-    // simulate a click on the corresponding button.
-    if (cookie) {
-      button = `mukurtu-browse-${cookie}`;
-      const event = new MouseEvent("click", {
-        view: window,
-        bubbles: true,
-        cancelable: true,
-      });
-      const cb = document.getElementById(button);
-      cb.dispatchEvent(event);
-    }
+    browseLinks.addEventListener("click", handleToggleBrowseMode);
+    toggleBrowseMode(getBrowseMode());
   }
 
   Drupal.behaviors.mukurtuBrowseSwitch = {
@@ -110,5 +94,5 @@
       once("browseContainer", ".browse-container", context).forEach(init);
     },
   };
-  
+
 })(Drupal, once);

--- a/modules/mukurtu_browse/src/Controller/MukurtuBrowseController.php
+++ b/modules/mukurtu_browse/src/Controller/MukurtuBrowseController.php
@@ -53,7 +53,7 @@ class MukurtuBrowseController extends ControllerBase {
       '#tag' => 'button',
       '#value' => $this->t('Map'),
       '#attributes' => [
-        'id' => 'mukurtu-browse-map',
+        'data-browse-mode' => 'map',
         'aria-label' => $this->t('Switch to Map'),
       ],
     ];

--- a/modules/mukurtu_browse/src/Controller/MukurtuDigitalHeritageBrowseController.php
+++ b/modules/mukurtu_browse/src/Controller/MukurtuDigitalHeritageBrowseController.php
@@ -52,7 +52,7 @@ class MukurtuDigitalHeritageBrowseController extends ControllerBase {
       '#tag' => 'button',
       '#value' => $this->t('Map'),
       '#attributes' => [
-        'id' => 'mukurtu-browse-map',
+        'data-browse-mode' => 'map',
         'aria-label' => $this->t('Switch to Map'),
       ],
     ];

--- a/modules/mukurtu_browse/templates/mukurtu-browse.html.twig
+++ b/modules/mukurtu_browse/templates/mukurtu-browse.html.twig
@@ -1,8 +1,8 @@
 <div class="browse-container">
   <div class="browse-results">
     <div class="browse-links">
-      <button id="mukurtu-browse-grid" aria-label="Switch to grid view">Grid</button>
-      <button id="mukurtu-browse-list" aria-label="Switch to list view" class="active-toggle">List</button>
+      <button data-browse-mode="grid" aria-label="{{ 'Switch to grid view'|t }}">{{ 'Grid'|t }}</button>
+      <button data-browse-mode="list" aria-label="{{ 'Switch to list view'|t }}" class="active-toggle">{{ 'List'|t }}</button>
       {% if maplink %}
         {{ maplink }}
       {% endif %}

--- a/modules/mukurtu_browse/templates/mukurtu-map-browse.html.twig
+++ b/modules/mukurtu_browse/templates/mukurtu-map-browse.html.twig
@@ -1,11 +1,11 @@
 <div class="browse-container">
   <div class="browse-results">
     <div class="browse-links">
-      <a href="/browse" id="mukurtu-browse-grid" aria-label="Switch to grid view">Grid</a>
+      <a href="/browse" data-browse-mode="grid" aria-label="{{ 'Switch to grid view'|t }}">{{ 'Grid'|t }}</a>
       {% if browselink %}
         {{ browselink }}
       {% endif %}
-      <a class="active-toggle" id="mukurtu-browse-map" aria-label="Switch to map view">Map</a>
+      <a class="active-toggle" data-browse-mode="map" aria-label="{{ 'Switch to map view'|t }}">{{ 'Map'|t }}</a>
     </div>
     <div id="mukurtu-map-browse-container">
       <div id="mukurtu-map-browse-map">{{ map }}</div>

--- a/themes/mukurtu_v4/css/leaflet-overrides.css
+++ b/themes/mukurtu_v4/css/leaflet-overrides.css
@@ -53,6 +53,6 @@
 /* Hide the Map on any page it appears if there are no location markers. */
 
 /* NOTE This is better handled in the View, however, clicking "Hide if empty" does not work for unknown reasons, as of this writing. */
-.browse-container:not(:has(.leaflet-marker-icon, .leaflet-interactive)) :is(#mukurtu-browse-map, .leaflet-container) {
+.browse-container:not(:has(.leaflet-marker-icon, .leaflet-interactive)) :is([data-browse-mode=map], .leaflet-container) {
   display: none;
 }


### PR DESCRIPTION
### Description

When viewing Browse Digital Heritage page for the first time, the grid appears broken as follows:

<img width="2736" height="2772" alt="image" src="https://github.com/user-attachments/assets/6d50459f-fc21-4085-a3c2-decc277815c5" />

This fixes this issue such that it defaults to the list mode, and avoids the broken experience on the first view (when local storage is empty).

### Steps to test

- [ ] Create a Public Community
- [ ] Create two Protocols, one Strict, and one Open
- [ ] Create two Media Assets, one belonging to the Strict protocol created, the other belonging to the Open protocol
- [ ] Create a Digital Heritage Item and add both strict and open Media Assets.
- [ ] Visit the Browse Digital Heritage page, eg. `/digital-heritage`. The browse mode should default to List and it should no longer look broken. 
- [ ] Try switching between modes, should work fine. Switch to Grid and reload the page. You should be in grid mode.