### PR TITLE
555: Show related original record, community records, multipage item

### DIFF
--- a/modules/mukurtu_community_records/src/Hook/RelatedContentDisplay.php
+++ b/modules/mukurtu_community_records/src/Hook/RelatedContentDisplay.php
@@ -49,7 +49,7 @@ class RelatedContentDisplay {
         '#type' => 'item',
         '#title' => $this->t('Original Record'),
         '#markup' => sprintf('<a href="%s">%s</a>', $original->toUrl()->toString(), $original->label()),
-        '#access' => $node->access('view'),
+        '#access' => $original->access('view'),
       ];
       $form['#fieldgroups']['group_related_content']->children[] = 'original_record';
       $form['#group_children']['original_record'] = 'group_related_content';

--- a/modules/mukurtu_multipage_items/mukurtu_multipage_items.info.yml
+++ b/modules/mukurtu_multipage_items/mukurtu_multipage_items.info.yml
@@ -4,6 +4,6 @@ description: 'Provides a multipage item entity.'
 core_version_requirement: '^9.4 || ^10 || ^11'
 package: 'Mukurtu CMS'
 dependencies:
-  - mukurtu_protocol
-  - mukurtu_collection
+  - mukurtu_protocol:mukurtu_protocol
+  - mukurtu_collection:mukurtu_collection
 configure: entity.multipage_item.settings

--- a/modules/mukurtu_multipage_items/mukurtu_multipage_items.services.yml
+++ b/modules/mukurtu_multipage_items/mukurtu_multipage_items.services.yml
@@ -6,3 +6,4 @@ services:
   mukurtu_multipage_items.multipage_item_manager:
     class: Drupal\mukurtu_multipage_items\MultipageItemManager
     arguments: ['@entity_type.manager']
+  Drupal\mukurtu_multipage_items\MultipageItemManager: '@mukurtu_multipage_items.multipage_item_manager'

--- a/modules/mukurtu_multipage_items/src/Hook/RelatedContentDisplay.php
+++ b/modules/mukurtu_multipage_items/src/Hook/RelatedContentDisplay.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\mukurtu_multipage_items\Hook;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Hook\Attribute\Hook;
+use Drupal\Core\Hook\Order\OrderAfter;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\mukurtu_multipage_items\MultipageItemManager;
+use Drupal\node\NodeInterface;
+
+/**
+ * Adds related community records / original record content to the node form.
+ */
+class RelatedContentDisplay {
+  use StringTranslationTrait;
+
+  /**
+   * Constructs a new RelatedContentDisplay object.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   *   The entity type manager.
+   * @param \Drupal\mukurtu_multipage_items\MultipageItemManager $multipageItemManager
+   *   The multipage item manager.
+   */
+  public function __construct(protected EntityTypeManagerInterface $entityTypeManager, protected MultipageItemManager $multipageItemManager) {}
+
+  /**
+   * Implements hook_form_FORM_ID_alter().
+   */
+  #[Hook('form_node_form_alter', order: new OrderAfter(['field_group'], [['field_group_form_alter']]))]
+  public function nodeFormAlter(&$form, FormStateInterface $form_state, $form_id): void {
+    $node = $form_state->getFormObject()->getEntity();
+    if (!$node instanceof NodeInterface) {
+      return;
+    }
+    // New nodes are not yet associated with a community record at all.
+    if ($node->isNew()) {
+      return;
+    }
+    // Lets not bother if we don't have a Related Content group.
+    if (!isset($form['#fieldgroups']['group_related_content'])) {
+      return;
+    }
+    if ($mpi = $this->multipageItemManager->getMultipageEntity($node)) {
+      $form['multipage_item'] = [
+        '#type' => 'item',
+        '#title' => $this->t('Multipage Item'),
+        '#markup' => sprintf('<a href="%s">%s</a>', $mpi->toUrl()->toString(), $mpi->label()),
+        '#access' => $mpi->access('view'),
+      ];
+      $form['#fieldgroups']['group_related_content']->children[] = 'multipage_item';
+      $form['#group_children']['multipage_item'] = 'group_related_content';
+    }
+  }
+
+}

--- a/modules/mukurtu_multipage_items/src/MultipageItemManager.php
+++ b/modules/mukurtu_multipage_items/src/MultipageItemManager.php
@@ -1,26 +1,24 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\mukurtu_multipage_items;
 
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\node\NodeInterface;
 
+/**
+ * Multipage item manager for loading an MPI from a node.
+ */
 class MultipageItemManager {
-  /**
-   * The entity type manager.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityTypeManager;
 
   /**
    * Constructs an MultipageItemManager object.
    *
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
    *   The entity type manager.
    */
-  public function __construct(EntityTypeManagerInterface $entity_type_manager) {
-    $this->entityTypeManager = $entity_type_manager;
-  }
+  public function __construct(protected EntityTypeManagerInterface $entityTypeManager) {}
 
   /**
    * Get the multipage_item entity that contains the node as a page.
@@ -31,7 +29,7 @@ class MultipageItemManager {
    * @return \Drupal\mukurtu_multipage_items\MultipageItemInterface|null
    *   The multipage_item entity or NULL if the node is not in a MPI.
    */
-  public function getMultipageEntity($node) {
+  public function getMultipageEntity(NodeInterface $node): ?MultipageItemInterface {
     $query = $this->entityTypeManager->getStorage('multipage_item')->getQuery();
 
     // CRs cannot be pages. Follow the OR relationship if node is a CR.
@@ -48,8 +46,9 @@ class MultipageItemManager {
       ->execute();
 
     if (!empty($result)) {
-      $mpiId = reset($result);
-      return $this->entityTypeManager->getStorage('multipage_item')->load($mpiId);
+      $mpi_id = reset($result);
+      $mpi = $this->entityTypeManager->getStorage('multipage_item')->load($mpi_id);
+      return $mpi instanceof MultipageItemInterface ? $mpi : NULL;
     }
     return NULL;
   }


### PR DESCRIPTION
Resolves #555

### Description

Adds new "Original Record", "Community Records", and "Multipage Item" read-only information to the Related Content tab of Content where relevant.

### Testing instructions

- [ ] Create some content
- [ ] Create some Community Records with said content
- [ ] Create a Multipage item using some of that content
- [ ] Verify that Community Records show a link to the Original Record on the Related Content tab
- [ ] Verify that content which is an original record, shows a list of all community records it has been used for
- [ ] Verity that content added to a multipage item, shows a link to the multipage item on the Related Content tab
- [ ] Only content and multipage items that the editor has access to should be displayed in the above places