### PR TITLE
1430: Prevent Mukurtu Managers from assigning Administrator role

### DIFF
--- a/modules/mukurtu_core/src/Hook/FormHooks.php
+++ b/modules/mukurtu_core/src/Hook/FormHooks.php
@@ -54,4 +54,38 @@ class FormHooks {
     }
   }
 
+  /**
+   * Implements hook_form_FORM_ID_alter() for 'user-register-form' and
+   * 'user-form'.
+   *
+   * Hides 'Administrator' option from the Roles selection for Mukurtu Managers
+   * so that they cannot assign the admin role.
+   */
+  #[Hook('form_user_register_form_alter')]
+  public function formUserRegisterFormAlter(array &$form, FormStateInterface $form_state): void {
+    $currentUser = \Drupal::currentUser()->getAccount();
+    /** @var \Drupal\Core\Session\UserSession $currentUser */
+    if ($currentUser->hasRole('mukurtu_manager')) {
+      if (isset($form['account']['roles']['#options']['administrator'])) {
+        unset($form['account']['roles']['#options']['administrator']);
+      }
+    }
+  }
+
+  /**
+   * Implements hook_form_FORM_ID_alter() for 'user-form'.
+   *
+   * Hides 'Administrator' option from the Roles selection for Mukurtu Managers
+   * so that they cannot assign the admin role.
+   */
+  #[Hook('form_user_form_alter')]
+  public function formUserFormAlter(array &$form, FormStateInterface $form_state): void {
+    $currentUser = \Drupal::currentUser()->getAccount();
+    /** @var \Drupal\Core\Session\UserSession $currentUser */
+    if ($currentUser->hasRole('mukurtu_manager')) {
+      if (isset($form['account']['roles']['#options']['administrator'])) {
+        unset($form['account']['roles']['#options']['administrator']);
+      }
+    }
+  }
 }


### PR DESCRIPTION
Fixes https://github.com/MukurtuCMS/Mukurtu-CMS/issues/1430 by removing the 'Administrator' role option from create and edit user forms for Mukurtu Managers.

Steps to test:
1. Create a new user and assign them the Mukurtu Manager role.
2. Login as the Mukurtu Manager.
3. Try to create a new user; verify that the 'Administrator' role option is not present.
4. Try to edit a user; verify that the 'Administrator' role option is not present.