### PR TITLE
Fix message_digest_ui fatal error and stale bulk actions for missing email_user flag

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -121,6 +121,9 @@
             },
             "drupal/search_api_glossary": {
                 "TypeError: Cannot access offset of type string on string": "web/profiles/mukurtu/patches/search_api_glossary_type-error-3492668-8.patch"
+            },
+            "drupal/message_digest_ui": {
+                "Fix null flag fatal error in DigestInterval::access()": "web/profiles/mukurtu/patches/message_digest_ui-digest-interval-null-flag.patch"
             }
         }
     }

--- a/modules/mukurtu_core/src/Hook/FormHooks.php
+++ b/modules/mukurtu_core/src/Hook/FormHooks.php
@@ -88,4 +88,31 @@ class FormHooks {
       }
     }
   }
+
+  /**
+   * Removes message_digest notification actions from the user admin bulk form.
+   *
+   * These come from message_digest_ui optional config and should not be
+   * exposed in Mukurtu's user management UI.
+   */
+  #[Hook('form_alter')]
+  public function formAlterRemoveNotificationBulkActions(array &$form, FormStateInterface $form_state, string $form_id): void {
+    if (!str_starts_with($form_id, 'views_form_user_admin_people_') &&
+        !str_starts_with($form_id, 'views_form_mukurtu_people_')) {
+      return;
+    }
+
+    $actions_to_remove = [
+      'message_digest_interval.email_user.immediate',
+      'message_digest_interval.email_user.daily',
+      'message_digest_interval.email_user.weekly',
+    ];
+
+    if (isset($form['header']['user_bulk_form']['action']['#options'])) {
+      foreach ($actions_to_remove as $action_id) {
+        unset($form['header']['user_bulk_form']['action']['#options'][$action_id]);
+      }
+    }
+  }
+
 }

--- a/mukurtu.install
+++ b/mukurtu.install
@@ -905,3 +905,18 @@ function mukurtu_update_40003(): void {
     ->save();
 }
 
+/**
+ * Remove message_digest bulk actions for the email_user flag, which does not
+ * exist in Mukurtu and caused fatal errors in Views bulk forms.
+ */
+function mukurtu_update_40004(): void {
+  $config_factory = \Drupal::configFactory();
+  $actions = [
+    'system.action.message_digest_interval.email_user.daily',
+    'system.action.message_digest_interval.email_user.immediate',
+    'system.action.message_digest_interval.email_user.weekly',
+  ];
+  foreach ($actions as $action) {
+    $config_factory->getEditable($action)->delete();
+  }
+}

--- a/patches/message_digest_ui-digest-interval-null-flag.patch
+++ b/patches/message_digest_ui-digest-interval-null-flag.patch
@@ -1,0 +1,91 @@
+--- /tmp/DigestInterval.php.orig	2026-04-18 18:08:39
++++ /Users/michael.wynne/ddev/mukurtu/web/modules/contrib/message_digest/message_digest_ui/src/Plugin/Action/DigestInterval.php	2026-04-18 18:08:51
+@@ -2,6 +2,7 @@
+ 
+ namespace Drupal\message_digest_ui\Plugin\Action;
+ 
++use Drupal\Core\Access\AccessResult;
+ use Drupal\Core\Action\ActionBase;
+ use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+ use Drupal\Core\Session\AccountInterface;
+@@ -59,6 +60,14 @@
+       // Get the flag by ID.
+       $this->flag = $this->flagService->getFlagById($configuration['flag_id']);
+     }
++    elseif (!empty($plugin_id)) {
++      // Derivative plugin IDs have the format base_id:flag_id:interval_id.
++      // Extract flag_id from the plugin ID when it's not in configuration.
++      $parts = explode(':', $plugin_id);
++      if (isset($parts[1])) {
++        $this->flag = $this->flagService->getFlagById($parts[1]);
++      }
++    }
+     $this->intervalPluginId = $configuration['value'];
+   }
+ 
+@@ -78,6 +87,9 @@
+    * {@inheritdoc}
+    */
+   public function access($object, AccountInterface $account = NULL, $return_as_object = FALSE) {
++    if (!$this->flag) {
++      return $return_as_object ? AccessResult::forbidden() : FALSE;
++    }
+     $result = $this->flag->actionAccess('flag', $account, $object);
+     return $return_as_object ? $result : $result->isAllowed();
+   }
+--- /tmp/DigestIntervalActionDeriver.php.orig	2026-04-18 18:15:14
++++ /Users/michael.wynne/ddev/mukurtu/web/modules/contrib/message_digest/message_digest_ui/src/Plugin/Derivative/DigestIntervalActionDeriver.php	2026-04-18 18:15:32
+@@ -5,6 +5,7 @@
+ use Drupal\Component\Plugin\Derivative\DeriverBase;
+ use Drupal\Core\Plugin\Discovery\ContainerDeriverInterface;
+ use Drupal\Core\StringTranslation\StringTranslationTrait;
++use Drupal\flag\FlagServiceInterface;
+ use Drupal\message_digest\Plugin\Notifier\DigestInterface;
+ use Drupal\message_notify\Plugin\Notifier\Manager;
+ use Symfony\Component\DependencyInjection\ContainerInterface;
+@@ -31,13 +32,23 @@
+   protected $subscribeManager;
+ 
+   /**
++   * The flag service.
++   *
++   * @var \Drupal\flag\FlagServiceInterface
++   */
++  protected $flagService;
++
++  /**
+    * Constructs the action deriver.
+    *
+    * @param \Drupal\message_notify\Plugin\Notifier\Manager $message_notifier
+    *   The notifier plugin manager.
++   * @param \Drupal\flag\FlagServiceInterface $flag_service
++   *   The flag service.
+    */
+-  public function __construct(Manager $message_notifier) {
++  public function __construct(Manager $message_notifier, FlagServiceInterface $flag_service) {
+     $this->messageNotifier = $message_notifier;
++    $this->flagService = $flag_service;
+   }
+ 
+   /**
+@@ -45,7 +56,8 @@
+    */
+   public static function create(ContainerInterface $container, $base_plugin_id) {
+     return new static(
+-      $container->get('plugin.message_notify.notifier.manager')
++      $container->get('plugin.message_notify.notifier.manager'),
++      $container->get('flag')
+     );
+   }
+ 
+@@ -61,6 +73,10 @@
+       'email_user' => 'user',
+     ];
+     foreach ($flags as $flag_id => $entity_type_id) {
++      // Skip if the flag doesn't exist on this site.
++      if (!$this->flagService->getFlagById($flag_id)) {
++        continue;
++      }
+       // Create a set of actions for each email flag/entity combination.
+       $plugin = [
+         'type' => $entity_type_id,


### PR DESCRIPTION
Closes https://github.com/MukurtuCMS/Mukurtu-CMS/issues/1239

In the end I don't think that's a neccessary set of bulk options and removed them instead.

## Summary

- `DigestInterval::access()` was calling `->actionAccess()` on a null `$flag` property, causing a fatal error when a Views bulk form action was submitted. The constructor only loaded the flag from `$configuration['flag_id']`, but the deriver never sets that key — so the flag was never loaded.
- The `DigestIntervalActionDeriver` hardcodes `email_user` as one of the three flags to create action derivatives for, but that flag does not exist in Mukurtu. This caused actions like "Send notifications immediately on User X" to appear in bulk forms and then fail with an access error.

## Changes

- **Patch (`DigestInterval`)**: Extract `flag_id` from the derivative plugin ID when it's not in configuration; add null guard in `access()` to prevent the fatal error
- **Patch (`DigestIntervalActionDeriver`)**: Inject the flag service and skip creating derivatives for flags that don't exist on the site
- **`mukurtu_update_40004`**: Deletes the three `system.action.message_digest_interval.email_user.*` config entities already stored on existing sites

## Test plan

- [ ] Run `drush updb` and confirm update hook 40004 runs cleanly
- [ ] Confirm "Send notifications immediately/daily/weekly on User" actions no longer appear in the Users view bulk actions
- [ ] Confirm digest interval bulk actions still work correctly on nodes and taxonomy terms
- [ ] Confirm no fatal errors in Drupal logs related to `DigestInterval`

🤖 Generated with [Claude Code](https://claude.com/claude-code)