### PR TITLE
1427: Make Local Contexts import delimiter configurable, default to >

### DIFF
--- a/modules/mukurtu_import/src/Entity/MukurtuImportStrategy.php
+++ b/modules/mukurtu_import/src/Entity/MukurtuImportStrategy.php
@@ -284,6 +284,7 @@ class MukurtuImportStrategy extends ConfigEntityBase implements MukurtuImportStr
       $context['multivalue_delimiter'] = $this->getConfig('multivalue_delimiter') ?? ';';
       $context['upload_location'] = $this->getConfig('upload_location') ?? NULL;
       $context['default_format'] = $this->getConfig('default_format') ?? self::DEFAULT_FORMAT;
+      $context['local_contexts_delimiter'] = $this->getConfig('local_contexts_delimiter') ?? '>';
       if ($subtarget) {
         $context['subfield'] = $subtarget;
       }

--- a/modules/mukurtu_import/src/Form/CustomStrategyFromFileForm.php
+++ b/modules/mukurtu_import/src/Form/CustomStrategyFromFileForm.php
@@ -136,6 +136,13 @@ class CustomStrategyFromFileForm extends ImportBaseForm {
       '#title' => $this->t('Multi-value Delimiter'),
       '#default_value' => $this->importConfig->getConfig('multivalue_delimiter') ?? ';',
     ];
+    $form['file_settings']['local_contexts_delimiter'] = [
+      '#type' => 'textfield',
+      '#size' => 5,
+      '#title' => $this->t('Local Contexts Delimiter'),
+      '#description' => $this->t('Delimiter used to separate the project name from the label/notice name in Local Contexts fields (e.g., "My Project > TK Attribution").'),
+      '#default_value' => $this->importConfig->getConfig('local_contexts_delimiter') ?? '>',
+    ];
     $form['file_settings']['default_format'] = [
       '#type' => 'select',
       '#required' => TRUE,
@@ -493,6 +500,7 @@ class CustomStrategyFromFileForm extends ImportBaseForm {
     $this->importConfig->setConfig('enclosure', $form_state->getValue('enclosure'));
     $this->importConfig->setConfig('escape', $form_state->getValue('escape'));
     $this->importConfig->setConfig('multivalue_delimiter', $form_state->getValue('multivalue_delimiter'));
+    $this->importConfig->setConfig('local_contexts_delimiter', $form_state->getValue('local_contexts_delimiter'));
     $this->importConfig->setConfig('default_format', $form_state->getValue('default_format'));
     $this->importConfig->setConfig('identifier_column', $form_state->getValue('identifier_column') ?: NULL);
 

--- a/modules/mukurtu_import/src/Plugin/MukurtuImportFieldProcess/LocalContextsLabelAndNotice.php
+++ b/modules/mukurtu_import/src/Plugin/MukurtuImportFieldProcess/LocalContextsLabelAndNotice.php
@@ -39,8 +39,10 @@ class LocalContextsLabelAndNotice extends MukurtuImportFieldProcessPluginBase {
       'plugin' => 'callback',
       'callable' => 'trim',
     ];
+    $local_contexts_delimiter = $context['local_contexts_delimiter'] ?? '>';
     $process[] = [
       'plugin' => 'local_contexts_label_lookup',
+      'delimiter' => $local_contexts_delimiter,
     ];
     $process[0]['source'] = $source;
     return $process;

--- a/modules/mukurtu_import/src/Plugin/migrate/process/LocalContextsLabelLookup.php
+++ b/modules/mukurtu_import/src/Plugin/migrate/process/LocalContextsLabelLookup.php
@@ -73,8 +73,10 @@ class LocalContextsLabelLookup extends ProcessPluginBase implements ContainerFac
       return $value;
     }
 
-    // Split on the first non-escaped colon to detect compound format.
-    $parts = preg_split('/(?<!\\\\):/', $value, 2);
+    // Split on the first non-escaped delimiter to detect compound format.
+    $delimiter = $this->configuration['delimiter'] ?? '>';
+    $escaped_delimiter = preg_quote($delimiter, '/');
+    $parts = preg_split('/(?<!\\\\)' . $escaped_delimiter . '/', $value, 2);
 
     if (count($parts) === 2) {
       return $this->transformCompound($parts[0], $parts[1], $labels, $notices, $value);
@@ -84,12 +86,12 @@ class LocalContextsLabelLookup extends ProcessPluginBase implements ContainerFac
   }
 
   /**
-   * Resolves a compound "Project Title: Label Name" value.
+   * Resolves a compound "Project Title > Label Name" value.
    *
    * @param string $project_part
-   *   The raw project title segment (may contain escaped colons).
+   *   The raw project title segment (may contain escaped delimiters).
    * @param string $label_part
-   *   The raw label/notice name segment (may contain escaped colons).
+   *   The raw label/notice name segment (may contain escaped delimiters).
    * @param array $labels
    *   All labels from the manager.
    * @param array $notices
@@ -103,8 +105,9 @@ class LocalContextsLabelLookup extends ProcessPluginBase implements ContainerFac
    * @throws \Drupal\migrate\MigrateException
    */
   protected function transformCompound(string $project_part, string $label_part, array $labels, array $notices, string $original_value): ?string {
-    $project_title = trim(str_replace('\:', ':', $project_part));
-    $label_name = trim(str_replace('\:', ':', $label_part));
+    $delimiter = $this->configuration['delimiter'] ?? '>';
+    $project_title = trim(str_replace('\\' . $delimiter, $delimiter, $project_part));
+    $label_name = trim(str_replace('\\' . $delimiter, $delimiter, $label_part));
 
     // Build a lowercased project title → [project_id, ...] map.
     $project_title_map = [];


### PR DESCRIPTION
Resolves #1427 

## Description

Change the compound project/label delimiter from a hardcoded colon to a configurable value (default ">") to avoid conflicts with the internal stored format (project_id:label_id:display). The delimiter is exposed as a "Local Contexts Delimiter" textfield under File Settings in the import strategy form.

## Testing instructions

- [ ] Setup the environment including importing local context data
- [x] Try an import for content that accepts a local context project / label with the new default delimiter of `>`
- [ ] Try an import configuring an alternative delimiter, eg. `|`. You can configure this on the Import - File Configuration page under the File Settings. Look for the "Local Contexts Delimiter" configuration option.