### PR TITLE
1451: Fix cultural protocol data loss when user saves content with inaccessible protocols

### DIFF
--- a/modules/mukurtu_protocol/src/Plugin/Field/FieldType/CulturalProtocolItem.php
+++ b/modules/mukurtu_protocol/src/Plugin/Field/FieldType/CulturalProtocolItem.php
@@ -19,6 +19,7 @@ use Drupal\mukurtu_protocol\CulturalProtocols;
  * )
  */
 class CulturalProtocolItem extends FieldItemBase {
+
   /**
    * {@inheritdoc}
    */
@@ -113,7 +114,8 @@ class CulturalProtocolItem extends FieldItemBase {
         }
 
         // If the user tried to add protocols they cannot apply, remove them.
-        $added_protocols_to_remove = array_diff($new_protocols, $protocol_ids_user_can_apply);
+        $newly_added_protocols = array_diff($new_protocols, $original_protocols);
+        $added_protocols_to_remove = array_diff($newly_added_protocols, $protocol_ids_user_can_apply);
         if (!empty($added_protocols_to_remove)) {
           $silently_changed_protocols = TRUE;
         }

--- a/modules/mukurtu_protocol/tests/src/Kernel/CulturalProtocolItemTest.php
+++ b/modules/mukurtu_protocol/tests/src/Kernel/CulturalProtocolItemTest.php
@@ -255,6 +255,37 @@ class CulturalProtocolItemTest extends ProtocolAwareEntityTestBase {
   }
 
   /**
+   * Updated entity where user re-submits with pre-existing inaccessible
+   * protocols included (as the widget does via hidden form values). The
+   * inaccessible protocols should be preserved.
+   */
+  public function testUpdatedEntityPreservesInaccessibleProtocols() {
+    $entity = $this->entity;
+
+    // otherUser can apply protocols 0 and 1 but not 2.
+    foreach (range(0, 1) as $delta) {
+      $this->communities[$delta]->addMember($this->otherUser);
+      $this->protocols[$delta]->addMember($this->otherUser, ['protocol_steward']);
+    }
+
+    // privilegedUser sets all three protocols.
+    $this->setCurrentUser($this->privilegedUser);
+    $entity->setOwner($this->privilegedUser);
+    $original_protocol_ids = [$this->protocols[0]->id(), $this->protocols[1]->id(), $this->protocols[2]->id()];
+    $entity->setSharingSetting('any');
+    $entity->setProtocols($original_protocol_ids);
+    $entity->save();
+    $this->assertEquals($original_protocol_ids, $entity->getProtocols());
+
+    // otherUser saves the entity with all protocols still present (the widget
+    // includes inaccessible protocol IDs as hidden form values).
+    $this->setCurrentUser($this->otherUser);
+    $entity->setProtocols($original_protocol_ids);
+    $entity->save();
+    $this->assertEquals($original_protocol_ids, $entity->getProtocols());
+  }
+
+  /**
    * Test on updated entity where user tries to both add and remove protocols
    * they cannot apply.
    */


### PR DESCRIPTION
Resolves #1451 

### Description

Pre-existing protocols the user cannot apply were being stripped on save because `preSave()` treated them as unauthorized additions. Now only genuinely new protocols (not in the original) are checked against the user's apply permission, so grandfathered-in protocols are preserved.

### Testing instuctions

- [ ] Run through steps to reproduce from the issue description. Should have desired result
- [ ] Try with media, and various content types, generally any entities that have a `cultural_protocol` type field.