### PR TITLE
Fully configuring Flat taxonomy

### DIFF
--- a/modules/mukurtu_core/config/install/taxonomy.vocabulary.category.yml
+++ b/modules/mukurtu_core/config/install/taxonomy.vocabulary.category.yml
@@ -6,3 +6,6 @@ vid: category
 description: 'The cultural categories to which digital content refers. Associating content with one or more categories facilitates browsing.'
 weight: 0
 new_revision: false
+third_party_settings:
+  flat_taxonomy:
+    flat: 1

--- a/modules/mukurtu_core/config/install/taxonomy.vocabulary.contributor.yml
+++ b/modules/mukurtu_core/config/install/taxonomy.vocabulary.contributor.yml
@@ -6,3 +6,6 @@ vid: contributor
 description: null
 weight: 0
 new_revision: false
+third_party_settings:
+  flat_taxonomy:
+    flat: 1

--- a/modules/mukurtu_core/config/install/taxonomy.vocabulary.creator.yml
+++ b/modules/mukurtu_core/config/install/taxonomy.vocabulary.creator.yml
@@ -6,3 +6,6 @@ vid: creator
 description: null
 weight: 0
 new_revision: false
+third_party_settings:
+  flat_taxonomy:
+    flat: 1

--- a/modules/mukurtu_core/config/install/taxonomy.vocabulary.format.yml
+++ b/modules/mukurtu_core/config/install/taxonomy.vocabulary.format.yml
@@ -6,3 +6,6 @@ vid: format
 description: null
 weight: 0
 new_revision: false
+third_party_settings:
+  flat_taxonomy:
+    flat: 1

--- a/modules/mukurtu_core/config/install/taxonomy.vocabulary.interpersonal_relationship.yml
+++ b/modules/mukurtu_core/config/install/taxonomy.vocabulary.interpersonal_relationship.yml
@@ -6,3 +6,6 @@ vid: interpersonal_relationship
 description: null
 weight: 0
 new_revision: false
+third_party_settings:
+  flat_taxonomy:
+    flat: 1

--- a/modules/mukurtu_core/config/install/taxonomy.vocabulary.keywords.yml
+++ b/modules/mukurtu_core/config/install/taxonomy.vocabulary.keywords.yml
@@ -6,3 +6,6 @@ vid: keywords
 description: null
 weight: 0
 new_revision: false
+third_party_settings:
+  flat_taxonomy:
+    flat: 1

--- a/modules/mukurtu_core/config/install/taxonomy.vocabulary.language.yml
+++ b/modules/mukurtu_core/config/install/taxonomy.vocabulary.language.yml
@@ -6,3 +6,6 @@ vid: language
 description: null
 weight: 0
 new_revision: false
+third_party_settings:
+  flat_taxonomy:
+    flat: 1

--- a/modules/mukurtu_core/config/install/taxonomy.vocabulary.location.yml
+++ b/modules/mukurtu_core/config/install/taxonomy.vocabulary.location.yml
@@ -6,3 +6,6 @@ vid: location
 description: null
 weight: 0
 new_revision: false
+third_party_settings:
+  flat_taxonomy:
+    flat: 1

--- a/modules/mukurtu_core/config/install/taxonomy.vocabulary.media_tag.yml
+++ b/modules/mukurtu_core/config/install/taxonomy.vocabulary.media_tag.yml
@@ -6,3 +6,6 @@ vid: media_tag
 description: 'Media tag vocabulary'
 weight: 0
 new_revision: false
+third_party_settings:
+  flat_taxonomy:
+    flat: 1

--- a/modules/mukurtu_core/config/install/taxonomy.vocabulary.people.yml
+++ b/modules/mukurtu_core/config/install/taxonomy.vocabulary.people.yml
@@ -6,3 +6,6 @@ vid: people
 description: null
 weight: 0
 new_revision: false
+third_party_settings:
+  flat_taxonomy:
+    flat: 1

--- a/modules/mukurtu_core/config/install/taxonomy.vocabulary.publisher.yml
+++ b/modules/mukurtu_core/config/install/taxonomy.vocabulary.publisher.yml
@@ -6,3 +6,6 @@ vid: publisher
 description: null
 weight: 0
 new_revision: false
+third_party_settings:
+  flat_taxonomy:
+    flat: 1

--- a/modules/mukurtu_core/config/install/taxonomy.vocabulary.subject.yml
+++ b/modules/mukurtu_core/config/install/taxonomy.vocabulary.subject.yml
@@ -6,3 +6,6 @@ vid: subject
 description: null
 weight: 0
 new_revision: false
+third_party_settings:
+  flat_taxonomy:
+    flat: 1

--- a/modules/mukurtu_core/config/install/taxonomy.vocabulary.type.yml
+++ b/modules/mukurtu_core/config/install/taxonomy.vocabulary.type.yml
@@ -6,3 +6,6 @@ vid: type
 description: null
 weight: 0
 new_revision: false
+third_party_settings:
+  flat_taxonomy:
+    flat: 1

--- a/modules/mukurtu_dictionary/config/install/taxonomy.vocabulary.word_type.yml
+++ b/modules/mukurtu_dictionary/config/install/taxonomy.vocabulary.word_type.yml
@@ -6,3 +6,6 @@ vid: word_type
 description: null
 weight: 0
 new_revision: false
+third_party_settings:
+  flat_taxonomy:
+    flat: 1

--- a/modules/mukurtu_protocol/config/install/taxonomy.vocabulary.community_type.yml
+++ b/modules/mukurtu_protocol/config/install/taxonomy.vocabulary.community_type.yml
@@ -6,3 +6,6 @@ vid: community_type
 description: null
 weight: 0
 new_revision: false
+third_party_settings:
+  flat_taxonomy:
+    flat: 1

--- a/modules/mukurtu_taxonomy/mukurtu_taxonomy.info.yml
+++ b/modules/mukurtu_taxonomy/mukurtu_taxonomy.info.yml
@@ -6,6 +6,7 @@ package: 'Mukurtu CMS'
 dependencies:
   - 'drupal:media'
   - 'drupal:node'
+  - 'flat_taxonomy:flat_taxonomy'
   - 'drupal:taxonomy'
   - 'drupal:text'
   - 'drupal:user'

--- a/modules/mukurtu_taxonomy/mukurtu_taxonomy.install
+++ b/modules/mukurtu_taxonomy/mukurtu_taxonomy.install
@@ -4,3 +4,55 @@
  * @file
  * Install, update and uninstall functions for the mukurtu_taxonomy module.
  */
+
+/**
+ * Enable flat_taxonomy and mark all stock Mukurtu vocabularies as flat.
+ */
+function mukurtu_taxonomy_update_40000(): void {
+  // Ensure the flat_taxonomy module is enabled.
+  \Drupal::service('module_installer')->install(['flat_taxonomy']);
+
+  $vids = [
+    'category',
+    'community_type',
+    'contributor',
+    'creator',
+    'format',
+    'interpersonal_relationship',
+    'keywords',
+    'language',
+    'location',
+    'media_tag',
+    'people',
+    'publisher',
+    'subject',
+    'type',
+    'word_type',
+  ];
+
+  $vocabulary_storage = \Drupal::entityTypeManager()->getStorage('taxonomy_vocabulary');
+
+  foreach ($vids as $vid) {
+    $vocabulary = $vocabulary_storage->load($vid);
+    if (!$vocabulary) {
+      continue;
+    }
+    $vocabulary->setThirdPartySetting('flat_taxonomy', 'flat', 1);
+    $vocabulary->save();
+
+    // Strip any existing parent relationships on terms in this vocabulary so
+    // live data matches the enforced flat structure.
+    $term_storage = \Drupal::entityTypeManager()->getStorage('taxonomy_term');
+    $tids = $term_storage->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('vid', $vid)
+      ->execute();
+
+    foreach ($term_storage->loadMultiple($tids) as $term) {
+      if (!empty($term->parent->target_id)) {
+        $term->parent = 0;
+        $term->save();
+      }
+    }
+  }
+}

--- a/modules/mukurtu_taxonomy/mukurtu_taxonomy.install
+++ b/modules/mukurtu_taxonomy/mukurtu_taxonomy.install
@@ -8,7 +8,7 @@
 /**
  * Enable flat_taxonomy and mark all stock Mukurtu vocabularies as flat.
  */
-function mukurtu_taxonomy_update_40000(): void {
+function mukurtu_taxonomy_update_40001(): void {
   // Ensure the flat_taxonomy module is enabled.
   \Drupal::service('module_installer')->install(['flat_taxonomy']);
 

--- a/modules/mukurtu_taxonomy/mukurtu_taxonomy.module
+++ b/modules/mukurtu_taxonomy/mukurtu_taxonomy.module
@@ -63,6 +63,48 @@ function mukurtu_taxonomy_entity_access(EntityInterface $entity, $operation, Acc
 }
 
 /**
+ * Implements hook_form_alter().
+ *
+ * Hides the entire "Relations" fieldset (parent terms + weight) on all stock
+ * Mukurtu taxonomy term forms. flat_taxonomy already hides only the parent
+ * field; hiding the whole block keeps the UI clean and consistent across all
+ * stock vocabs.
+ */
+function mukurtu_taxonomy_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $form_state, $form_id) {
+  static $mukurtu_vocabs = [
+    'category',
+    'community_type',
+    'contributor',
+    'creator',
+    'format',
+    'interpersonal_relationship',
+    'keywords',
+    'language',
+    'location',
+    'media_tag',
+    'people',
+    'publisher',
+    'subject',
+    'type',
+    'word_type',
+  ];
+
+  if (!str_starts_with($form_id, 'taxonomy_term_') || !str_ends_with($form_id, '_form')) {
+    return;
+  }
+
+  $vid = substr($form_id, strlen('taxonomy_term_'), -strlen('_form'));
+
+  if (!in_array($vid, $mukurtu_vocabs, TRUE)) {
+    return;
+  }
+
+  if (isset($form['relations'])) {
+    $form['relations']['#access'] = FALSE;
+  }
+}
+
+/**
  * Implements hook_form_form_id_alter().
  */
 function mukurtu_taxonomy_form_taxonomy_term_category_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $form_state, $form_id) {


### PR DESCRIPTION
resolves #1527  

Pre-merge checklist:

- [x] I have checked for and if required, created update hooks.
- [ ] I have recompiled SCSS if required.
- [ ] I have updated or created CI/CD tests, if required.
- [ ] I have updated from `main` and resolved any merge conflicts.
- [ ] I have verified that all expected checks pass.

How to Test: Flat Taxonomy for All Stock Vocabularies
Prerequisites
A running Mukurtu CMS instance with this branch checked out
composer install run to pull in drupal/flat_taxonomy
Drush available
1. Fresh install (new site)
Run a fresh install of Mukurtu CMS
Confirm the flat_taxonomy module is enabled: drush pm:list --status=enabled | grep flat
Go to Structure → Taxonomy and open any stock vocabulary (e.g. Keywords, Contributors, Location)
Click Edit on an existing term or Add term
Verify: There is no "Parent terms" field visible on the form
Verify: On the term listing page (overview), drag handles do not allow nesting — terms can only be reordered, not indented
Verify: There is no "Add child" link in term operation menus
Repeat steps 3–7 for at least 3 other vocabularies (e.g. Format, People, Subject)
2. Update hook on an existing site
Check out the branch on an existing Mukurtu install (pre-update)
Run composer install
Run drush updb -y
Verify: mukurtu_taxonomy_update_40000 runs without errors
Verify: flat_taxonomy module is now enabled: drush pm:list --status=enabled | grep flat
Verify: Each vocabulary now has the flat setting — check via Drush:

drush php:eval "foreach (['category','keywords','contributor','creator','format','interpersonal_relationship','language','location','media_tag','people','publisher','subject','type','word_type','community_type'] as \$vid) { \$v = \Drupal\taxonomy\Entity\Vocabulary::load(\$vid); echo \$vid . ': ' . (\$v ? \$v->getThirdPartySetting('flat_taxonomy', 'flat') : 'NOT FOUND') . PHP_EOL; }"
All 15 should print 1
Confirm the form and listing UI changes from Section 1 above apply to all vocabs
3. Data integrity (existing hierarchical terms)
Before running drush updb, manually create a child term in any stock vocabulary (e.g. give a Keyword term a parent)
Run drush updb -y
Verify: That term's parent has been stripped — it now appears as a root-level term
Check the Drupal watchdog for the flat_taxonomy warning log entry: drush watchdog:show | grep flat_taxonomy
4. Category-specific behavior (unchanged)
Go to Admin → Categories → Add category
Verify: The name field still shows the label "Category name" (not just "Name")
Verify: No "Parent terms" field is visible (now handled by flat_taxonomy rather than our custom code)
5. Non-stock vocabularies (should NOT be affected)
Create a custom vocabulary (e.g. "My Custom Vocab")
Add a term and verify: The "Parent terms" field IS visible — flat enforcement only applies to the 15 stock Mukurtu vocabs