### PR TITLE
Change role select to checkboxes in bulk operations (#1221)

### DIFF
--- a/modules/mukurtu_protocol/mukurtu_protocol.module
+++ b/modules/mukurtu_protocol/mukurtu_protocol.module
@@ -699,6 +699,28 @@ function mukurtu_protocol_form_og_membership_form_alter(&$form, FormStateInterfa
   }
 }
 
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function mukurtu_protocol_form_og_membership_add_multiple_roles_action_form_alter(&$form, FormStateInterface $form_state) {
+  $form['roles']['#type'] = 'checkboxes';
+  unset($form['roles']['#multiple']);
+  $form['#validate'][] = 'mukurtu_protocol_og_add_roles_form_validate';
+  array_unshift($form['#submit'], 'mukurtu_protocol_og_add_roles_form_pre_submit');
+}
+
+function mukurtu_protocol_og_add_roles_form_validate(&$form, FormStateInterface $form_state) {
+  $roles = array_filter($form_state->getValue('roles'));
+  if (empty($roles)) {
+    $form_state->setErrorByName('roles', t('Please select at least one role.'));
+  }
+}
+
+function mukurtu_protocol_og_add_roles_form_pre_submit(&$form, FormStateInterface $form_state) {
+  $roles = array_filter($form_state->getValue('roles'));
+  $form_state->setValue('roles', $roles);
+}
+
 function add_protocol_member_form_validate(&$form, FormStateInterface $form_state)
 {
   $uid = isset($form_state->getValue('uid')[0]['target_id']) ? $form_state->getValue('uid')[0]['target_id'] : NULL;


### PR DESCRIPTION
## Summary

- Adds a `hook_form_FORM_ID_alter` targeting OG's `og_membership_add_multiple_roles_action_form`
- Changes the roles field from a multi-select (`#type => select, #multiple => TRUE`) to checkboxes
- Adds a validation handler to require at least one checkbox be checked
- Adds a pre-submit handler to filter unchecked values before OG's submit handler runs

Closes #1221

## Test plan

- [ ] Navigate to a group members overview and select one or more members
- [ ] Choose "Add roles" from the bulk operations dropdown
- [ ] Confirm the roles field renders as checkboxes instead of a multi-select
- [ ] Verify submitting with no roles checked shows a validation error
- [ ] Verify selecting roles and submitting correctly assigns those roles to the selected members

🤖 Generated with [Claude Code](https://claude.com/claude-code)