### PR TITLE
1394: Don't set default value on reference fields for collection, tighten up ValidCollectionItemValidator

### DIFF
--- a/modules/mukurtu_collection/src/Entity/Collection.php
+++ b/modules/mukurtu_collection/src/Entity/Collection.php
@@ -42,7 +42,6 @@ class Collection extends Node implements CollectionInterface, CulturalProtocolCo
           'auto_create_bundle' => '',
         ]
       ])
-      ->setDefaultValue('')
       ->setCardinality(-1)
       ->setRequired(FALSE)
       ->setRevisionable(TRUE)
@@ -81,7 +80,6 @@ class Collection extends Node implements CollectionInterface, CulturalProtocolCo
           'auto_create_bundle' => '',
         ]
       ])
-      ->setDefaultValue('')
       ->setCardinality(1)
       ->setRequired(FALSE)
       ->setRevisionable(TRUE)
@@ -129,7 +127,6 @@ class Collection extends Node implements CollectionInterface, CulturalProtocolCo
           'auto_create_bundle' => 'collection',
         ]
       ])
-      ->setDefaultValue('')
       ->setCardinality(-1)
       ->setRequired(FALSE)
       ->setRevisionable(TRUE)
@@ -155,7 +152,6 @@ class Collection extends Node implements CollectionInterface, CulturalProtocolCo
           'auto_create_bundle' => '',
         ]
       ])
-      ->setDefaultValue('')
       ->setCardinality(-1)
       ->setRequired(FALSE)
       ->setRevisionable(TRUE)
@@ -178,7 +174,6 @@ class Collection extends Node implements CollectionInterface, CulturalProtocolCo
           'auto_create_bundle' => 'article',
         ]
       ])
-      ->setDefaultValue('')
       ->setCardinality(-1)
       ->setRequired(FALSE)
       ->setRevisionable(TRUE)

--- a/modules/mukurtu_collection/src/Plugin/Validation/Constraint/ValidCollectionItemValidator.php
+++ b/modules/mukurtu_collection/src/Plugin/Validation/Constraint/ValidCollectionItemValidator.php
@@ -1,36 +1,70 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\mukurtu_collection\Plugin\Validation\Constraint;
 
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\node\NodeInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 
 /**
  * Validates the ValidCollectionItem constraint.
  */
-class ValidCollectionItemValidator extends ConstraintValidator {
+class ValidCollectionItemValidator extends ConstraintValidator implements ContainerInjectionInterface {
+
+  /**
+   * Constructs a ValidCollectionItemValidator object.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   *   The entity type manager.
+   */
+  public function __construct(protected EntityTypeManagerInterface $entityTypeManager) {
+  }
 
   /**
    * {@inheritdoc}
    */
-  public function validate($items, Constraint $constraint) {
+  public static function create(ContainerInterface $container): static {
+    return new static(
+      $container->get('entity_type.manager')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validate($value, Constraint $constraint): void {
+    assert($constraint instanceof ValidCollectionItem);
     // Get the owning entity and its ID.
-    $entity = $items->getEntity();
+    $entity = $value->getEntity();
 
     $refs = [];
-    foreach ($items as $item) {
+    foreach ($value as $item) {
+      $target_id = $item->target_id;
+      // Don't bother with empty value.
+      if (empty($target_id)) {
+        continue;
+      }
+
       // No circular references allowed.
-      if ($item->target_id == $entity->id()) {
+      if ($target_id === $entity->id()) {
         $this->context->addViolation($constraint->invalidCollectionItemSelfReference);
       }
 
       // Check for duplicates.
-      if (in_array($item->target_id, $refs)) {
-        $entity = \Drupal::entityTypeManager()->getStorage('node')->load($item->target_id);
-        $title = $entity->getTitle() ?? '';
+      if (in_array($target_id, $refs)) {
+        $entity = $this->entityTypeManager->getStorage('node')->load($target_id);
+        $title = '';
+        if ($entity instanceof NodeInterface) {
+          $title = $entity->getTitle() ?? '';
+        }
         $this->context->addViolation($constraint->invalidCollectionItemDuplicate, ['@item' => $title]);
       }
-      $refs[] = $item->target_id;
+      $refs[] = $target_id;
     }
   }
 


### PR DESCRIPTION
Resolves #1394 

## Description

Fixes validation constraint errors with importing collections. For most of the errors, what was happening was at a base field level, we had configured reference fields to have a default value of empty string, which doesn't make any sense. In one other case of a constraint checking for duplicate referenced in collections, we were improperly handling that empty reference. All tidied up now.

## Testing instructions

- [ ] Navigate to `/admin/import`
- [ ] Upload a basic, required fields only collection
- [ ] Run through the import, should finish successfully