### PR TITLE
Updates to community and protocol forms

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -79,7 +79,8 @@
         "drupal/tagify": "^1.2",
         "drupal/genpass": "^2.1",
         "drupal/rebuild_cache_access": "^1.12",
-        "drupal/notify_user_default": "^1.0"
+        "drupal/notify_user_default": "^1.0",
+        "drupal/readonly_field_widget":"^2.1"
     },
     "require-dev": {
         "drupal/devel": "*",

--- a/composer.json
+++ b/composer.json
@@ -80,7 +80,7 @@
         "drupal/genpass": "^2.1",
         "drupal/rebuild_cache_access": "^1.12",
         "drupal/notify_user_default": "^1.0",
-        "drupal/readonly_field_widget":"^2.1"
+        "drupal/readonly_field_widget": "^2.1"
     },
     "require-dev": {
         "drupal/devel": "*",

--- a/modules/mukurtu_core/mukurtu_core.install
+++ b/modules/mukurtu_core/mukurtu_core.install
@@ -149,3 +149,10 @@ function mukurtu_core_update_40004(): void {
 function mukurtu_core_update_40005(): void {
   \Drupal::service('module_installer')->install(['genpass', 'notify_user_default']);
 }
+
+/**
+ * Install readonly_field_widget module.
+ */
+function mukurtu_core_update_40006(): void {
+  \Drupal::service('module_installer')->install(['readonly_field_widget']);
+}

--- a/modules/mukurtu_protocol/config/install/core.entity_form_display.community.community.default.yml
+++ b/modules/mukurtu_protocol/config/install/core.entity_form_display.community.community.default.yml
@@ -8,7 +8,10 @@ dependencies:
     - media_library
     - mukurtu_protocol
     - path
+    - readonly_field_widget
     - text
+_core:
+  default_config_hash: aaK99YSsV5QeMama3zE5jC_SPMsK6krhSHq_lyCOSjQ
 id: community.community.default
 targetEntityType: community
 bundle: community
@@ -32,24 +35,27 @@ content:
     third_party_settings: {  }
   field_banner_image:
     type: media_library_widget
-    weight: 7
+    weight: 6
     region: content
     settings:
       media_types: {  }
     third_party_settings: {  }
   field_child_communities:
-    type: entity_reference_autocomplete
-    weight: 10
+    type: readonly_field_widget
+    weight: 11
     region: content
     settings:
-      match_operator: CONTAINS
-      match_limit: 10
-      size: 60
-      placeholder: ''
+      label: above
+      formatter_type: entity_reference_label
+      formatter_settings:
+        entity_reference_label:
+          link: true
+      show_description: false
+      error_validation: false
     third_party_settings: {  }
   field_community_type:
     type: options_buttons
-    weight: 5
+    weight: 9
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -65,7 +71,7 @@ content:
     third_party_settings: {  }
   field_featured_content:
     type: entity_browser_entity_reference
-    weight: 9
+    weight: 8
     region: content
     settings:
       entity_browser: mukurtu_content_browser
@@ -87,13 +93,24 @@ content:
     third_party_settings: {  }
   field_membership_display:
     type: options_buttons
-    weight: 6
+    weight: 5
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_parent_community:
+    type: readonly_field_widget
+    weight: 10
+    region: content
+    settings:
+      label: above
+      formatter_type: null
+      formatter_settings: {  }
+      show_description: false
+      error_validation: false
+    third_party_settings: {  }
   field_thumbnail_image:
     type: media_library_widget
-    weight: 8
+    weight: 7
     region: content
     settings:
       media_types: {  }
@@ -115,13 +132,13 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 11
+    weight: 12
     region: content
     settings: {  }
     third_party_settings: {  }
   user_id:
     type: entity_reference_autocomplete
-    weight: 12
+    weight: 13
     region: content
     settings:
       match_operator: CONTAINS
@@ -130,4 +147,6 @@ content:
       placeholder: ''
     third_party_settings: {  }
 hidden:
-  field_parent_community: true
+  create_new_revision: true
+  revision_log: true
+  

--- a/modules/mukurtu_protocol/config/install/core.entity_form_display.community.community.default.yml
+++ b/modules/mukurtu_protocol/config/install/core.entity_form_display.community.community.default.yml
@@ -146,7 +146,5 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-hidden:
-  create_new_revision: true
-  revision_log: true
+hidden: {}
   

--- a/modules/mukurtu_protocol/mukurtu_protocol.info.yml
+++ b/modules/mukurtu_protocol/mukurtu_protocol.info.yml
@@ -30,5 +30,6 @@ dependencies:
   - 'og:og'
   - 'og_ui:og_ui'
   - 'pathauto:pathauto'
+  - 'readonly_field_widget:readonly_field_widget'
   - 'views_bulk_operations:views_bulk_operations'
 version: 4.x-dev

--- a/modules/mukurtu_protocol/mukurtu_protocol.install
+++ b/modules/mukurtu_protocol/mukurtu_protocol.install
@@ -121,3 +121,67 @@ function mukurtu_protocol_install() {
   $config->set('enabled_entity_types', $types);
   $config->save();
 }
+
+/**
+ * Update community form display: show parent/child communities as read-only.
+ */
+function mukurtu_protocol_update_40000(): void {
+  $config = \Drupal::configFactory()->getEditable('core.entity_form_display.community.community.default');
+
+  // Add readonly_field_widget to config dependencies.
+  $dependencies = $config->get('dependencies.module');
+  if (!in_array('readonly_field_widget', $dependencies)) {
+    $dependencies[] = 'readonly_field_widget';
+    sort($dependencies);
+    $config->set('dependencies.module', $dependencies);
+  }
+
+  // Switch field_child_communities from entity_reference_autocomplete to
+  // readonly_field_widget.
+  $config->set('content.field_child_communities', [
+    'type' => 'readonly_field_widget',
+    'weight' => 11,
+    'region' => 'content',
+    'settings' => [
+      'label' => 'above',
+      'formatter_type' => 'entity_reference_label',
+      'formatter_settings' => [
+        'entity_reference_label' => ['link' => TRUE],
+      ],
+      'show_description' => FALSE,
+      'error_validation' => FALSE,
+    ],
+    'third_party_settings' => [],
+  ]);
+
+  // Move field_parent_community from hidden to visible as readonly_field_widget.
+  $config->set('content.field_parent_community', [
+    'type' => 'readonly_field_widget',
+    'weight' => 10,
+    'region' => 'content',
+    'settings' => [
+      'label' => 'above',
+      'formatter_type' => NULL,
+      'formatter_settings' => [],
+      'show_description' => FALSE,
+      'error_validation' => FALSE,
+    ],
+    'third_party_settings' => [],
+  ]);
+  $config->clear('hidden.field_parent_community');
+
+  // Hide revision fields.
+  $config->set('hidden.create_new_revision', TRUE);
+  $config->set('hidden.revision_log', TRUE);
+
+  // Update field weights.
+  $config->set('content.field_banner_image.weight', 6);
+  $config->set('content.field_community_type.weight', 9);
+  $config->set('content.field_featured_content.weight', 8);
+  $config->set('content.field_membership_display.weight', 5);
+  $config->set('content.field_thumbnail_image.weight', 7);
+  $config->set('content.path.weight', 12);
+  $config->set('content.user_id.weight', 13);
+
+  $config->save();
+}

--- a/modules/mukurtu_protocol/mukurtu_protocol.install
+++ b/modules/mukurtu_protocol/mukurtu_protocol.install
@@ -125,7 +125,7 @@ function mukurtu_protocol_install() {
 /**
  * Update community form display: show parent/child communities as read-only.
  */
-function mukurtu_protocol_update_40000(): void {
+function mukurtu_protocol_update_40001(): void {
   $config = \Drupal::configFactory()->getEditable('core.entity_form_display.community.community.default');
 
   // Add readonly_field_widget to config dependencies.

--- a/modules/mukurtu_protocol/src/Entity/Community.php
+++ b/modules/mukurtu_protocol/src/Entity/Community.php
@@ -580,7 +580,7 @@ class Community extends EditorialContentEntityBase implements CommunityInterface
 
     $fields['user_id'] = BaseFieldDefinition::create('entity_reference')
       ->setLabel(t('Authored by'))
-      ->setDescription(t('The user ID of author of the Community entity.'))
+      ->setDescription(t('The username and ID that created the community.'))
       ->setRevisionable(TRUE)
       ->setSetting('target_type', 'user')
       ->setSetting('handler', 'default')
@@ -605,7 +605,7 @@ class Community extends EditorialContentEntityBase implements CommunityInterface
 
     $fields['name'] = BaseFieldDefinition::create('string')
       ->setLabel(t('Community name'))
-      ->setDescription(t('The name of the Community.'))
+      ->setDescription(t('The name of the community as you want it displayed across the site.'))
       ->setRevisionable(TRUE)
       ->setTranslatable(TRUE)
       ->setSettings([
@@ -627,7 +627,7 @@ class Community extends EditorialContentEntityBase implements CommunityInterface
       ->setRequired(TRUE);
 
     $fields['field_description'] = BaseFieldDefinition::create('text_with_summary')
-      ->setLabel(t('Description'))
+      ->setLabel(t('A description of the community that gives site visitors more information about the community and its purpose. This is shown to anyone who can view the community page.'))
       ->setTranslatable(TRUE)
       ->setDisplayOptions('view', [
         'label' => 'visible',
@@ -646,7 +646,7 @@ class Community extends EditorialContentEntityBase implements CommunityInterface
     $fields['field_parent_community'] = BaseFieldDefinition::create('entity_reference')
       ->setName('field_parent_community')
       ->setLabel(t('Parent Community'))
-      ->setDescription('')
+      ->setDescription('Displays the parent community, if one exists. This is a read only field. Community organization is managed through the community organization admin page and not through this field.')
       ->setComputed(TRUE)
       ->setClass('Drupal\mukurtu_protocol\Plugin\Field\CommunityParentCommunityItemList')
       ->setSetting('target_type', 'community')
@@ -661,6 +661,7 @@ class Community extends EditorialContentEntityBase implements CommunityInterface
     $fields['field_child_communities'] = BaseFieldDefinition::create('entity_reference')
       ->setName('field_child_communities')
       ->setLabel(t('Sub-communities'))
+      ->setDescription('Displays any child communities. This is a read only field. Community organization is managed through the community organization admin page and not through this field.')
       ->setComputed(TRUE)
       ->setClass('Drupal\mukurtu_protocol\Plugin\Field\CommunityChildCommunitiesItemList')
       ->setSetting('target_type', 'community')
@@ -676,7 +677,7 @@ class Community extends EditorialContentEntityBase implements CommunityInterface
       ->setDisplayConfigurable('view', TRUE)
       ->setDisplayConfigurable('form', TRUE);
 
-    $fields['status']->setDescription(t('A boolean indicating whether the Community is published.'))
+    $fields['status']->setDescription(t('Publish or unpublish the community. If unpublished, this community will not be visible to anyone except community managers and site admins.'))
       ->setDisplayOptions('form', [
         'type' => 'boolean_checkbox',
         'weight' => 30,
@@ -684,11 +685,11 @@ class Community extends EditorialContentEntityBase implements CommunityInterface
 
     $fields['created'] = BaseFieldDefinition::create('created')
       ->setLabel(t('Created'))
-      ->setDescription(t('The time that the entity was created.'));
+      ->setDescription(t('The time that the community was created.'));
 
     $fields['changed'] = BaseFieldDefinition::create('changed')
       ->setLabel(t('Changed'))
-      ->setDescription(t('The time that the entity was last edited.'));
+      ->setDescription(t('The time that the community was last edited.'));
 
     $fields['revision_translation_affected'] = BaseFieldDefinition::create('boolean')
       ->setLabel(t('Revision translation affected'))
@@ -725,7 +726,7 @@ class Community extends EditorialContentEntityBase implements CommunityInterface
 
     $fields['field_community_type'] = BaseFieldDefinition::create('entity_reference')
       ->setLabel(t('Community Type'))
-      ->setDescription(t('Indicates the type of community.'))
+      ->setDescription(t('Indicates the type of community. This can be used to group and filter different types of communities. eg: institution, repository, tribe, nation.'))
       ->setSetting('target_type', 'taxonomy_term')
       ->setSetting('handler', 'default:taxonomy_term')
       ->setSetting('handler_settings',
@@ -746,6 +747,7 @@ class Community extends EditorialContentEntityBase implements CommunityInterface
       ->setDisplayConfigurable('form', TRUE);
     $fields['field_featured_content'] = BaseFieldDefinition::create('entity_reference')
       ->setLabel(t('Featured Content'))
+      ->setDescription(t('Select content to be displayed on the community page. Protocols apply to featured content.'))
       ->setSetting('target_type', 'node')
       ->setSetting('handler', 'default:node')
       ->setSetting('handler_settings', [
@@ -764,7 +766,7 @@ class Community extends EditorialContentEntityBase implements CommunityInterface
 
     $fields['field_banner_image'] = BaseFieldDefinition::create('entity_reference')
       ->setLabel(t('Banner Image'))
-      ->setDescription(t('Note: banner and thumbnail images require a cultural protocol (like all other media assets). If you cannot upload images here, ensure that you are enrolled in a relevant cultural protocol with permission to upload media.'))
+      ->setDescription(t('The banner image is displayed on the community page. Note: banner images require a cultural protocol (like all other media assets). If you cannot upload images here, ensure that you are enrolled in a relevant cultural protocol with permission to upload media.'))
       ->setSetting('target_type', 'media')
       ->setSetting('handler', 'default:media')
       ->setSetting('handler_settings', [
@@ -784,7 +786,7 @@ class Community extends EditorialContentEntityBase implements CommunityInterface
 
     $fields['field_thumbnail_image'] = BaseFieldDefinition::create('entity_reference')
       ->setLabel(t('Thumbnail Image'))
-      ->setDescription(t('Note: banner and thumbnail images require a cultural protocol (like all other media assets). If you cannot upload images here, ensure that you are enrolled in a relevant cultural protocol with permission to upload media.'))
+      ->setDescription(t('The thumbnail image is displayed in the browse communities page and block. Note: thumbnail images require a cultural protocol (like all other media assets). If you cannot upload images here, ensure that you are enrolled in a relevant cultural protocol with permission to upload media.'))
       ->setSetting('target_type', 'media')
       ->setSetting('handler', 'default:media')
       ->setSetting('handler_settings', [
@@ -804,7 +806,7 @@ class Community extends EditorialContentEntityBase implements CommunityInterface
 
     $fields['field_membership_display'] = BaseFieldDefinition::create('list_string')
       ->setLabel(t('Membership Display'))
-      ->setDescription('TODO: membership display helper text')
+      ->setDescription('Select which, if any, community members are displayed on the community page.')
       ->setSettings([
         'allowed_values' => [
           'none' => 'Do not display any community members',
@@ -838,7 +840,7 @@ class Community extends EditorialContentEntityBase implements CommunityInterface
     $fields['field_local_contexts_description'] = BaseFieldDefinition::create('text_long')
       ->setName('field_local_contexts_description')
       ->setLabel(t('Local Contexts Description'))
-      ->setDescription(t('Enter the description for the Local Contexts project directory page.'))
+      ->setDescription(t('All community-level Local Contexts projects are displayed on a directory page. Provide a more detailed description of the use and development of these projects if applicable.'))
       ->setRequired(FALSE)
       ->setTranslatable(TRUE)
       ->setDefaultValue([])

--- a/modules/mukurtu_protocol/src/Entity/Community.php
+++ b/modules/mukurtu_protocol/src/Entity/Community.php
@@ -627,7 +627,8 @@ class Community extends EditorialContentEntityBase implements CommunityInterface
       ->setRequired(TRUE);
 
     $fields['field_description'] = BaseFieldDefinition::create('text_with_summary')
-      ->setLabel(t('A description of the community that gives site visitors more information about the community and its purpose. This is shown to anyone who can view the community page.'))
+      ->setLabel(t('Description'))
+      ->setDescription(t('A description of the community that gives site visitors more information about the community and its purpose. This is shown to anyone who can view the community page.'))
       ->setTranslatable(TRUE)
       ->setDisplayOptions('view', [
         'label' => 'visible',

--- a/modules/mukurtu_protocol/src/Entity/Protocol.php
+++ b/modules/mukurtu_protocol/src/Entity/Protocol.php
@@ -495,7 +495,7 @@ class Protocol extends EditorialContentEntityBase implements ProtocolInterface {
 
     $fields['user_id'] = BaseFieldDefinition::create('entity_reference')
       ->setLabel(t('Authored by'))
-      ->setDescription(t('The user ID of author of the Protocol.'))
+      ->setDescription(t('The username and ID of the user that created the protocol.'))
       ->setRevisionable(TRUE)
       ->setSetting('target_type', 'user')
       ->setSetting('handler', 'default')
@@ -519,7 +519,7 @@ class Protocol extends EditorialContentEntityBase implements ProtocolInterface {
 
     $fields['name'] = BaseFieldDefinition::create('string')
       ->setLabel(t('Cultural protocol name'))
-      ->setDescription(t('The name of the Protocol.'))
+      ->setDescription(t('The name of the cultural protocol as you want it displayed across the site.'))
       ->setRevisionable(TRUE)
       ->setTranslatable(TRUE)
       ->setSettings([
@@ -541,6 +541,7 @@ class Protocol extends EditorialContentEntityBase implements ProtocolInterface {
 
     $fields['field_description'] = BaseFieldDefinition::create('text_with_summary')
       ->setLabel(t('Description'))
+      ->setDescription(t('A description of the cultural protocol that gives site visitors more information about the protocol and its purpose. This is shown to anyone who can view the protocol page.'))
       ->setTranslatable(TRUE)
       ->setDisplayOptions('view', [
         'label' => 'visible',
@@ -556,7 +557,7 @@ class Protocol extends EditorialContentEntityBase implements ProtocolInterface {
 
     $fields['field_comment_status'] = BaseFieldDefinition::create('boolean')
       ->setLabel(t('Comments Status'))
-      ->setDescription(t('If comments are enabled for the protocol.'))
+      ->setDescription(t('Enable or disable comments for all content using this protocol.'))
       ->setRevisionable(FALSE)
       ->setDefaultValue(TRUE)
       ->setTranslatable(FALSE)
@@ -565,25 +566,25 @@ class Protocol extends EditorialContentEntityBase implements ProtocolInterface {
 
     $fields['field_comment_require_approval'] = BaseFieldDefinition::create('boolean')
       ->setLabel(t('Comments Require Approval'))
-      ->setDescription(t('If comments require approval for the protocol.'))
+      ->setDescription(t('Enable or disable comment approval for all content using this protocol.'))
       ->setRevisionable(FALSE)
       ->setDefaultValue(TRUE)
       ->setTranslatable(FALSE)
       ->setDisplayConfigurable('view', TRUE)
       ->setDisplayConfigurable('form', TRUE);
 
-    $fields['status']->setDescription(t('A boolean indicating whether the Protocol is published.'))
+    $fields['status']->setDescription(t('Publish or unpublish the protocol. If unpublished, this protocol will not be visible to anyone except protocol managers and site admins.'))
       ->setDisplayOptions('form', [
         'type' => 'boolean_checkbox',
       ]);
 
     $fields['created'] = BaseFieldDefinition::create('created')
       ->setLabel(t('Created'))
-      ->setDescription(t('The time that the entity was created.'));
+      ->setDescription(t('The time that the protocol was created.'));
 
     $fields['changed'] = BaseFieldDefinition::create('changed')
       ->setLabel(t('Changed'))
-      ->setDescription(t('The time that the entity was last edited.'));
+      ->setDescription(t('The time that the protocol was last edited.'));
 
     $fields['revision_translation_affected'] = BaseFieldDefinition::create('boolean')
       ->setLabel(t('Revision translation affected'))
@@ -595,6 +596,7 @@ class Protocol extends EditorialContentEntityBase implements ProtocolInterface {
     $fields['field_communities'] = BaseFieldDefinition::create('entity_reference')
       ->setLabel(t('Communities'))
       ->setSetting('target_type', 'community')
+      ->setDescription(t('Protocols must belong to at least one community. If a protocol belongs to multiple communities, it will be displayed on each of those community pages. Select "Select communities" to choose from available communities.'))
       ->setSetting('handler', 'community_selection_for_protocols')
       ->setSetting('handler_settings', [
         'auto_create' => FALSE,
@@ -612,6 +614,7 @@ class Protocol extends EditorialContentEntityBase implements ProtocolInterface {
 
     $fields['field_featured_content'] = BaseFieldDefinition::create('entity_reference')
       ->setLabel(t('Featured Content'))
+      ->setDescription(t('Select content to be displayed on the protocol page. Protocols apply to featured content.'))
       ->setSetting('target_type', 'node')
       ->setSetting('handler', 'default:node')
       ->setSetting('handler_settings', [
@@ -630,7 +633,7 @@ class Protocol extends EditorialContentEntityBase implements ProtocolInterface {
 
     $fields['field_banner_image'] = BaseFieldDefinition::create('entity_reference')
       ->setLabel(t('Banner Image'))
-      ->setDescription(t('Note: banner and thumbnail images require a cultural protocol (like all other media assets). If you cannot upload images here, ensure that you are enrolled in a relevant cultural protocol with permission to upload media.'))
+      ->setDescription(t('The banner image is displayed on the protocol page. Note: banner images require a cultural protocol (like all other media assets). If you cannot upload images here, ensure that you are enrolled in a relevant cultural protocol with permission to upload media.'))
       ->setSetting('target_type', 'media')
       ->setSetting('handler', 'default:media')
       ->setSetting('handler_settings', [
@@ -675,7 +678,7 @@ class Protocol extends EditorialContentEntityBase implements ProtocolInterface {
 
     $fields['field_thumbnail_image'] = BaseFieldDefinition::create('entity_reference')
       ->setLabel(t('Thumbnail Image'))
-      ->setDescription(t('Note: banner and thumbnail images require a cultural protocol (like all other media assets). If you cannot upload images here, ensure that you are enrolled in a relevant cultural protocol with permission to upload media.'))
+      ->setDescription(t('The thumbnail image is not used in the stock Mukurtu 4 theme. Note: thumbnail images require a cultural protocol (like all other media assets). If you cannot upload images here, ensure that you are enrolled in a relevant cultural protocol with permission to upload media.'))
       ->setSetting('target_type', 'media')
       ->setSetting('handler', 'default:media')
       ->setSetting('handler_settings', [
@@ -695,7 +698,7 @@ class Protocol extends EditorialContentEntityBase implements ProtocolInterface {
 
     $fields['field_membership_display'] = BaseFieldDefinition::create('list_string')
       ->setLabel(t('Membership Display'))
-      ->setDescription('')
+      ->setDescription(t('Select which, if any, protocol members are displayed on the protocol page.'))
       ->setSettings([
         'allowed_values' => [
           'none' => 'Do not display',
@@ -729,7 +732,7 @@ class Protocol extends EditorialContentEntityBase implements ProtocolInterface {
     $fields['field_local_contexts_description'] = BaseFieldDefinition::create('text_long')
       ->setName('field_local_contexts_description')
       ->setLabel(t('Local Contexts Description'))
-      ->setDescription(t('Enter the description for the Local Contexts project directory page.'))
+      ->setDescription(t('All protocol-level Local Contexts projects are displayed on a directory page. Provide a more detailed description of the use and development of these projects if applicable.'))
       ->setRequired(FALSE)
       ->setTranslatable(TRUE)
       ->setDefaultValue([])

--- a/modules/mukurtu_protocol/src/Form/CommunityAddForm.php
+++ b/modules/mukurtu_protocol/src/Form/CommunityAddForm.php
@@ -59,7 +59,7 @@ class CommunityAddForm extends ContentEntityForm {
     $form['community_member_item'] = [
       '#type' => 'item',
       '#title' => $this->t('Community members'),
-      '#description' => $this->t('Community members have basic membership in the community. This role is assigned to all community members by default. If they have not been added to any protocols, they can view the community page and any public content.'),
+      '#description' => $this->t('Community members can view the community page and be added to protocols within the community.'),
       '#weight' => '1001',
       '#access' => $this->isDefaultFormLangcode($form_state),
     ];
@@ -88,7 +88,7 @@ class CommunityAddForm extends ContentEntityForm {
     $form['community_affiliate_item'] = [
       '#type' => 'item',
       '#title' => $this->t('Community affiliates'),
-      '#description' => $this->t('The community affiliates role is designated for users who aren\'t part of the community but work with the community in some capacity that requires a level of access to community content. Community affiliates may be assigned other roles within the community and it\' protocols.'),
+      '#description' => $this->t('Community affiliates can view the community page and be added to protocols within the community. This is a designation for community partners.'),
       '#weight' => '1003',
       '#access' => $this->isDefaultFormLangcode($form_state),
     ];
@@ -117,7 +117,7 @@ class CommunityAddForm extends ContentEntityForm {
     $form['community_manager_item'] = [
       '#type' => 'item',
       '#title' => $this->t('Community managers'),
-      '#description' => $this->t('Community managers are responsible for managing membership in the community. They can manage the title, banner and thumbnail images, description, featured content, Local Contexts projects, and other display settings.'),
+      '#description' => $this->t('Community managers can manage community information and membership, and create new protocols.'),
       '#weight' => '1005',
       '#access' => $this->isDefaultFormLangcode($form_state),
     ];

--- a/modules/mukurtu_protocol/src/Form/CommunityAddForm.php
+++ b/modules/mukurtu_protocol/src/Form/CommunityAddForm.php
@@ -59,7 +59,7 @@ class CommunityAddForm extends ContentEntityForm {
     $form['community_member_item'] = [
       '#type' => 'item',
       '#title' => $this->t('Community members'),
-      '#description' => $this->t('Helper text about community members.'),
+      '#description' => $this->t('Community members have basic membership in the community. This role is assigned to all community members by default. If they have not been added to any protocols, they can view the community page and any public content.'),
       '#weight' => '1001',
       '#access' => $this->isDefaultFormLangcode($form_state),
     ];
@@ -88,7 +88,7 @@ class CommunityAddForm extends ContentEntityForm {
     $form['community_affiliate_item'] = [
       '#type' => 'item',
       '#title' => $this->t('Community affiliates'),
-      '#description' => $this->t('Helper text about community affiliates.'),
+      '#description' => $this->t('The community affiliates role is designated for users who aren\'t part of the community but work with the community in some capacity that requires a level of access to community content. Community affiliates may be assigned other roles within the community and it\' protocols.'),
       '#weight' => '1003',
       '#access' => $this->isDefaultFormLangcode($form_state),
     ];
@@ -117,7 +117,7 @@ class CommunityAddForm extends ContentEntityForm {
     $form['community_manager_item'] = [
       '#type' => 'item',
       '#title' => $this->t('Community managers'),
-      '#description' => $this->t('Helper text about community managers.'),
+      '#description' => $this->t('Community managers are responsible for managing membership in the community. They can manage the title, banner and thumbnail images, description, featured content, Local Contexts projects, and other display settings.'),
       '#weight' => '1005',
       '#access' => $this->isDefaultFormLangcode($form_state),
     ];

--- a/modules/mukurtu_protocol/src/Form/CommunityAddForm.php
+++ b/modules/mukurtu_protocol/src/Form/CommunityAddForm.php
@@ -43,7 +43,7 @@ class CommunityAddForm extends ContentEntityForm {
 
     foreach (Element::children($form) as $key) {
       if (!in_array($key, $allow_list)) {
-        $form[$key]['#access'] = FALSE;
+        unset($form[$key]);
       }
     }
 

--- a/modules/mukurtu_protocol/src/Form/CommunityForm.php
+++ b/modules/mukurtu_protocol/src/Form/CommunityForm.php
@@ -42,7 +42,7 @@ class CommunityForm extends ContentEntityForm {
         '#type' => 'checkbox',
         '#title' => $this->t('Create new revision'),
         '#default_value' => FALSE,
-        '#weight' => 10,
+        '#weight' => 50,
       ];
     }
 

--- a/modules/mukurtu_protocol/src/Form/ProtocolAddForm.php
+++ b/modules/mukurtu_protocol/src/Form/ProtocolAddForm.php
@@ -116,7 +116,7 @@ class ProtocolAddForm extends EntityForm {
     $form['field_membership_display'] = [
       '#type' => 'radios',
       '#title' => $this->t('Membership display'),
-      '#description' => $this->t('TODO: membership display helper text'),
+      '#description' => $this->t('Select which, if any, protocol members to display on the protocol page.'),
       '#options' => [
         'none' => $this->t('Do not display any protocol members'),
         'stewards' => $this->t('Only display cultural protocol stewards'),
@@ -132,7 +132,7 @@ class ProtocolAddForm extends EntityForm {
     $form['protocol_member_item'] = [
       '#type' => 'item',
       '#title' => $this->t('Protocol members'),
-      '#description' => $this->t('Helper text about protocol members.'),
+      '#description' => $this->t('Protocol members can view content but cannot add or edit content.'),
     ];
     $form['protocol_member'] = [
       '#type' => 'entity_browser',
@@ -158,7 +158,7 @@ class ProtocolAddForm extends EntityForm {
     $form['protocol_affiliate_item'] = [
       '#type' => 'item',
       '#title' => $this->t('Protocol affiliates'),
-      '#description' => $this->t('Helper text about protocol affiliates.'),
+      '#description' => $this->t('Protocol affiliates can view content but cannot add or edit. This is a designation for community partners that mirrors the community affiliate role.'),
     ];
     $form['protocol_affiliate'] = [
       '#type' => 'entity_browser',
@@ -184,7 +184,7 @@ class ProtocolAddForm extends EntityForm {
     $form['protocol_contributor_item'] = [
       '#type' => 'item',
       '#title' => $this->t('Contributors'),
-      '#description' => $this->t('Helper text about contributors.'),
+      '#description' => $this->t('Contributors can create, edit and delete their own digital heritage items, person records, place records, and media assets.'),
     ];
     $form['contributor'] = [
       '#type' => 'entity_browser',
@@ -210,7 +210,7 @@ class ProtocolAddForm extends EntityForm {
     $form['protocol_curator_item'] = [
       '#type' => 'item',
       '#title' => $this->t('Curators'),
-      '#description' => $this->t('Helper text about curators.'),
+      '#description' => $this->t('Curators can create, edit and delete their own collections and upload media assets.'),
     ];
     $form['curator'] = [
       '#type' => 'entity_browser',
@@ -236,7 +236,7 @@ class ProtocolAddForm extends EntityForm {
     $form['protocol_community_record_steward_item'] = [
       '#type' => 'item',
       '#title' => $this->t('Community record stewards'),
-      '#description' => $this->t('Helper text about community record stewards'),
+      '#description' => $this->t('Community record stewards can add community records to content, as well as edit and delete their community records.'),
     ];
     $form['community_record_steward'] = [
       '#type' => 'entity_browser',
@@ -262,7 +262,7 @@ class ProtocolAddForm extends EntityForm {
     $form['protocol_language_contributor_item'] = [
       '#type' => 'item',
       '#title' => $this->t('Language contributors'),
-      '#description' => $this->t('Helper text about language contributors.'),
+      '#description' => $this->t('Language contributors can add, edit and delete their own dictionary words and word lists.'),
     ];
     $form['language_contributor'] = [
       '#type' => 'entity_browser',
@@ -288,7 +288,7 @@ class ProtocolAddForm extends EntityForm {
     $form['protocol_language_steward_item'] = [
       '#type' => 'item',
       '#title' => $this->t('Language stewards'),
-      '#description' => $this->t('Helper text about language stewards.'),
+      '#description' => $this->t('Language stewards can add, edit and delete ALL dictionary words and word lists,and add media assets.'),
     ];
     $form['language_steward'] = [
       '#type' => 'entity_browser',
@@ -314,7 +314,7 @@ class ProtocolAddForm extends EntityForm {
     $form['protocol_steward_item'] = [
       '#type' => 'item',
       '#title' => $this->t('Protocol stewards'),
-      '#description' => $this->t('Helper text about protocol stewards.'),
+      '#description' => $this->t('Protocol stewards can manage protocol membership, add edit and delete ALL content and media assets, manage the look and feel of the protocol page, and manage Local Contexts projects.'),
     ];
     $defaultStatus = "<ul>";
     $defaultStatus .= "<li>{$currentUser->getAccountName()} ({$currentUser->getEmail()})</li>";

--- a/modules/mukurtu_protocol/src/Form/ProtocolForm.php
+++ b/modules/mukurtu_protocol/src/Form/ProtocolForm.php
@@ -42,7 +42,7 @@ class ProtocolForm extends ContentEntityForm {
         '#type' => 'checkbox',
         '#title' => $this->t('Create new revision'),
         '#default_value' => FALSE,
-        '#weight' => 10,
+        '#weight' => 50,
       ];
     }
 

--- a/mukurtu.info.yml
+++ b/mukurtu.info.yml
@@ -54,6 +54,7 @@ install:
   - genpass
   - rebuild_cache_access
   - notify_user_default
+  - readonly_field_widget
 
 dependencies:
   - 'blazy:blazy'
@@ -95,6 +96,7 @@ dependencies:
   - 'drupal:rebuild_cache_access'
   - 'drupal:genpass'
   - 'drupal:notify_user_default'
+  - 'drupal:readonly_field_widget'
   - 'embed:embed'
   - 'entity_browser:entity_browser'
   - 'entity_embed:entity_embed'


### PR DESCRIPTION
Closes #361 and updates protocol forms as well.

This update:

- [ ] Adds a new read only field widget module.
- [ ] Applies the new module to parent/child communities on community edit forms.
- [ ] Adds helper text to all community and protocol forms (create and edit for both)
- [ ] Adjusts weight of some form fields.

To review:

- [ ] Create a new community
- [ ] Create a new protocol
- [ ] Manage community organization and set at least one parent/child relationship
- [ ] Edit an existing community
- [ ] Edit an existing protocol
- [ ] Check that all fields have useful and accurate helper text, all fields appear or don't appear as expected, and that all associated actions and processes work.

Checklist:

- [x] I have checked for required update hooks.
- [x] I have applied required update hooks.
- [ ] I have checked for required changes to existing CI tests.
- [ ] I have checked for required new CI tests.
- [ ] I have update or created required CI tests.
- [x] I have verified that all expected checks pass.


