### PR TITLE
Add user memberships and roles view (#451)

### DIFF
--- a/modules/mukurtu_core/src/MukurtuUserListBuilder.php
+++ b/modules/mukurtu_core/src/MukurtuUserListBuilder.php
@@ -3,6 +3,7 @@
 namespace Drupal\mukurtu_core;
 
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Url;
 use Drupal\user\RoleInterface;
 use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\user\Entity\Role;
@@ -93,6 +94,19 @@ class MukurtuUserListBuilder extends \Drupal\user\UserListBuilder {
       $row['access']['data']['#markup'] = t('never');
     }
     return $row + parent::buildRow($entity);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getOperations(EntityInterface $entity) {
+    $operations = parent::getOperations($entity);
+    $operations['memberships'] = [
+      'title' => $this->t('Memberships'),
+      'url' => Url::fromRoute('mukurtu_protocol.user_memberships', ['user' => $entity->id()]),
+      'weight' => 20,
+    ];
+    return $operations;
   }
 
   protected function getUserCommunities($account) {

--- a/modules/mukurtu_protocol/mukurtu_protocol.links.menu.yml
+++ b/modules/mukurtu_protocol/mukurtu_protocol.links.menu.yml
@@ -95,3 +95,9 @@ mukurtu_protocol.protocol_create:
   description: 'Add a new cultural protocol.'
   route_name: mukurtu_protocol.protocol_create
 
+mukurtu_protocol.my_memberships_dashboard:
+  title: 'My memberships'
+  description: 'View my community and protocol memberships.'
+  menu_name: dashboard-my-content
+  route_name: mukurtu_protocol.my_memberships
+

--- a/modules/mukurtu_protocol/mukurtu_protocol.routing.yml
+++ b/modules/mukurtu_protocol/mukurtu_protocol.routing.yml
@@ -220,3 +220,26 @@ mukurtu_protocol.protocol_create:
     _title: 'Add cultural protocol'
   requirements:
     _permission: 'add protocol entities'
+
+mukurtu_protocol.my_memberships:
+  path: '/user/memberships'
+  defaults:
+    _controller: '\Drupal\mukurtu_protocol\Controller\UserMembershipsController::content'
+    _title: 'My Memberships'
+  options:
+    _admin_route: TRUE
+  requirements:
+    _user_is_logged_in: 'TRUE'
+
+mukurtu_protocol.user_memberships:
+  path: '/user/{user}/memberships'
+  defaults:
+    _controller: '\Drupal\mukurtu_protocol\Controller\UserMembershipsController::contentForUser'
+    _title_callback: '\Drupal\mukurtu_protocol\Controller\UserMembershipsController::title'
+  options:
+    _admin_route: TRUE
+    parameters:
+      user:
+        type: entity:user
+  requirements:
+    _custom_access: '\Drupal\mukurtu_protocol\Controller\UserMembershipsController::access'

--- a/modules/mukurtu_protocol/src/Controller/UserMembershipsController.php
+++ b/modules/mukurtu_protocol/src/Controller/UserMembershipsController.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Drupal\mukurtu_protocol\Controller;
+
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\og\Og;
+use Drupal\user\UserInterface;
+
+class UserMembershipsController extends ControllerBase {
+
+  public function content() {
+    $user = $this->entityTypeManager()->getStorage('user')->load($this->currentUser()->id());
+    return $this->buildPage($user);
+  }
+
+  public function contentForUser(UserInterface $user) {
+    return $this->buildPage($user);
+  }
+
+  public function access(AccountInterface $account, UserInterface $user) {
+    if ($account->id() == $user->id()) {
+      return AccessResult::allowedIf($account->isAuthenticated())->cachePerUser();
+    }
+    return AccessResult::allowedIfHasPermission($account, 'administer users')->cachePerPermissions();
+  }
+
+  public function title(UserInterface $user) {
+    $display_name = $user->get('field_display_name')->value ?: $user->getAccountName();
+    return $this->t("@name's Memberships", ['@name' => $display_name]);
+  }
+
+  protected function buildPage(UserInterface $user) {
+    $all_memberships = Og::getMemberships($user);
+
+    $community_memberships = array_filter($all_memberships, fn($m) => $m->getGroupBundle() === 'community');
+    $protocol_memberships_by_id = [];
+    foreach (array_filter($all_memberships, fn($m) => $m->getGroupBundle() === 'protocol') as $pm) {
+      $group = $pm->getGroup();
+      if ($group) {
+        $protocol_memberships_by_id[$group->id()] = $pm;
+      }
+    }
+
+    $assigned_protocol_ids = [];
+    $communities = [];
+
+    foreach ($community_memberships as $cm) {
+      $community = $cm->getGroup();
+      if (!$community) {
+        continue;
+      }
+
+      $community_roles = array_values(array_map(
+        fn($r) => $r->label(),
+        array_filter($cm->getRoles(), fn($r) => !in_array($r->getName(), ['member', 'non-member']))
+      ));
+
+      $protocols_in_community = [];
+      foreach (array_keys($protocol_memberships_by_id) as $protocol_id) {
+        $pm = $protocol_memberships_by_id[$protocol_id];
+        $protocol = $pm->getGroup();
+        if (!$protocol) {
+          continue;
+        }
+        $protocol_community_ids = array_map(fn($c) => $c->id(), $protocol->getCommunities());
+        if (in_array($community->id(), $protocol_community_ids)) {
+          $protocol_roles = array_values(array_map(
+            fn($r) => $r->label(),
+            array_filter($pm->getRoles(), fn($r) => !in_array($r->getName(), ['member', 'non-member']))
+          ));
+          $protocols_in_community[] = [
+            'name' => $protocol->label(),
+            'url' => $protocol->toUrl()->toString(),
+            'roles' => $protocol_roles,
+          ];
+          $assigned_protocol_ids[] = $protocol_id;
+        }
+      }
+
+      $communities[] = [
+        'name' => $community->label(),
+        'url' => $community->toUrl()->toString(),
+        'roles' => $community_roles,
+        'protocols' => $protocols_in_community,
+      ];
+    }
+
+    $orphan_protocols = [];
+    foreach ($protocol_memberships_by_id as $protocol_id => $pm) {
+      if (in_array($protocol_id, $assigned_protocol_ids)) {
+        continue;
+      }
+      $protocol = $pm->getGroup();
+      if (!$protocol) {
+        continue;
+      }
+      $protocol_roles = array_values(array_map(
+        fn($r) => $r->label(),
+        array_filter($pm->getRoles(), fn($r) => !in_array($r->getName(), ['member', 'non-member']))
+      ));
+      $orphan_protocols[] = [
+        'name' => $protocol->label(),
+        'url' => $protocol->toUrl()->toString(),
+        'roles' => $protocol_roles,
+      ];
+    }
+
+    return [
+      '#theme' => 'mukurtu_user_memberships',
+      '#communities' => $communities,
+      '#orphan_protocols' => $orphan_protocols,
+      '#user' => $user,
+    ];
+  }
+
+}

--- a/modules/mukurtu_protocol/src/Hook/MukurtuProtocolHooks.php
+++ b/modules/mukurtu_protocol/src/Hook/MukurtuProtocolHooks.php
@@ -65,6 +65,13 @@ class MukurtuProtocolHooks {
           'items' => [],
         ],
       ],
+      'mukurtu_user_memberships' => [
+        'variables' => [
+          'communities' => [],
+          'orphan_protocols' => [],
+          'user' => NULL,
+        ],
+      ],
     ];
   }
 

--- a/modules/mukurtu_protocol/templates/mukurtu-user-memberships.html.twig
+++ b/modules/mukurtu_protocol/templates/mukurtu-user-memberships.html.twig
@@ -1,0 +1,74 @@
+{#
+/**
+ * @file
+ * Template for the user memberships page.
+ *
+ * Available variables:
+ * - communities: List of community membership items, each with:
+ *   - name: Community label string.
+ *   - url: Community canonical URL string.
+ *   - roles: Array of role label strings.
+ *   - protocols: List of protocol membership items within this community, each with:
+ *     - name: Protocol label string.
+ *     - url: Protocol canonical URL string.
+ *     - roles: Array of role label strings.
+ * - orphan_protocols: Protocol memberships not under any of the user's communities.
+ * - user: The user entity whose memberships are displayed.
+ */
+#}
+<div class="mukurtu-user-memberships">
+  {% if communities is empty and orphan_protocols is empty %}
+    <p>{{ 'You are not a member of any communities or cultural protocols.'|t }}</p>
+  {% else %}
+    <table class="views-table cols-4">
+      <thead>
+        <tr>
+          <th>{{ 'Community'|t }}</th>
+          <th>{{ 'Community Role(s)'|t }}</th>
+          <th>{{ 'Cultural Protocol'|t }}</th>
+          <th>{{ 'Protocol Role(s)'|t }}</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for item in communities %}
+          {% set rowspan = item.protocols|length > 0 ? item.protocols|length : 1 %}
+          {% for protocol_item in item.protocols %}
+            <tr>
+              {% if loop.first %}
+                <td rowspan="{{ rowspan }}">
+                  <a href="{{ item.url }}">{{ item.name }}</a>
+                </td>
+                <td rowspan="{{ rowspan }}">
+                  {{ item.roles|join(', ') ?: '—' }}
+                </td>
+              {% endif %}
+              <td><a href="{{ protocol_item.url }}">{{ protocol_item.name }}</a></td>
+              <td>{{ protocol_item.roles|join(', ') ?: '—' }}</td>
+            </tr>
+          {% else %}
+            <tr>
+              <td><a href="{{ item.url }}">{{ item.name }}</a></td>
+              <td>{{ item.roles|join(', ') ?: '—' }}</td>
+              <td>—</td>
+              <td>—</td>
+            </tr>
+          {% endfor %}
+        {% endfor %}
+
+        {% if orphan_protocols is not empty %}
+          <tr>
+            <td colspan="4"><strong>{{ 'Other Cultural Protocol Memberships'|t }}</strong></td>
+          </tr>
+          {% for protocol_item in orphan_protocols %}
+            <tr>
+              <td>—</td>
+              <td>—</td>
+              <td><a href="{{ protocol_item.url }}">{{ protocol_item.name }}</a></td>
+              <td>{{ protocol_item.roles|join(', ') ?: '—' }}</td>
+            </tr>
+          {% endfor %}
+        {% endif %}
+      </tbody>
+    </table>
+  {% endif %}
+</div>


### PR DESCRIPTION
## Summary

- Adds `/user/memberships` (dashboard, current user) and `/user/{uid}/memberships` (owner or admin) pages showing a hierarchical table of all community and protocol memberships with roles
- Adds a "My memberships" link to the dashboard's "My Content" menu
- Adds a "Memberships" operation to each row on `/admin/people` for quick admin access

## Test plan

- [ ] Log in as a user with community/protocol memberships → dashboard "My Content" → "My memberships" shows correct communities, roles, and nested protocols
- [ ] Log in as admin → `/admin/people` → Operations dropdown → "Memberships" opens the correct user's page
- [ ] Admin can view `/user/{uid}/memberships` for any user; non-admin cannot view another user's page (403)
- [ ] A user with no memberships sees the empty-state message
- [ ] A protocol belonging to multiple communities appears under each community the user is a member of

Closes #451

🤖 Generated with [Claude Code](https://claude.com/claude-code)