### PR TITLE
1472: Fix a regression caused to migrate from updates to import

### DIFF
--- a/modules/mukurtu_import/src/Plugin/migrate/destination/ProtocolAwareEntityContent.php
+++ b/modules/mukurtu_import/src/Plugin/migrate/destination/ProtocolAwareEntityContent.php
@@ -114,21 +114,27 @@ class ProtocolAwareEntityContent extends EntityContentBase {
       $entity->prepareSave();
     }
 
-    // Determine if this is a create or update operation.
-    $operation = $entity->isNew() ? 'create' : 'update';
+    // Skip access checks for user 1. The initial v3-to-v4 site migration is
+    // restricted to user 1 (see MukurtuMigrateAccessCheck) and runs before OG
+    // memberships are migrated, so protocol/community access checks would
+    // incorrectly deny entity creation.
+    if ((int) $this->currentUser->id() !== 1) {
+      // Determine if this is a create or update operation.
+      $operation = $entity->isNew() ? 'create' : 'update';
 
-    // Check entity access for the current user.
-    $access = $entity->access($operation, $this->currentUser, TRUE);
-    if (!$access->isAllowed()) {
-      $reason = $access->getReason();
-      throw new MigrateException(
-        sprintf('The current user does not have %s access for this %s (ID: %s).%s',
-          $operation,
-          mb_strtolower((string)$entity->getEntityType()->getLabel()),
-          $entity->isNew() ? 'new' : $entity->id(),
-          $reason ? ' ' . $reason : '',
-        )
-      );
+      // Check entity access for the current user.
+      $access = $entity->access($operation, $this->currentUser, TRUE);
+      if (!$access->isAllowed()) {
+        $reason = $access->getReason();
+        throw new MigrateException(
+          sprintf('The current user does not have %s access for this %s (ID: %s).%s',
+            $operation,
+            mb_strtolower((string)$entity->getEntityType()->getLabel()),
+            $entity->isNew() ? 'new' : $entity->id(),
+            $reason ? ' ' . $reason : '',
+          )
+        );
+      }
     }
 
     if ($this->isEntityValidationRequired($entity)) {
@@ -227,12 +233,18 @@ class ProtocolAwareEntityContent extends EntityContentBase {
    * {@inheritdoc}
    */
   protected function updateEntity(EntityInterface $entity, Row $row) {
+    // Skip access checks for user 1. See the corresponding check in import()
+    // for rationale.
+    if ((int) $this->currentUser->id() !== 1) {
+      return parent::updateEntity($entity, $row);
+    }
+
     // Check update access against the original, unmodified entity before the
-    // parent applies imported field values. This prevents a user from bypassing
-    // access control by importing their own protocol onto content they cannot
-    // otherwise edit. Without this check, the protocol change would already be
-    // applied in memory by the time the post-edit access check runs in
-    // import(), causing it to incorrectly pass.
+    // parent applies imported field values. This prevents a user from
+    // bypassing access control by importing their own protocol onto content
+    // they cannot otherwise edit. Without this check, the protocol change
+    // would already be applied in memory by the time the post-edit access
+    // check runs in import(), causing it to incorrectly pass.
     $access = $entity->access('update', $this->currentUser, TRUE);
     if (!$access->isAllowed()) {
       $reason = $access->getReason();


### PR DESCRIPTION
Resolves #1472

### Description

Recent updates in the Mukutu Roundtrip code (see https://github.com/MukurtuCMS/Mukurtu-CMS/pull/1435) caused a regression in the initial site migration. The access checks that were added presume that OG groups and memberships are already established on the site and include checks for membership before allowing certain content operations. 

The fix leverages the requirement for user 1 to run the initial site migration, and bypasses these checks when the current user is user 1.

### Testing

- [ ] Run an initial site migration as user 1 (as required)
- [ ] Verify that Communities and Protocols were correctly migrated as well as memberships
- [ ] Create one or more Mukurtu Roundtrip Manager users with limited access on certain protocols
- [ ] Run through the site import and verify that they cannot change the protocol on content not in their purview
- [ ] Run through the site import and verify that they cannot create content outside of their purview or assigned protocols