### PR TITLE
Index PDF extracted text in content search

### DIFF
--- a/modules/mukurtu_browse/config/install/search_api.index.mukurtu_default_content_index.yml
+++ b/modules/mukurtu_browse/config/install/search_api.index.mukurtu_default_content_index.yml
@@ -154,6 +154,27 @@ field_settings:
     indexed_locked: true
     type_locked: true
     hidden: true
+  media_extracted_text:
+    label: 'Media Assets Extracted Text'
+    datasource_id: 'entity:node'
+    property_path: 'field_media_assets:entity:field_extracted_text'
+    type: text
+    dependencies:
+      module:
+        - media
+        - mukurtu_media
+        - node
+  page_media_extracted_text:
+    label: 'Page Media Assets Extracted Text'
+    datasource_id: 'entity:node'
+    property_path: 'field_page_media_assets:entity:field_extracted_text'
+    type: text
+    dependencies:
+      config:
+        - field.storage.node.field_page_media_assets
+      module:
+        - media
+        - mukurtu_media
   media_type:
     label: 'Media Assets » Media » Media type'
     datasource_id: 'entity:node'
@@ -277,7 +298,7 @@ processor_settings:
   glossary:
     weights:
       preprocess_index: -20
-    glossarytable: 'a:1:{s:13:"glossarytable";a:24:{s:11:"collections";a:2:{s:8:"grouping";a:3:{s:14:"grouping_other";s:14:"grouping_other";s:11:"grouping_az";i:0;s:11:"grouping_09";i:0;}s:8:"glossary";i:0;}s:15:"community_title";a:2:{s:8:"grouping";a:3:{s:14:"grouping_other";s:14:"grouping_other";s:11:"grouping_az";i:0;s:11:"grouping_09";i:0;}s:8:"glossary";i:0;}s:16:"contributor_name";a:2:{s:8:"grouping";a:3:{s:14:"grouping_other";s:14:"grouping_other";s:11:"grouping_az";i:0;s:11:"grouping_09";i:0;}s:8:"glossary";i:0;}s:12:"creator_name";a:2:{s:8:"grouping";a:3:{s:14:"grouping_other";s:14:"grouping_other";s:11:"grouping_az";i:0;s:11:"grouping_09";i:0;}s:8:"glossary";i:0;}s:14:"field_coverage";a:2:{s:8:"grouping";a:3:{s:14:"grouping_other";s:14:"grouping_other";s:11:"grouping_az";i:0;s:11:"grouping_09";i:0;}s:8:"glossary";i:0;}s:26:"field_coverage_description";a:2:{s:8:"grouping";a:3:{s:14:"grouping_other";s:14:"grouping_other";s:11:"grouping_az";i:0;s:11:"grouping_09";i:0;}s:8:"glossary";i:0;}s:24:"field_cultural_narrative";a:2:{s:8:"grouping";a:3:{s:14:"grouping_other";s:14:"grouping_other";s:11:"grouping_az";i:0;s:11:"grouping_09";i:0;}s:8:"glossary";i:0;}s:22:"field_date_description";a:2:{s:8:"grouping";a:3:{s:14:"grouping_other";s:14:"grouping_other";s:11:"grouping_az";i:0;s:11:"grouping_09";i:0;}s:8:"glossary";i:0;}s:17:"field_description";a:2:{s:8:"grouping";a:3:{s:14:"grouping_other";s:14:"grouping_other";s:11:"grouping_az";i:0;s:11:"grouping_09";i:0;}s:8:"glossary";i:0;}s:16:"field_identifier";a:2:{s:8:"grouping";a:3:{s:14:"grouping_other";s:14:"grouping_other";s:11:"grouping_az";i:0;s:11:"grouping_09";i:0;}s:8:"glossary";i:0;}s:23:"field_rights_statements";a:2:{s:8:"grouping";a:3:{s:14:"grouping_other";s:14:"grouping_other";s:11:"grouping_az";i:0;s:11:"grouping_09";i:0;}s:8:"glossary";i:0;}s:12:"field_source";a:2:{s:8:"grouping";a:3:{s:14:"grouping_other";s:14:"grouping_other";s:11:"grouping_az";i:0;s:11:"grouping_09";i:0;}s:8:"glossary";i:0;}s:13:"field_summary";a:2:{s:8:"grouping";a:3:{s:14:"grouping_other";s:14:"grouping_other";s:11:"grouping_az";i:0;s:11:"grouping_09";i:0;}s:8:"glossary";i:0;}s:27:"field_traditional_knowledge";a:2:{s:8:"grouping";a:3:{s:14:"grouping_other";s:14:"grouping_other";s:11:"grouping_az";i:0;s:11:"grouping_09";i:0;}s:8:"glossary";i:0;}s:19:"field_transcription";a:2:{s:8:"grouping";a:3:{s:14:"grouping_other";s:14:"grouping_other";s:11:"grouping_az";i:0;s:11:"grouping_09";i:0;}s:8:"glossary";i:0;}s:10:"media_type";a:2:{s:8:"grouping";a:3:{s:14:"grouping_other";s:14:"grouping_other";s:11:"grouping_az";i:0;s:11:"grouping_09";i:0;}s:8:"glossary";i:0;}s:4:"name";a:2:{s:8:"grouping";a:3:{s:14:"grouping_other";s:14:"grouping_other";s:11:"grouping_az";i:0;s:11:"grouping_09";i:0;}s:8:"glossary";i:0;}s:6:"name_1";a:2:{s:8:"grouping";a:3:{s:14:"grouping_other";s:14:"grouping_other";s:11:"grouping_az";i:0;s:11:"grouping_09";i:0;}s:8:"glossary";i:0;}s:13:"original_date";a:2:{s:8:"grouping";a:3:{s:14:"grouping_other";s:14:"grouping_other";s:11:"grouping_az";i:0;s:11:"grouping_09";i:0;}s:8:"glossary";i:0;}s:11:"people_name";a:2:{s:8:"grouping";a:3:{s:14:"grouping_other";s:14:"grouping_other";s:11:"grouping_az";i:0;s:11:"grouping_09";i:0;}s:8:"glossary";i:0;}s:12:"subject_name";a:2:{s:8:"grouping";a:3:{s:14:"grouping_other";s:14:"grouping_other";s:11:"grouping_az";i:0;s:11:"grouping_09";i:0;}s:8:"glossary";i:0;}s:5:"title";a:2:{s:8:"glossary";s:1:"1";s:8:"grouping";a:3:{s:11:"grouping_09";s:11:"grouping_09";s:14:"grouping_other";s:14:"grouping_other";s:11:"grouping_az";i:0;}}s:4:"type";a:2:{s:8:"grouping";a:3:{s:14:"grouping_other";s:14:"grouping_other";s:11:"grouping_az";i:0;s:11:"grouping_09";i:0;}s:8:"glossary";i:0;}s:3:"uid";a:2:{s:8:"grouping";a:3:{s:14:"grouping_other";s:14:"grouping_other";s:11:"grouping_az";i:0;s:11:"grouping_09";i:0;}s:8:"glossary";i:0;}}}'
+    glossarytable: 'a:1:{s:13:"glossarytable";a:26:{s:11:"collections";a:2:{s:8:"grouping";a:3:{s:14:"grouping_other";s:14:"grouping_other";s:11:"grouping_az";i:0;s:11:"grouping_09";i:0;}s:8:"glossary";i:0;}s:15:"community_title";a:2:{s:8:"grouping";a:3:{s:14:"grouping_other";s:14:"grouping_other";s:11:"grouping_az";i:0;s:11:"grouping_09";i:0;}s:8:"glossary";i:0;}s:16:"contributor_name";a:2:{s:8:"grouping";a:3:{s:14:"grouping_other";s:14:"grouping_other";s:11:"grouping_az";i:0;s:11:"grouping_09";i:0;}s:8:"glossary";i:0;}s:12:"creator_name";a:2:{s:8:"grouping";a:3:{s:14:"grouping_other";s:14:"grouping_other";s:11:"grouping_az";i:0;s:11:"grouping_09";i:0;}s:8:"glossary";i:0;}s:14:"field_coverage";a:2:{s:8:"grouping";a:3:{s:14:"grouping_other";s:14:"grouping_other";s:11:"grouping_az";i:0;s:11:"grouping_09";i:0;}s:8:"glossary";i:0;}s:26:"field_coverage_description";a:2:{s:8:"grouping";a:3:{s:14:"grouping_other";s:14:"grouping_other";s:11:"grouping_az";i:0;s:11:"grouping_09";i:0;}s:8:"glossary";i:0;}s:24:"field_cultural_narrative";a:2:{s:8:"grouping";a:3:{s:14:"grouping_other";s:14:"grouping_other";s:11:"grouping_az";i:0;s:11:"grouping_09";i:0;}s:8:"glossary";i:0;}s:22:"field_date_description";a:2:{s:8:"grouping";a:3:{s:14:"grouping_other";s:14:"grouping_other";s:11:"grouping_az";i:0;s:11:"grouping_09";i:0;}s:8:"glossary";i:0;}s:17:"field_description";a:2:{s:8:"grouping";a:3:{s:14:"grouping_other";s:14:"grouping_other";s:11:"grouping_az";i:0;s:11:"grouping_09";i:0;}s:8:"glossary";i:0;}s:16:"field_identifier";a:2:{s:8:"grouping";a:3:{s:14:"grouping_other";s:14:"grouping_other";s:11:"grouping_az";i:0;s:11:"grouping_09";i:0;}s:8:"glossary";i:0;}s:23:"field_rights_statements";a:2:{s:8:"grouping";a:3:{s:14:"grouping_other";s:14:"grouping_other";s:11:"grouping_az";i:0;s:11:"grouping_09";i:0;}s:8:"glossary";i:0;}s:12:"field_source";a:2:{s:8:"grouping";a:3:{s:14:"grouping_other";s:14:"grouping_other";s:11:"grouping_az";i:0;s:11:"grouping_09";i:0;}s:8:"glossary";i:0;}s:13:"field_summary";a:2:{s:8:"grouping";a:3:{s:14:"grouping_other";s:14:"grouping_other";s:11:"grouping_az";i:0;s:11:"grouping_09";i:0;}s:8:"glossary";i:0;}s:27:"field_traditional_knowledge";a:2:{s:8:"grouping";a:3:{s:14:"grouping_other";s:14:"grouping_other";s:11:"grouping_az";i:0;s:11:"grouping_09";i:0;}s:8:"glossary";i:0;}s:19:"field_transcription";a:2:{s:8:"grouping";a:3:{s:14:"grouping_other";s:14:"grouping_other";s:11:"grouping_az";i:0;s:11:"grouping_09";i:0;}s:8:"glossary";i:0;}s:20:"media_extracted_text";a:2:{s:8:"grouping";a:3:{s:14:"grouping_other";s:14:"grouping_other";s:11:"grouping_az";i:0;s:11:"grouping_09";i:0;}s:8:"glossary";i:0;}s:10:"media_type";a:2:{s:8:"grouping";a:3:{s:14:"grouping_other";s:14:"grouping_other";s:11:"grouping_az";i:0;s:11:"grouping_09";i:0;}s:8:"glossary";i:0;}s:4:"name";a:2:{s:8:"grouping";a:3:{s:14:"grouping_other";s:14:"grouping_other";s:11:"grouping_az";i:0;s:11:"grouping_09";i:0;}s:8:"glossary";i:0;}s:6:"name_1";a:2:{s:8:"grouping";a:3:{s:14:"grouping_other";s:14:"grouping_other";s:11:"grouping_az";i:0;s:11:"grouping_09";i:0;}s:8:"glossary";i:0;}s:13:"original_date";a:2:{s:8:"grouping";a:3:{s:14:"grouping_other";s:14:"grouping_other";s:11:"grouping_az";i:0;s:11:"grouping_09";i:0;}s:8:"glossary";i:0;}s:25:"page_media_extracted_text";a:2:{s:8:"grouping";a:3:{s:14:"grouping_other";s:14:"grouping_other";s:11:"grouping_az";i:0;s:11:"grouping_09";i:0;}s:8:"glossary";i:0;}s:11:"people_name";a:2:{s:8:"grouping";a:3:{s:14:"grouping_other";s:14:"grouping_other";s:11:"grouping_az";i:0;s:11:"grouping_09";i:0;}s:8:"glossary";i:0;}s:12:"subject_name";a:2:{s:8:"grouping";a:3:{s:14:"grouping_other";s:14:"grouping_other";s:11:"grouping_az";i:0;s:11:"grouping_09";i:0;}s:8:"glossary";i:0;}s:5:"title";a:2:{s:8:"glossary";s:1:"1";s:8:"grouping";a:3:{s:11:"grouping_09";s:11:"grouping_09";s:14:"grouping_other";s:14:"grouping_other";s:11:"grouping_az";i:0;}}s:4:"type";a:2:{s:8:"grouping";a:3:{s:14:"grouping_other";s:14:"grouping_other";s:11:"grouping_az";i:0;s:11:"grouping_09";i:0;}s:8:"glossary";i:0;}s:3:"uid";a:2:{s:8:"grouping";a:3:{s:14:"grouping_other";s:14:"grouping_other";s:11:"grouping_az";i:0;s:11:"grouping_09";i:0;}s:8:"glossary";i:0;}}}'
     field_enabled: 0
     grouping_defaults:
       grouping_other: grouping_other
@@ -305,11 +326,13 @@ processor_settings:
       - field_traditional_knowledge
       - field_transcription
       - glossaryaz_title
+      - media_extracted_text
       - media_type
       - mukurtu_cultural_protocol_ids
       - name
       - name_1
       - original_date
+      - page_media_extracted_text
       - people_name
       - subject_name
       - title
@@ -341,7 +364,9 @@ processor_settings:
       - field_summary
       - field_traditional_knowledge
       - field_transcription
+      - media_extracted_text
       - original_date
+      - page_media_extracted_text
       - people_name
       - subject_name
       - title
@@ -367,7 +392,9 @@ processor_settings:
       - field_summary
       - field_traditional_knowledge
       - field_transcription
+      - media_extracted_text
       - original_date
+      - page_media_extracted_text
       - title
     spaces: ''
     ignored: ._-
@@ -395,11 +422,13 @@ processor_settings:
       - field_traditional_knowledge
       - field_transcription
       - glossaryaz_title
+      - media_extracted_text
       - media_type
       - mukurtu_cultural_protocol_ids
       - name
       - name_1
       - original_date
+      - page_media_extracted_text
       - people_name
       - subject_name
       - title

--- a/modules/mukurtu_browse/mukurtu_browse.install
+++ b/modules/mukurtu_browse/mukurtu_browse.install
@@ -98,3 +98,65 @@ function mukurtu_browse_update_40002() {
     }
   }
 }
+
+/**
+ * Add PDF extracted text fields to the content search index.
+ */
+function mukurtu_browse_update_40003() {
+  $index = \Drupal\search_api\Entity\Index::load('mukurtu_default_content_index');
+  if (!$index) {
+    return;
+  }
+
+  $new_fields = [
+    'media_extracted_text' => [
+      'type' => 'text',
+      'property_path' => 'field_media_assets:entity:field_extracted_text',
+      'datasource_id' => 'entity:node',
+      'label' => 'Media Assets Extracted Text',
+    ],
+    'page_media_extracted_text' => [
+      'type' => 'text',
+      'property_path' => 'field_page_media_assets:entity:field_extracted_text',
+      'datasource_id' => 'entity:node',
+      'label' => 'Page Media Assets Extracted Text',
+    ],
+  ];
+
+  $index_changed = FALSE;
+  foreach ($new_fields as $field_id => $field_config) {
+    if (!$index->getField($field_id)) {
+      $field = new \Drupal\search_api\Item\Field($index, $field_id);
+      $field->setType($field_config['type']);
+      $field->setPropertyPath($field_config['property_path']);
+      $field->setDatasourceId($field_config['datasource_id']);
+      $field->setLabel($field_config['label']);
+      $index->addField($field);
+      $index_changed = TRUE;
+    }
+  }
+
+  // Register both fields with the ignorecase processor, which has all_fields: false.
+  $processors = $index->getProcessors();
+  if (isset($processors['ignorecase'])) {
+    $config = $processors['ignorecase']->getConfiguration();
+    $processor_changed = FALSE;
+    foreach (array_keys($new_fields) as $field_id) {
+      if (!in_array($field_id, $config['fields'])) {
+        $config['fields'][] = $field_id;
+        $processor_changed = TRUE;
+      }
+    }
+    if ($processor_changed) {
+      $processors['ignorecase']->setConfiguration($config);
+      $index->setProcessors($processors);
+      $index_changed = TRUE;
+    }
+  }
+
+  if ($index_changed) {
+    $index->save();
+  }
+
+  $index->reindex();
+}


### PR DESCRIPTION
Closes #221

## Summary

PDF files uploaded as Document media assets already have their text extracted via `pdftotext` on save (`Document::preSave()`) and stored in `field_extracted_text`. However, that field was never included in any search index, so PDF content was invisible to search.

This PR adds `field_extracted_text` from referenced media entities to the default DB content index (`mukurtu_default_content_index`) via Search API's property path traversal:

- `field_media_assets:entity:field_extracted_text` — covers digital heritage items and other content using the standard media assets field
- `field_page_media_assets:entity:field_extracted_text` — covers multipage item pages

Both fields are registered with all relevant processors (`html_filter`, `ignorecase`, `tokenizer`, `transliteration`). The `ignorecase` processor required explicit field registration since it has `all_fields: false`.

No changes to PDF text extraction logic — that already works correctly.

## Update hook

`mukurtu_browse_update_40003` handles existing installations by:
1. Adding both fields to the live index programmatically (guards against re-running)
2. Registering them with the `ignorecase` processor
3. Triggering a full reindex

## Test plan

- [ ] Run `drush updb -y` — hook should complete without errors
- [ ] Upload a PDF with embedded/OCR text as a Document media entity
- [ ] Add the Document to a digital heritage item's media assets field and save
- [ ] Run `drush search-api:index` or wait for cron
- [ ] Search for a word that appears only in the PDF text — the digital heritage item should appear in results
- [ ] Confirm the same works for a multipage item page with a PDF in `field_page_media_assets`

🤖 Generated with [Claude Code](https://claude.com/claude-code)