### PR TITLE
1221: Change role select form in bulk operations

### DIFF
--- a/modules/mukurtu_protocol/mukurtu_protocol.module
+++ b/modules/mukurtu_protocol/mukurtu_protocol.module
@@ -735,3 +735,17 @@ function add_protocol_member_form_validate(&$form, FormStateInterface $form_stat
     }
   }
 }
+
+/**
+ * Implements hook_form_form_id_alter().
+ *
+ * Change the roles select from multiselect to checkboxes.
+ */
+function mukurtu_protocol_form_og_membership_add_multiple_roles_action_form_alter(&$form, FormStateInterface $form_state) {
+  $rolesElement = $form['roles'];
+
+  $form['roles'] = [
+    '#type' => 'checkboxes',
+    '#options' => $rolesElement['#options']
+  ];
+}


### PR DESCRIPTION
Addresses https://github.com/MukurtuCMS/Mukurtu-CMS/issues/1221

Steps to test:

- [ ] Create a community
- [ ] Go to manage members in that community
- [ ] Select a community member and apply the 'Add roles to selected membership(s)' bulk action
- [ ] Verify that the roles options display as checkboxes instead of multiselect.