### PR TITLE
Block deletion of category terms referenced by digital heritage items

### DIFF
--- a/modules/mukurtu_taxonomy/mukurtu_taxonomy.module
+++ b/modules/mukurtu_taxonomy/mukurtu_taxonomy.module
@@ -92,6 +92,42 @@ if (isset($form['description'])) {
 }
 
 /**
+ * Implements hook_form_FORM_ID_alter() for taxonomy_term_category_delete_form.
+ *
+ * Prevents deletion of a category term that is referenced by digital
+ * heritage items, since field_category is a required field on those items.
+ */
+function mukurtu_taxonomy_form_taxonomy_term_category_delete_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $form_state, $form_id) {
+  $form['#validate'][] = 'mukurtu_taxonomy_category_term_delete_validate';
+}
+
+/**
+ * Validation handler: blocks category term deletion when DH items reference it.
+ */
+function mukurtu_taxonomy_category_term_delete_validate(&$form, \Drupal\Core\Form\FormStateInterface $form_state) {
+  /** @var \Drupal\taxonomy\TermInterface $term */
+  $term = $form_state->getFormObject()->getEntity();
+
+  $count = \Drupal::entityTypeManager()
+    ->getStorage('node')
+    ->getQuery()
+    ->condition('type', 'digital_heritage')
+    ->condition('field_category', $term->id())
+    ->accessCheck(FALSE)
+    ->count()
+    ->execute();
+
+  if ($count > 0) {
+    $form_state->setError($form, \Drupal::translation()->formatPlural(
+      $count,
+      'The category %name cannot be deleted because it is used by 1 digital heritage item.',
+      'The category %name cannot be deleted because it is used by @count digital heritage items.',
+      ['%name' => $term->label(), '@count' => $count]
+    ));
+  }
+}
+
+/**
  * Implements hook_form_form_id_alter().
  *
  * Change the description of the 'Terms to merge' form element for the


### PR DESCRIPTION
## Summary

- Adds a validation handler on the category taxonomy term delete confirmation form that prevents deletion when one or more digital heritage items reference the term
- Since `field_category` is a required field on digital heritage items, deleting a referenced term would silently leave those items in an invalid state (required field becomes empty, items fail validation on next save)
- Error message uses singular/plural and names the term being deleted

## What changed

**`modules/mukurtu_taxonomy/mukurtu_taxonomy.module`**

Added `hook_form_taxonomy_term_category_delete_form_alter()` to register a `#validate` callback, and `mukurtu_taxonomy_category_term_delete_validate()` which queries for digital heritage nodes referencing the term and sets a form error if any are found.

## Test plan

- [ ] Assign a category term to a digital heritage item
- [ ] Navigate to `/taxonomy/term/{tid}/delete` for that term — confirm the form shows an error and cannot be submitted
- [ ] Assign a second category to the DH item, remove the first, then retry deletion — confirm it now succeeds
- [ ] Test with a term used by multiple DH items to verify the plural message

🤖 Generated with [Claude Code](https://claude.com/claude-code)