### PR TITLE
Reorder roles on protocol and community members/add forms

### DIFF
--- a/config/install/og.og_role.community-community-community_affiliate.yml
+++ b/config/install/og.og_role.community-community-community_affiliate.yml
@@ -5,7 +5,7 @@ dependencies:
     - mukurtu_protocol
 id: community-community-community_affiliate
 label: 'Community Affiliate'
-weight: 17
+weight: 2
 is_admin: null
 group_type: community
 group_bundle: community

--- a/config/install/og.og_role.community-community-community_member.yml
+++ b/config/install/og.og_role.community-community-community_member.yml
@@ -5,7 +5,7 @@ dependencies:
     - mukurtu_protocol
 id: community-community-community_member
 label: 'Community Member'
-weight: 15
+weight: 1
 is_admin: null
 group_type: community
 group_bundle: community

--- a/config/install/og.og_role.protocol-protocol-community_record_steward.yml
+++ b/config/install/og.og_role.protocol-protocol-community_record_steward.yml
@@ -5,7 +5,7 @@ dependencies:
     - mukurtu_protocol
 id: protocol-protocol-community_record_steward
 label: 'Community Record Steward'
-weight: 9
+weight: 5
 is_admin: null
 group_type: protocol
 group_bundle: protocol

--- a/config/install/og.og_role.protocol-protocol-contributor.yml
+++ b/config/install/og.og_role.protocol-protocol-contributor.yml
@@ -5,7 +5,7 @@ dependencies:
     - mukurtu_protocol
 id: protocol-protocol-contributor
 label: Contributor
-weight: 8
+weight: 3
 is_admin: null
 group_type: protocol
 group_bundle: protocol

--- a/config/install/og.og_role.protocol-protocol-curator.yml
+++ b/config/install/og.og_role.protocol-protocol-curator.yml
@@ -5,7 +5,7 @@ dependencies:
     - mukurtu_protocol
 id: protocol-protocol-curator
 label: Curator
-weight: 9
+weight: 4
 is_admin: null
 group_type: protocol
 group_bundle: protocol

--- a/config/install/og.og_role.protocol-protocol-language_contributor.yml
+++ b/config/install/og.og_role.protocol-protocol-language_contributor.yml
@@ -5,7 +5,7 @@ dependencies:
     - mukurtu_protocol
 id: protocol-protocol-language_contributor
 label: 'Language Contributor'
-weight: 8
+weight: 6
 is_admin: null
 group_type: protocol
 group_bundle: protocol

--- a/config/install/og.og_role.protocol-protocol-language_steward.yml
+++ b/config/install/og.og_role.protocol-protocol-language_steward.yml
@@ -5,7 +5,7 @@ dependencies:
     - mukurtu_protocol
 id: protocol-protocol-language_steward
 label: 'Language Steward'
-weight: 8
+weight: 7
 is_admin: null
 group_type: protocol
 group_bundle: protocol

--- a/config/install/og.og_role.protocol-protocol-protocol_affiliate.yml
+++ b/config/install/og.og_role.protocol-protocol-protocol_affiliate.yml
@@ -5,7 +5,7 @@ dependencies:
     - mukurtu_protocol
 id: protocol-protocol-protocol_affiliate
 label: 'Protocol Affiliate'
-weight: 14
+weight: 2
 is_admin: null
 group_type: protocol
 group_bundle: protocol

--- a/config/install/og.og_role.protocol-protocol-protocol_member.yml
+++ b/config/install/og.og_role.protocol-protocol-protocol_member.yml
@@ -5,7 +5,7 @@ dependencies:
     - mukurtu_protocol
 id: protocol-protocol-protocol_member
 label: 'Protocol Member'
-weight: 12
+weight: 1
 is_admin: null
 group_type: protocol
 group_bundle: protocol

--- a/config/install/og.og_role.protocol-protocol-protocol_steward.yml
+++ b/config/install/og.og_role.protocol-protocol-protocol_steward.yml
@@ -5,7 +5,7 @@ dependencies:
     - mukurtu_protocol
 id: protocol-protocol-protocol_steward
 label: 'Protocol Steward'
-weight: 7
+weight: 8
 is_admin: null
 group_type: protocol
 group_bundle: protocol

--- a/modules/mukurtu_protocol/config/install/og.og_role.community-community-community_manager.yml
+++ b/modules/mukurtu_protocol/config/install/og.og_role.community-community-community_manager.yml
@@ -5,7 +5,7 @@ dependencies:
     - mukurtu_protocol
 id: community-community-community_manager
 label: 'Community Manager'
-weight: 13
+weight: 3
 is_admin: null
 group_type: community
 group_bundle: community

--- a/modules/mukurtu_protocol/mukurtu_protocol.install
+++ b/modules/mukurtu_protocol/mukurtu_protocol.install
@@ -266,3 +266,29 @@ function mukurtu_protocol_update_40004(): void {
     $config->set('hidden', $hidden);
   }
 }
+
+/**
+ * Reorder protocol and community roles to match the creation forms.
+ */
+function mukurtu_protocol_update_40005(): void {
+  $role_weights = [
+    'protocol-protocol-protocol_member' => 1,
+    'protocol-protocol-protocol_affiliate' => 2,
+    'protocol-protocol-contributor' => 3,
+    'protocol-protocol-curator' => 4,
+    'protocol-protocol-community_record_steward' => 5,
+    'protocol-protocol-language_contributor' => 6,
+    'protocol-protocol-language_steward' => 7,
+    'protocol-protocol-protocol_steward' => 8,
+    'community-community-community_member' => 1,
+    'community-community-community_affiliate' => 2,
+    'community-community-community_manager' => 3,
+  ];
+
+  foreach ($role_weights as $role_id => $weight) {
+    $config = \Drupal::configFactory()->getEditable("og.og_role.$role_id");
+    if (!$config->isNew()) {
+      $config->set('weight', $weight)->save();
+    }
+  }
+}

--- a/modules/mukurtu_protocol/mukurtu_protocol.module
+++ b/modules/mukurtu_protocol/mukurtu_protocol.module
@@ -690,12 +690,25 @@ function mukurtu_protocol_form_og_membership_form_alter(&$form, FormStateInterfa
   // Make roles field required on og forms.
   $form['roles']['widget']['#required'] = TRUE;
 
+  $group = \Drupal::requestStack()->getCurrentRequest()->attributes->get('group');
+
   // Add validation to prevent users from being added to protocols without
   // adding them first to the protocol owning communities.
-  $group = \Drupal::requestStack()->getCurrentRequest()->attributes->get('group');
   if ($group instanceof ProtocolInterface) {
-    // Only add the form validator if this form is in the protocol context.
     $form['#validate'][] = 'add_protocol_member_form_validate';
+  }
+
+  // Sort roles checkboxes by weight for both protocol and community forms.
+  if (($group instanceof ProtocolInterface || $group instanceof CommunityInterface) && !empty($form['roles']['widget']['#options'])) {
+    $role_storage = \Drupal::entityTypeManager()->getStorage('og_role');
+    $options = $form['roles']['widget']['#options'];
+    $weights = [];
+    foreach (array_keys($options) as $role_id) {
+      $role = $role_storage->load($role_id);
+      $weights[$role_id] = $role ? $role->getWeight() : 99;
+    }
+    asort($weights);
+    $form['roles']['widget']['#options'] = array_replace($weights, $options);
   }
 }
 


### PR DESCRIPTION
Fixes #1090

## Summary
- Reorders protocol roles on `/admin/protocols/{id}/members/add` to: Protocol Member, Protocol Affiliate, Contributor, Curator, Community Record Steward, Language Contributor, Language Steward, Protocol Steward
- Reorders community roles on `/admin/communities/{id}/members/add` to: Community Member, Community Affiliate, Community Manager
- Sorting is applied in `hook_form_og_membership_form_alter` by loading each role's weight from config — the `options_buttons` widget does not respect weight natively
- Updated role config weights and added `mukurtu_protocol_update_40005` for existing installs

## Test plan
- [ ] Visit `/admin/protocols/{id}/members/add` and confirm role order matches: Protocol Member, Protocol Affiliate, Contributor, Curator, Community Record Steward, Language Contributor, Language Steward, Protocol Steward
- [ ] Visit `/admin/communities/{id}/members/add` and confirm role order matches: Community Member, Community Affiliate, Community Manager
- [ ] Run `drush updb` on an existing install and confirm roles are reordered

🤖 Generated with [Claude Code](https://claude.com/claude-code)