### PR TITLE
1361: Be consistent with actions across all import forms

### DIFF
--- a/modules/mukurtu_import/src/Form/ExecuteImportForm.php
+++ b/modules/mukurtu_import/src/Form/ExecuteImportForm.php
@@ -131,30 +131,38 @@ class ExecuteImportForm extends ImportBaseForm {
 
     }
 
-    $form['import'] = [
-      '#type' => 'submit',
-      '#value' => $this->t('Start Import'),
-      '#button_type' => 'primary',
-      '#submit' => ['::startImport'],
-    ];
     $form['actions'] = [
       '#type' => 'actions',
+    ];
+    $form['actions']['submit'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Start Import'),
     ];
     $form['actions']['back'] = [
       '#type' => 'submit',
       '#value' => $this->t('Back'),
-      '#button_type' => 'primary',
       '#submit' => ['::submitBack'],
     ];
 
     return $form;
   }
 
+  /**
+   * Submit callback for the Back button.
+   *
+   * @param array $form
+   *    An associative array containing the structure of the form.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *    The current state of the form.
+   */
   public function submitBack(array &$form, FormStateInterface $form_state): void {
     $form_state->setRedirect('mukurtu_import.import_files');
   }
 
-  public function startImport(array &$form, FormStateInterface $form_state): void {
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state): void {
     // $metadata_files sorted by weight in this case.
     $metadata_files = array_keys($this->getMetadataFileWeights());
     $migration_definitions = [];

--- a/modules/mukurtu_import/src/Form/ImportResultsForm.php
+++ b/modules/mukurtu_import/src/Form/ImportResultsForm.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\mukurtu_import\Form;
 
-use Drupal\mukurtu_import\Form\ImportBaseForm;
 use Drupal\Core\Form\FormStateInterface;
 
 /**
@@ -13,14 +14,14 @@ class ImportResultsForm extends ImportBaseForm {
   /**
    * {@inheritdoc}
    */
-  public function getFormId() {
+  public function getFormId(): string {
     return 'mukurtu_import_results';
   }
 
   /**
    * {@inheritdoc}
    */
-  public function buildForm(array $form, FormStateInterface $form_state) {
+  public function buildForm(array $form, FormStateInterface $form_state): array {
     $success = $this->store->get('batch_results_success') ?? FALSE;
     $messages = $this->getMessages();
 
@@ -40,15 +41,20 @@ class ImportResultsForm extends ImportBaseForm {
       }
     }
 
-    $this->buildTable($form, $form_state, 'node');
+    $this->buildTable($form, $form_state);
+
+    $form['actions'] = [
+      '#type' => 'actions',
+    ];
 
     if (!empty($messages) || !$success) {
-      $form['actions']['back'] = [
+      $form['actions']['submit'] = [
         '#type' => 'submit',
         '#value' => $this->t('Return to Uploaded Files'),
         '#submit' => ['::submitReturnToFiles'],
       ];
-    } else {
+    }
+    else {
       $form['actions']['submit'] = [
         '#type' => 'submit',
         '#value' => $this->t('Start a new import'),
@@ -61,16 +67,32 @@ class ImportResultsForm extends ImportBaseForm {
   /**
    * {@inheritdoc}
    */
-  public function submitForm(array &$form, FormStateInterface $form_state) {
+  public function submitForm(array &$form, FormStateInterface $form_state): void {
     $this->reset();
     $form_state->setRedirect('mukurtu_import.file_upload');
   }
 
-  public function submitReturnToFiles(array &$form, FormStateInterface $form_state) {
+  /**
+   * Submit handler for the 'Return to Uploaded Files' button.
+   *
+   * @param array $form
+   *    An associative array containing the structure of the form.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *    The current state of the form.
+   */
+  public function submitReturnToFiles(array &$form, FormStateInterface $form_state): void {
     $form_state->setRedirect('mukurtu_import.file_upload');
   }
 
-  protected function buildTable(array &$form, FormStateInterface $form_state, $entity_type_id) {
+  /**
+   * Builds the results table.
+   *
+   * @param array $form
+   *   An associative array containing the structure of the form.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The current state of the form.
+   */
+  protected function buildTable(array &$form, FormStateInterface $form_state): void {
     $message = $this->getImportRevisionMessage();
 
     $communities_block = [


### PR DESCRIPTION
Resolves #1361

### Description

This adjustment makes us consistent with button placement across all of the import forms. We always ensure use of `'#type' => 'actions'` and the presence of a `submit` form element, which allows the admin theme to always have the primary action up top, with a more menu for other secondary actions.

### Testing Instructions

- [ ] Browser through the import process
- [ ] Verify that there is always a primary action button at the top, beside the title
- [ ] Verify secondary actions are always in the more actions (three dot) menu
- [ ] Verify there are no longer any buttons that follow the form
- [ ] Click through an import, including customizing the template, and downloading a CSV template to ensure no regressions