### PR TITLE
1368: List binary files on review import

### DIFF
--- a/modules/mukurtu_import/src/Form/ExecuteImportForm.php
+++ b/modules/mukurtu_import/src/Form/ExecuteImportForm.php
@@ -91,9 +91,13 @@ class ExecuteImportForm extends ImportBaseForm {
    * {@inheritdoc}
    */
   public function buildForm(array $form, FormStateInterface $form_state): array {
+    $form['review_message'] = [
+      '#markup' => '<p>' . $this->t('Review your import. Once you begin the import you cannot stop it. There is no way to rollback the import. Click the "Start Import" button to begin.') . '</p>',
+    ];
+
     $form['table'] = [
       '#type' => 'table',
-      '#caption' => $this->t('Review your import. Once you begin the import you cannot stop it. There is no way to rollback the import. Click the "Start Import" button to begin.'),
+      '#caption' => ['#markup' => '<strong>' . $this->t('Metadata Files') . '</strong>'],
       '#header' => [
         $this->t('Filename'),
         $this->t('Import Configuration'),
@@ -130,6 +134,27 @@ class ExecuteImportForm extends ImportBaseForm {
         '#markup' => "<div>$entity_label: $bundle_label</div>",
       ];
 
+    }
+
+    $binary_files = $this->getBinaryFiles();
+    $form['binary_table'] = [
+      '#type' => 'table',
+      '#caption' => ['#markup' => '<strong>' . $this->t('Media/Binary Files') . '</strong>'],
+      '#header' => [
+        $this->t('Filename'),
+      ],
+      '#attributes' => [
+        'id' => 'import-review-binary',
+      ],
+      '#empty' => $this->t('No media/binary files uploaded.'),
+    ];
+
+    foreach ($binary_files as $fid) {
+      $filename = $this->getImportFilename($fid);
+      $form['binary_table'][$fid]['filename'] = [
+        '#type' => 'markup',
+        '#markup' => "<div>$filename</div>",
+      ];
     }
 
     $form['actions'] = [


### PR DESCRIPTION
Resolves #1368 

## Description

Lists the binary files that are part of the active import session on the review page at `/admin/import/run`

### Testing instructions

- [ ] Run through an import with and without "Media/Binary Files" uploaded in the first step. 
- [ ] The files you upload should be reflected in a list on the review screen.
- [ ] If you haven't uploaded any, you should see a note indicating "No media/binary files uploaded."