### PR TITLE
Fix protocol all-mode access control and activate image alt constraint

### DIFF
--- a/modules/mukurtu_media/src/Entity/Image.php
+++ b/modules/mukurtu_media/src/Entity/Image.php
@@ -77,7 +77,8 @@ class Image extends Media implements ImageInterface, CulturalProtocolControlledI
       ->setRevisionable(TRUE)
       ->setTranslatable(TRUE)
       ->setDisplayConfigurable('view', TRUE)
-      ->setDisplayConfigurable('form', TRUE);
+      ->setDisplayConfigurable('form', TRUE)
+      ->addPropertyConstraints('alt', ['ImageAltRequired' => []]);
 
     $definitions['field_media_tags'] = BaseFieldDefinition::create('entity_reference')
       ->setLabel(t('Media Tags'))

--- a/modules/mukurtu_protocol/src/MukurtuProtocolNodeAccessControlHandler.php
+++ b/modules/mukurtu_protocol/src/MukurtuProtocolNodeAccessControlHandler.php
@@ -46,35 +46,35 @@ class MukurtuProtocolNodeAccessControlHandler extends NodeAccessControlHandler {
 
       case 'update':
       case 'delete':
-        // Ask each member OG group about specific permissions.
         $ogAccessService = \Drupal::service('og.access');
-        $protocols = $entity->getMemberProtocols($account);
 
-        // By this point, we have already taken the sharing setting into account
-        // with the call to isProtocolSetMember() above, which guarantees that
-        // if the sharing setting is 'any', the user is a member of at least one
-        // of the protocols, and if it is 'all', the user is a member of all the
-        // protocols.
-
-        // Given this, the access result for each protocol must be combined
-        // using orIf. Previously, orIf was only used for entities under the
-        // 'any' sharing setting; andIf was used for 'all'. Using andIf for
-        // 'all' was denying legitimate access in the case where a user has a
-        // mix of highly privileged roles and lesser privileged roles, i.e., if
-        // the user was both a protocol steward of one protocol and a protocol
-        // member of another and both these protocols were applied to an entity
-        // under the 'all' setting. The access check on the protocol where the
-        // user was merely a protocol member returned neutral(), which, when
-        // andIfed with the protocol steward access of allowed(), returned
-        // neutral(). We don't grant access if the result is only neutral(), so
-        // access was denied in this case.
-
-        // The correct thing to do is to consider the user's most privileged
-        // permissions for access, hence the change to using orIf for 'all'.
-        $result = AccessResult::neutral();
-
-        foreach ($protocols as $protocol) {
-          $result = $result->orIf($ogAccessService->userAccessGroupContentEntityOperation($operation, $protocol, $entity, $account));
+        if ($entity->getSharingSetting() == 'all') {
+          // For 'all', every protocol must individually grant edit access.
+          // We use andIf starting from allowed; neutral (no edit permission) is
+          // treated as forbidden since every single protocol must grant access.
+          // Cache metadata from each OG result is preserved via addCacheableDependency.
+          $protocolEntities = $entity->getProtocolEntities();
+          if (empty($protocolEntities)) {
+            // Broken protocol references — deny conservatively.
+            return AccessResult::forbidden();
+          }
+          $result = AccessResult::allowed();
+          foreach ($protocolEntities as $protocol) {
+            $protocolResult = $ogAccessService->userAccessGroupContentEntityOperation($operation, $protocol, $entity, $account);
+            if ($protocolResult->isNeutral()) {
+              $protocolResult = AccessResult::forbidden()->addCacheableDependency($protocolResult);
+            }
+            $result = $result->andIf($protocolResult);
+          }
+        }
+        else {
+          // For 'any', one protocol granting edit access is sufficient.
+          // getMemberProtocols() ensures the user is a member of at least one
+          // protocol (guaranteed by isProtocolSetMember() above).
+          $result = AccessResult::neutral();
+          foreach ($entity->getMemberProtocols($account) as $protocol) {
+            $result = $result->orIf($ogAccessService->userAccessGroupContentEntityOperation($operation, $protocol, $entity, $account));
+          }
         }
 
         // Protocols are very opinionated, neutral is not good enough for


### PR DESCRIPTION
- MukurtuProtocolNodeAccessControlHandler: under the 'all' sharing setting, every protocol must now individually grant edit/delete access. Previously, a qualifying role in any single protocol was sufficient, allowing unintended access to content requiring membership in all protocols.

- Image.php: attach the ImageAltRequired constraint to field_media_image so that $media->validate() actually enforces it. The constraint class existed but was never wired to the field definition.  There are other places this could also be added -- like thumbnails -- but we should confirm this approach too.

--these are two possible production fixes that came up in my CI investigation and build-out (that I will push separately).  We should confirm our any / all settings are working the way we want them to  as proposed fix could just be over tightening a screw (if yes we can disregard the changes to the MukurtuProtocolNodeAccessControlHandler).    