### PR TITLE
1333: Basic pages are returning protocol related errors

### DIFF
--- a/modules/mukurtu_protocol/mukurtu_protocol.module
+++ b/modules/mukurtu_protocol/mukurtu_protocol.module
@@ -191,20 +191,25 @@ function mukurtu_protocol_menu_local_tasks_alter(&$data, $route_name, \Drupal\Co
       $editAny = 'edit any ' . $bundleType . ' content';
       $editOwn = 'edit own ' . $bundleType . ' content';
 
-      /** @var \Drupal\mukurtu_protocol\CulturalProtocolControlledInterface $node */
-      $nodeProtocols = $node->getProtocolEntities();
-      $hasEditPermission = FALSE;
-      foreach ($nodeProtocols as $protocol) {
-        $membership = Og::getMembership($protocol, $currentUser);
-        if ($membership) {
-          if ($membership->hasPermission($editAny) || $membership->hasPermission($editOwn)) {
-            $hasEditPermission = TRUE;
-            break;
+      // Do not perform protocol-based permission checks on stock Drupal content
+      // types (article, basic page). Doing so caused an error since these
+      // content types are not protocol-controlled.
+      if ($node instanceof CulturalProtocolControlledInterface) {
+        /** @var \Drupal\mukurtu_protocol\CulturalProtocolControlledInterface $node */
+        $nodeProtocols = $node->getProtocolEntities();
+        $hasEditPermission = FALSE;
+        foreach ($nodeProtocols as $protocol) {
+          $membership = Og::getMembership($protocol, $currentUser);
+          if ($membership) {
+            if ($membership->hasPermission($editAny) || $membership->hasPermission($editOwn)) {
+              $hasEditPermission = TRUE;
+              break;
+            }
           }
         }
-      }
-      if ($hasEditPermission) {
-        $data['tabs'][0]['entity.node.version_history'] = $revisionsTab;
+        if ($hasEditPermission) {
+          $data['tabs'][0]['entity.node.version_history'] = $revisionsTab;
+        }
       }
     }
   }


### PR DESCRIPTION
Fixes https://github.com/MukurtuCMS/Mukurtu-CMS/issues/1333

The problem was in `mukurtu_protocol_menu_local_tasks_alter()` of `mukurtu_protocol.module`. The node coming in was always assumed to be protocol-controlled and thus assumed to be compatible with protocol methods defined in `CulturalProtocolControlledInterface.php`. However, since articles and basic pages are not currently protocol-controlled, calling `CulturalProtocolControlledInterface` methods on them results in an error. The fix was to check if the node coming in actually implements `CulturalProtocolControlledInterface` before calling its methods on the node.

Steps to test:

- [ ] Create an article
- [ ] Navigate to that article's full view as an anonymous user
- [ ] Verify that no errors show up
- [ ] Repeat for basic page