### PR TITLE
Fix mukurtu_protocol_update_40003 calling protected SectionComponent::getConfiguration()

### DIFF
--- a/modules/mukurtu_protocol/mukurtu_protocol.install
+++ b/modules/mukurtu_protocol/mukurtu_protocol.install
@@ -227,7 +227,7 @@ function mukurtu_protocol_update_40003(): void {
 
     foreach ($sections as $section) {
       foreach ($section->getComponents() as $component) {
-        $config = $component->getConfiguration();
+        $config = $component->toArray()['configuration'] ?? [];
         if (($config['id'] ?? '') === 'views_block:browse_by_community-community_browse_block') {
           $component->setConfiguration([
             'id' => 'mukurtu_browse_by_community',


### PR DESCRIPTION
## Summary

- `mukurtu_protocol_update_40003` calls `SectionComponent::getConfiguration()`, which is a `protected` method — calling it from procedural (global) scope throws a fatal error, breaking `drush updb` for any site that has landing page nodes
- Fix replaces the call with `$component->toArray()['configuration']`, which returns identical data via the public API

## Test plan

- [ ] Run `drush updb` on a site with landing page nodes — update should complete without error
- [ ] Run `drush updb` on a site with no landing page nodes — update should complete without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)