### PR TITLE
Updating fast-xml-parser to 4.5.4

### DIFF
--- a/themes/mukurtu_v4/package-lock.json
+++ b/themes/mukurtu_v4/package-lock.json
@@ -4361,20 +4361,17 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.3.2.tgz",
-      "integrity": "sha512-rmrXUXwbJedoXkStenj1kkljNF7ugn5ZjR9FJcwmCfcCbtOMDghPajbc+Tck6vE6F5XsDmx+Pr2le9fw8+pXBg==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.4.tgz",
+      "integrity": "sha512-jE8ugADnYOBsu1uaoayVl1tVKAMNOXyjwvv2U6udEA2ORBhDooJDWoGxTkhd4Qn4yh59JVVt/pKXtjPwx9OguQ==",
       "dev": true,
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/naturalintelligence"
         }
       ],
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "strnum": "^1.0.5"


### PR DESCRIPTION
Closes #1396 

This PR updates `fast-xml-parser` to `4.5.4` in order to fix dependabot alters.

Validate that the new version is `4.5.4` by checking out the branch and running `npm install` at `/web/profiles/mukurtu/themes/mukurtu_v4`