### PR TITLE
Allow media reference by name or filename in formatted text embeds

### DIFF
--- a/modules/mukurtu_import/src/Plugin/MukurtuImportFieldProcess/FormattedText.php
+++ b/modules/mukurtu_import/src/Plugin/MukurtuImportFieldProcess/FormattedText.php
@@ -32,6 +32,9 @@ class FormattedText extends MukurtuImportFieldProcessPluginBase {
   public function getProcess(FieldDefinitionInterface $field_config, $source, $context = []): array {
     $multivalue_delimiter = $context['multivalue_delimiter'] ?? self::MULTIVALUE_DELIMITER;
     $process = [];
+    $process[] = [
+      'plugin' => 'mukurtu_resolve_media_embeds',
+    ];
     if ($this->isMultiple($field_config)) {
       $process[] = [
         'plugin' => 'explode',

--- a/modules/mukurtu_import/src/Plugin/migrate/process/ResolveMediaEmbeds.php
+++ b/modules/mukurtu_import/src/Plugin/migrate/process/ResolveMediaEmbeds.php
@@ -57,6 +57,13 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class ResolveMediaEmbeds extends ProcessPluginBase implements ContainerFactoryPluginInterface {
 
   /**
+   * Cached map of media type ID to source field name, built on first use.
+   *
+   * @var array<string, string>
+   */
+  protected array $sourceFieldNames = [];
+
+  /**
    * Constructs a ResolveMediaEmbeds object.
    */
   public function __construct(
@@ -171,10 +178,18 @@ class ResolveMediaEmbeds extends ProcessPluginBase implements ContainerFactoryPl
         }
         catch (MigrateException $e) {
           $migrate_executable->saveMessage($e->getMessage());
+          // Replace the intermediate attribute with data-entity-name so the
+          // stored tag is consistent with unresolved data-entity-name tags.
+          $element->setAttribute('data-entity-name', $identifier);
+          $element->removeAttribute('data-entity-identifier');
+          $resolved = TRUE;
           continue;
         }
         if (!$uuid) {
           $migrate_executable->saveMessage(sprintf('Could not find a media entity matching "%s".', $identifier));
+          $element->setAttribute('data-entity-name', $identifier);
+          $element->removeAttribute('data-entity-identifier');
+          $resolved = TRUE;
           continue;
         }
         $element->setAttribute('data-entity-uuid', $uuid);
@@ -319,20 +334,21 @@ class ResolveMediaEmbeds extends ProcessPluginBase implements ContainerFactoryPl
 
     $file_ids = array_values($file_ids);
     $media_storage = $this->entityTypeManager->getStorage('media');
-    $media_type_storage = $this->entityTypeManager->getStorage('media_type');
+
+    if (!$this->sourceFieldNames) {
+      foreach ($this->entityTypeManager->getStorage('media_type')->loadMultiple() as $media_type) {
+        $source_field_def = $media_type->getSource()->getSourceFieldDefinition($media_type);
+        if ($source_field_def) {
+          $this->sourceFieldNames[$media_type->id()] = $source_field_def->getName();
+        }
+      }
+    }
 
     $matches = [];
-    foreach ($media_type_storage->loadMultiple() as $media_type) {
-      $source_plugin = $media_type->getSource();
-      $source_field_def = $source_plugin->getSourceFieldDefinition($media_type);
-      if (!$source_field_def) {
-        continue;
-      }
-      $source_field_name = $source_field_def->getName();
-
+    foreach ($this->sourceFieldNames as $type_id => $source_field_name) {
       $results = $media_storage->getQuery()
         ->accessCheck(FALSE)
-        ->condition('bundle', $media_type->id())
+        ->condition('bundle', $type_id)
         ->condition($source_field_name, $file_ids, 'IN')
         ->execute();
 

--- a/modules/mukurtu_import/src/Plugin/migrate/process/ResolveMediaEmbeds.php
+++ b/modules/mukurtu_import/src/Plugin/migrate/process/ResolveMediaEmbeds.php
@@ -1,0 +1,230 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\mukurtu_import\Plugin\migrate\process;
+
+use DOMDocument;
+use DOMXPath;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\migrate\MigrateException;
+use Drupal\migrate\MigrateExecutableInterface;
+use Drupal\migrate\ProcessPluginBase;
+use Drupal\migrate\Row;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Resolves drupal-media embed tags using media name or filename attributes.
+ *
+ * During CSV import, users can reference media assets in formatted text fields
+ * using human-readable identifiers instead of UUIDs:
+ *
+ * By media entity name:
+ * @code
+ * <drupal-media data-entity-type="media" data-entity-name="My Image" data-view-mode="default">
+ * @endcode
+ *
+ * By source file filename:
+ * @code
+ * <drupal-media data-entity-type="media" data-entity-filename="my-image.jpg" data-view-mode="default">
+ * @endcode
+ *
+ * Both attributes are resolved to a proper data-entity-uuid and removed from
+ * the tag before the content is saved.
+ *
+ * @MigrateProcessPlugin(
+ *   id = "mukurtu_resolve_media_embeds",
+ *   handle_multiples = FALSE
+ * )
+ */
+class ResolveMediaEmbeds extends ProcessPluginBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * Constructs a ResolveMediaEmbeds object.
+   */
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    protected EntityTypeManagerInterface $entityTypeManager,
+  ) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('entity_type.manager'),
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function transform($value, MigrateExecutableInterface $migrate_executable, Row $row, $destination_property) {
+    if (empty($value) || !is_string($value)) {
+      return $value;
+    }
+
+    // Quick check: only parse HTML if there's a drupal-media tag with one of
+    // the custom lookup attributes present.
+    if (
+      !str_contains($value, 'data-entity-name') &&
+      !str_contains($value, 'data-entity-filename')
+    ) {
+      return $value;
+    }
+
+    $doc = new DOMDocument();
+    $previous = libxml_use_internal_errors(TRUE);
+    $doc->loadHTML($value, LIBXML_HTML_NODEFDTD);
+    libxml_use_internal_errors($previous);
+    $xpath = new DOMXPath($doc);
+    $media_elements = $xpath->query('//drupal-media[@data-entity-name or @data-entity-filename]');
+
+    if ($media_elements->length === 0) {
+      return $value;
+    }
+
+    $resolved = FALSE;
+    foreach ($media_elements as $element) {
+      $uuid = NULL;
+
+      if ($name = $element->getAttribute('data-entity-name')) {
+        try {
+          $uuid = $this->resolveByName($name);
+        }
+        catch (MigrateException $e) {
+          $migrate_executable->saveMessage($e->getMessage());
+          continue;
+        }
+        if (!$uuid) {
+          $migrate_executable->saveMessage(sprintf('Could not find a media entity with name "%s".', $name));
+          continue;
+        }
+        $element->setAttribute('data-entity-uuid', $uuid);
+        $element->removeAttribute('data-entity-name');
+        $resolved = TRUE;
+      }
+      elseif ($filename = $element->getAttribute('data-entity-filename')) {
+        try {
+          $uuid = $this->resolveByFilename($filename);
+        }
+        catch (MigrateException $e) {
+          $migrate_executable->saveMessage($e->getMessage());
+          continue;
+        }
+        if (!$uuid) {
+          $migrate_executable->saveMessage(sprintf('Could not find a media entity with filename "%s".', $filename));
+          continue;
+        }
+        $element->setAttribute('data-entity-uuid', $uuid);
+        $element->removeAttribute('data-entity-filename');
+        $resolved = TRUE;
+      }
+    }
+
+    if ($resolved) {
+      $new_value = $doc->saveHTML();
+      $strip_these_tags = ['<html>', '</html>', '<body>', '</body>'];
+      $value = str_replace($strip_these_tags, '', $new_value);
+    }
+
+    return $value;
+  }
+
+  /**
+   * Resolve a media entity UUID by the media entity's name/label.
+   *
+   * @param string $name
+   *   The media entity name (label).
+   *
+   * @return string|null
+   *   The UUID of the matching media entity, or NULL if not found.
+   *
+   * @throws \Drupal\migrate\MigrateException
+   *   Thrown when the name matches multiple media entities.
+   */
+  protected function resolveByName(string $name): ?string {
+    $results = $this->entityTypeManager->getStorage('media')
+      ->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('name', $name)
+      ->execute();
+
+    if (empty($results)) {
+      return NULL;
+    }
+    if (count($results) > 1) {
+      throw new MigrateException(sprintf('"%s" is ambiguous, multiple media entities share this name. Try using data-entity-uuid instead.', $name));
+    }
+
+    $media = $this->entityTypeManager->getStorage('media')->load(reset($results));
+    return $media ? $media->uuid() : NULL;
+  }
+
+  /**
+   * Resolve a media entity UUID by the filename of its source file.
+   *
+   * @param string $filename
+   *   The filename of the media source file (e.g. "my-image.jpg").
+   *
+   * @return string|null
+   *   The UUID of the matching media entity, or NULL if not found.
+   *
+   * @throws \Drupal\migrate\MigrateException
+   *   Thrown when the filename matches multiple media entities.
+   */
+  protected function resolveByFilename(string $filename): ?string {
+    $file_ids = $this->entityTypeManager->getStorage('file')
+      ->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('filename', $filename)
+      ->execute();
+
+    if (empty($file_ids)) {
+      return NULL;
+    }
+
+    $file_ids = array_values($file_ids);
+    $media_storage = $this->entityTypeManager->getStorage('media');
+    $media_type_storage = $this->entityTypeManager->getStorage('media_type');
+
+    $matches = [];
+    foreach ($media_type_storage->loadMultiple() as $media_type) {
+      $source_plugin = $media_type->getSource();
+      $source_field_def = $source_plugin->getSourceFieldDefinition($media_type);
+      if (!$source_field_def) {
+        continue;
+      }
+      $source_field_name = $source_field_def->getName();
+
+      $results = $media_storage->getQuery()
+        ->accessCheck(FALSE)
+        ->condition('bundle', $media_type->id())
+        ->condition($source_field_name, $file_ids, 'IN')
+        ->execute();
+
+      foreach ($results as $mid) {
+        $matches[$mid] = TRUE;
+      }
+    }
+
+    if (empty($matches)) {
+      return NULL;
+    }
+    if (count($matches) > 1) {
+      throw new MigrateException(sprintf('"%s" is ambiguous, multiple media entities reference a file with this name. Try using data-entity-uuid instead.', $filename));
+    }
+
+    $media = $media_storage->load(array_key_first($matches));
+    return $media ? $media->uuid() : NULL;
+  }
+
+}

--- a/modules/mukurtu_import/src/Plugin/migrate/process/ResolveMediaEmbeds.php
+++ b/modules/mukurtu_import/src/Plugin/migrate/process/ResolveMediaEmbeds.php
@@ -229,7 +229,14 @@ class ResolveMediaEmbeds extends ProcessPluginBase implements ContainerFactoryPl
     $value = preg_replace_callback(
       '/\[media\s+([^\]]+)\]/i',
       function (array $m) use ($attr_map): string {
-        preg_match_all('/(\w[\w-]*)\s*=\s*(?:"([^"]*?)"|\'([^\']*?)\')/i', $m[1], $pairs, PREG_SET_ORDER);
+        // Normalize curly/smart quotes to straight quotes so CSV editors that
+        // auto-convert punctuation don't break attribute parsing.
+        $attrs_str = str_replace(
+          ["\u{201C}", "\u{201D}", "\u{2018}", "\u{2019}"],
+          ['"',        '"',        "'",         "'"],
+          $m[1]
+        );
+        preg_match_all('/(\w[\w-]*)\s*=\s*(?:"([^"]*?)"|\'([^\']*?)\')/i', $attrs_str, $pairs, PREG_SET_ORDER);
 
         $tag_attrs = ['data-entity-type="media"'];
         $has_view_mode = FALSE;

--- a/modules/mukurtu_import/src/Plugin/migrate/process/ResolveMediaEmbeds.php
+++ b/modules/mukurtu_import/src/Plugin/migrate/process/ResolveMediaEmbeds.php
@@ -15,23 +15,39 @@ use Drupal\migrate\Row;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * Resolves drupal-media embed tags using media name or filename attributes.
+ * Resolves media embed references in formatted text fields during import.
  *
- * During CSV import, users can reference media assets in formatted text fields
- * using human-readable identifiers instead of UUIDs:
+ * Three syntaxes are supported:
  *
- * By media entity name:
+ * 1. Full drupal-media tag with data-entity-name (resolves by media label):
  * @code
  * <drupal-media data-entity-type="media" data-entity-name="My Image" data-view-mode="default">
  * @endcode
  *
- * By source file filename:
+ * 2. Full drupal-media tag with data-entity-filename (resolves by source file
+ *    filename):
  * @code
  * <drupal-media data-entity-type="media" data-entity-filename="my-image.jpg" data-view-mode="default">
  * @endcode
  *
- * Both attributes are resolved to a proper data-entity-uuid and removed from
- * the tag before the content is saved.
+ * 3. Curly-brace shortcode (tries name first, then filename):
+ * @code
+ * {{media:My Image}}
+ * {{media:my-image.jpg}}
+ * @endcode
+ *
+ * 4. Square-bracket shortcode with optional attributes:
+ * @code
+ * [media name="My Image"]
+ * [media filename="my-image.jpg" view-mode="thumbnail" align="center"]
+ * @endcode
+ *
+ * Supported square-bracket attributes: name, filename, view-mode, align,
+ * caption, alt.
+ *
+ * All references are resolved to a proper data-entity-uuid and the temporary
+ * attributes/shortcodes are removed before the content is saved. Existing
+ * data-entity-uuid tags are passed through unchanged.
  *
  * @MigrateProcessPlugin(
  *   id = "mukurtu_resolve_media_embeds",
@@ -72,11 +88,23 @@ class ResolveMediaEmbeds extends ProcessPluginBase implements ContainerFactoryPl
       return $value;
     }
 
-    // Quick check: only parse HTML if there's a drupal-media tag with one of
-    // the custom lookup attributes present.
+    $has_drupal_media_attrs = str_contains($value, 'data-entity-name') || str_contains($value, 'data-entity-filename');
+    $has_shortcode = str_contains($value, '{{media:') || str_contains($value, '[media ');
+
+    if (!$has_drupal_media_attrs && !$has_shortcode) {
+      return $value;
+    }
+
+    if ($has_shortcode) {
+      $value = $this->convertShortcodes($value);
+    }
+
+    // After shortcode conversion, bail out if there is nothing for the DOM
+    // to resolve.
     if (
       !str_contains($value, 'data-entity-name') &&
-      !str_contains($value, 'data-entity-filename')
+      !str_contains($value, 'data-entity-filename') &&
+      !str_contains($value, 'data-entity-identifier')
     ) {
       return $value;
     }
@@ -86,7 +114,9 @@ class ResolveMediaEmbeds extends ProcessPluginBase implements ContainerFactoryPl
     $doc->loadHTML($value, LIBXML_HTML_NODEFDTD);
     libxml_use_internal_errors($previous);
     $xpath = new DOMXPath($doc);
-    $media_elements = $xpath->query('//drupal-media[@data-entity-name or @data-entity-filename]');
+    $media_elements = $xpath->query(
+      '//drupal-media[@data-entity-name or @data-entity-filename or @data-entity-identifier]'
+    );
 
     if ($media_elements->length === 0) {
       return $value;
@@ -128,6 +158,26 @@ class ResolveMediaEmbeds extends ProcessPluginBase implements ContainerFactoryPl
         $element->removeAttribute('data-entity-filename');
         $resolved = TRUE;
       }
+      elseif ($identifier = $element->getAttribute('data-entity-identifier')) {
+        // Try name first; fall back to filename only if nothing matched.
+        try {
+          $uuid = $this->resolveByName($identifier);
+          if ($uuid === NULL) {
+            $uuid = $this->resolveByFilename($identifier);
+          }
+        }
+        catch (MigrateException $e) {
+          $migrate_executable->saveMessage($e->getMessage());
+          continue;
+        }
+        if (!$uuid) {
+          $migrate_executable->saveMessage(sprintf('Could not find a media entity matching "%s".', $identifier));
+          continue;
+        }
+        $element->setAttribute('data-entity-uuid', $uuid);
+        $element->removeAttribute('data-entity-identifier');
+        $resolved = TRUE;
+      }
     }
 
     if ($resolved) {
@@ -135,6 +185,71 @@ class ResolveMediaEmbeds extends ProcessPluginBase implements ContainerFactoryPl
       $strip_these_tags = ['<html>', '</html>', '<body>', '</body>'];
       $value = str_replace($strip_these_tags, '', $new_value);
     }
+
+    return $value;
+  }
+
+  /**
+   * Convert shortcode syntax to intermediate drupal-media tags.
+   *
+   * Handles:
+   *   {{media:VALUE}} → data-entity-identifier (resolved by name then filename)
+   *   [media name="..." filename="..." view-mode="..." align="..." caption="..." alt="..."]
+   *
+   * @param string $value
+   *   The raw text value.
+   *
+   * @return string
+   *   The value with shortcodes replaced by drupal-media tags.
+   */
+  protected function convertShortcodes(string $value): string {
+    // {{media:VALUE}} shortcode.
+    $value = preg_replace_callback(
+      '/\{\{media:([^}]+)\}\}/i',
+      function (array $m): string {
+        $identifier = htmlspecialchars(trim($m[1]), ENT_QUOTES, 'UTF-8');
+        return '<drupal-media data-entity-type="media" data-entity-identifier="' . $identifier . '" data-view-mode="default">&nbsp;</drupal-media>';
+      },
+      $value
+    );
+
+    // [media attr="value" ...] shortcode.
+    $attr_map = [
+      'name'      => 'data-entity-name',
+      'filename'  => 'data-entity-filename',
+      'view-mode' => 'data-view-mode',
+      'align'     => 'data-align',
+      'caption'   => 'data-caption',
+      'alt'       => 'alt',
+    ];
+
+    $value = preg_replace_callback(
+      '/\[media\s+([^\]]+)\]/i',
+      function (array $m) use ($attr_map): string {
+        preg_match_all('/(\w[\w-]*)\s*=\s*(?:"([^"]*?)"|\'([^\']*?)\')/i', $m[1], $pairs, PREG_SET_ORDER);
+
+        $tag_attrs = ['data-entity-type="media"'];
+        $has_view_mode = FALSE;
+
+        foreach ($pairs as $pair) {
+          $key = strtolower($pair[1]);
+          $val = $pair[2] !== '' ? $pair[2] : $pair[3];
+          if (isset($attr_map[$key])) {
+            $tag_attrs[] = $attr_map[$key] . '="' . htmlspecialchars($val, ENT_QUOTES, 'UTF-8') . '"';
+            if ($key === 'view-mode') {
+              $has_view_mode = TRUE;
+            }
+          }
+        }
+
+        if (!$has_view_mode) {
+          $tag_attrs[] = 'data-view-mode="default"';
+        }
+
+        return '<drupal-media ' . implode(' ', $tag_attrs) . '>&nbsp;</drupal-media>';
+      },
+      $value
+    );
 
     return $value;
   }

--- a/modules/mukurtu_import/src/Plugin/migrate/process/ResolveMediaEmbeds.php
+++ b/modules/mukurtu_import/src/Plugin/migrate/process/ResolveMediaEmbeds.php
@@ -17,7 +17,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 /**
  * Resolves media embed references in formatted text fields during import.
  *
- * Three syntaxes are supported:
+ * Four syntaxes are supported:
  *
  * 1. Full drupal-media tag with data-entity-name (resolves by media label):
  * @code

--- a/modules/mukurtu_import/src/Plugin/migrate/process/ResolveMediaEmbeds.php
+++ b/modules/mukurtu_import/src/Plugin/migrate/process/ResolveMediaEmbeds.php
@@ -111,7 +111,10 @@ class ResolveMediaEmbeds extends ProcessPluginBase implements ContainerFactoryPl
 
     $doc = new DOMDocument();
     $previous = libxml_use_internal_errors(TRUE);
-    $doc->loadHTML($value, LIBXML_HTML_NODEFDTD);
+    // Prefix with an XML encoding declaration so DOMDocument parses the input
+    // as UTF-8 rather than its default ISO-8859-1, which would corrupt any
+    // multi-byte characters (e.g. curly quotes, accented letters).
+    $doc->loadHTML('<?xml encoding="utf-8"?>' . $value, LIBXML_HTML_NODEFDTD);
     libxml_use_internal_errors($previous);
     $xpath = new DOMXPath($doc);
     $media_elements = $xpath->query(
@@ -182,7 +185,7 @@ class ResolveMediaEmbeds extends ProcessPluginBase implements ContainerFactoryPl
 
     if ($resolved) {
       $new_value = $doc->saveHTML();
-      $strip_these_tags = ['<html>', '</html>', '<body>', '</body>'];
+      $strip_these_tags = ['<?xml encoding="utf-8"?>', '<html>', '</html>', '<body>', '</body>'];
       $value = str_replace($strip_these_tags, '', $new_value);
     }
 

--- a/modules/mukurtu_import/tests/src/Kernel/ImportFormattedTextMediaEmbedTest.php
+++ b/modules/mukurtu_import/tests/src/Kernel/ImportFormattedTextMediaEmbedTest.php
@@ -319,6 +319,29 @@ class ImportFormattedTextMediaEmbedTest extends MukurtuImportTestBase {
   }
 
   /**
+   * Tests that curly/smart quotes in [media] shortcode attributes are handled.
+   */
+  public function testSquareBracketShortcodeWithSmartQuotes(): void {
+    // Simulate a CSV editor that auto-converts straight quotes to curly quotes.
+    $embed = "[media name=\u{201C}My Named Asset\u{201D}]";
+    $data = [
+      ['nid', 'body'],
+      [$this->node->id(), $embed],
+    ];
+    $import_file = $this->createCsvFile($data);
+    $mapping = [
+      ['target' => 'nid', 'source' => 'nid'],
+      ['target' => 'field_body', 'source' => 'body'],
+    ];
+
+    $result = $this->importCsvFile($import_file, $mapping);
+    $this->assertEquals(MigrationInterface::RESULT_COMPLETED, $result);
+
+    $body = $this->entityTypeManager->getStorage('node')->load($this->node->id())->get('field_body')->value;
+    $this->assertStringContainsString('data-entity-uuid="' . $this->mediaByName->uuid() . '"', $body);
+  }
+
+  /**
    * Tests that an unknown name leaves the tag unchanged and migration completes.
    */
   public function testUnknownNameLeavesTagUnchanged(): void {

--- a/modules/mukurtu_import/tests/src/Kernel/ImportFormattedTextMediaEmbedTest.php
+++ b/modules/mukurtu_import/tests/src/Kernel/ImportFormattedTextMediaEmbedTest.php
@@ -342,6 +342,113 @@ class ImportFormattedTextMediaEmbedTest extends MukurtuImportTestBase {
   }
 
   /**
+   * Tests that an ambiguous name logs a message and leaves the tag unchanged.
+   */
+  public function testAmbiguousNameLogsMessageAndLeavesTagUnchanged(): void {
+    // Create a second media entity with the same name to trigger ambiguity.
+    $file_dupe = File::create([
+      'uri' => 'public://name-lookup-dupe.txt',
+      'filename' => 'name-lookup-dupe.txt',
+      'uid' => $this->currentUser->id(),
+      'status' => 1,
+    ]);
+    $file_dupe->save();
+    $media_type = $this->entityTypeManager->getStorage('media_type')->loadMultiple();
+    $media_type = reset($media_type);
+    $source_field = $media_type->getSource()->getSourceFieldDefinition($media_type)->getName();
+    Media::create([
+      'bundle' => $media_type->id(),
+      'name' => 'My Named Asset',
+      $source_field => ['target_id' => $file_dupe->id()],
+      'uid' => $this->currentUser->id(),
+    ])->save();
+
+    $embed = '<drupal-media data-entity-type="media" data-entity-name="My Named Asset" data-view-mode="default">&nbsp;</drupal-media>';
+    $data = [
+      ['nid', 'body'],
+      [$this->node->id(), $embed],
+    ];
+    $import_file = $this->createCsvFile($data);
+    $mapping = [
+      ['target' => 'nid', 'source' => 'nid'],
+      ['target' => 'field_body', 'source' => 'body'],
+    ];
+
+    $result = $this->importCsvFile($import_file, $mapping);
+    $this->assertEquals(MigrationInterface::RESULT_COMPLETED, $result);
+
+    $body = $this->entityTypeManager->getStorage('node')->load($this->node->id())->get('field_body')->value;
+    $this->assertStringNotContainsString('data-entity-uuid=', $body);
+    $this->assertStringContainsString('data-entity-name="My Named Asset"', $body);
+  }
+
+  /**
+   * Tests that an ambiguous filename logs a message and leaves the tag unchanged.
+   */
+  public function testAmbiguousFilenameLogsMessageAndLeavesTagUnchanged(): void {
+    // Create a second file with the same filename (different URI) and a media
+    // entity referencing it, so two media entities share the same filename.
+    $file_dupe = File::create([
+      'uri' => 'public://subdir/filename-lookup.txt',
+      'filename' => 'filename-lookup.txt',
+      'uid' => $this->currentUser->id(),
+      'status' => 1,
+    ]);
+    $file_dupe->save();
+    $media_type = $this->entityTypeManager->getStorage('media_type')->loadMultiple();
+    $media_type = reset($media_type);
+    $source_field = $media_type->getSource()->getSourceFieldDefinition($media_type)->getName();
+    Media::create([
+      'bundle' => $media_type->id(),
+      'name' => 'Duplicate Filename Asset',
+      $source_field => ['target_id' => $file_dupe->id()],
+      'uid' => $this->currentUser->id(),
+    ])->save();
+
+    $embed = '<drupal-media data-entity-type="media" data-entity-filename="filename-lookup.txt" data-view-mode="default">&nbsp;</drupal-media>';
+    $data = [
+      ['nid', 'body'],
+      [$this->node->id(), $embed],
+    ];
+    $import_file = $this->createCsvFile($data);
+    $mapping = [
+      ['target' => 'nid', 'source' => 'nid'],
+      ['target' => 'field_body', 'source' => 'body'],
+    ];
+
+    $result = $this->importCsvFile($import_file, $mapping);
+    $this->assertEquals(MigrationInterface::RESULT_COMPLETED, $result);
+
+    $body = $this->entityTypeManager->getStorage('node')->load($this->node->id())->get('field_body')->value;
+    $this->assertStringNotContainsString('data-entity-uuid=', $body);
+    $this->assertStringContainsString('data-entity-filename="filename-lookup.txt"', $body);
+  }
+
+  /**
+   * Tests that an unresolvable {{media:}} shortcode leaves a data-entity-name
+   * tag (not the intermediate data-entity-identifier) and migration completes.
+   */
+  public function testUnresolvableCurlyBraceShortcodeLeavesSafeAttribute(): void {
+    $data = [
+      ['nid', 'body'],
+      [$this->node->id(), '{{media:Does Not Exist}}'],
+    ];
+    $import_file = $this->createCsvFile($data);
+    $mapping = [
+      ['target' => 'nid', 'source' => 'nid'],
+      ['target' => 'field_body', 'source' => 'body'],
+    ];
+
+    $result = $this->importCsvFile($import_file, $mapping);
+    $this->assertEquals(MigrationInterface::RESULT_COMPLETED, $result);
+
+    $body = $this->entityTypeManager->getStorage('node')->load($this->node->id())->get('field_body')->value;
+    $this->assertStringNotContainsString('data-entity-uuid=', $body);
+    $this->assertStringNotContainsString('data-entity-identifier=', $body);
+    $this->assertStringContainsString('data-entity-name="Does Not Exist"', $body);
+  }
+
+  /**
    * Tests that an unknown name leaves the tag unchanged and migration completes.
    */
   public function testUnknownNameLeavesTagUnchanged(): void {

--- a/modules/mukurtu_import/tests/src/Kernel/ImportFormattedTextMediaEmbedTest.php
+++ b/modules/mukurtu_import/tests/src/Kernel/ImportFormattedTextMediaEmbedTest.php
@@ -1,0 +1,233 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\mukurtu_import\Kernel;
+
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\file\Entity\File;
+use Drupal\filter\Entity\FilterFormat;
+use Drupal\media\Entity\Media;
+use Drupal\migrate\Plugin\MigrationInterface;
+use Drupal\node\Entity\Node;
+use Drupal\Tests\media\Traits\MediaTypeCreationTrait;
+
+/**
+ * Tests that drupal-media embed tags in formatted text fields can reference
+ * media assets by name or filename during CSV import.
+ *
+ * @group mukurtu_import
+ */
+class ImportFormattedTextMediaEmbedTest extends MukurtuImportTestBase {
+
+  use MediaTypeCreationTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = ['media', 'image'];
+
+  /**
+   * A node to update during import.
+   *
+   * @var \Drupal\node\Entity\Node
+   */
+  protected $node;
+
+  /**
+   * A media entity for name-based lookup tests.
+   *
+   * @var \Drupal\media\Entity\Media
+   */
+  protected $mediaByName;
+
+  /**
+   * A media entity for filename-based lookup tests.
+   *
+   * @var \Drupal\media\Entity\Media
+   */
+  protected $mediaByFilename;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->installEntitySchema('media');
+    $this->installConfig(['media', 'image', 'file']);
+
+    // Create the basic_html text format expected by FormattedTextProcessCallback.
+    FilterFormat::create([
+      'format' => 'basic_html',
+      'name' => 'Basic HTML',
+    ])->save();
+
+    // Create a generic file media type.
+    $media_type = $this->createMediaType('file');
+    $source_field = $media_type->getSource()->getSourceFieldDefinition($media_type)->getName();
+
+    // Add a text_long body field to the node type.
+    FieldStorageConfig::create([
+      'field_name' => 'field_body',
+      'entity_type' => 'node',
+      'type' => 'text_long',
+      'cardinality' => 1,
+    ])->save();
+
+    FieldConfig::create([
+      'field_name' => 'field_body',
+      'entity_type' => 'node',
+      'bundle' => 'protocol_aware_content',
+      'label' => 'Body',
+    ])->save();
+
+    // Create a node to update via import.
+    $node = Node::create([
+      'title' => 'Test Node',
+      'type' => 'protocol_aware_content',
+      'status' => TRUE,
+      'uid' => $this->currentUser->id(),
+    ]);
+    $node->setSharingSetting('any');
+    $node->setProtocols([$this->protocol]);
+    $node->save();
+    $this->node = $node;
+
+    // Create a file + media entity for name-based lookup.
+    $file_name = File::create([
+      'uri' => 'public://name-lookup.txt',
+      'filename' => 'name-lookup.txt',
+      'uid' => $this->currentUser->id(),
+      'status' => 1,
+    ]);
+    $file_name->save();
+
+    $this->mediaByName = Media::create([
+      'bundle' => $media_type->id(),
+      'name' => 'My Named Asset',
+      $source_field => ['target_id' => $file_name->id()],
+      'uid' => $this->currentUser->id(),
+    ]);
+    $this->mediaByName->save();
+
+    // Create a file + media entity for filename-based lookup.
+    $file_fn = File::create([
+      'uri' => 'public://filename-lookup.txt',
+      'filename' => 'filename-lookup.txt',
+      'uid' => $this->currentUser->id(),
+      'status' => 1,
+    ]);
+    $file_fn->save();
+
+    $this->mediaByFilename = Media::create([
+      'bundle' => $media_type->id(),
+      'name' => 'Asset Looked Up By Filename',
+      $source_field => ['target_id' => $file_fn->id()],
+      'uid' => $this->currentUser->id(),
+    ]);
+    $this->mediaByFilename->save();
+  }
+
+  /**
+   * Tests that data-entity-name resolves to the correct UUID.
+   */
+  public function testResolveByName(): void {
+    $embed = '<drupal-media data-entity-type="media" data-entity-name="My Named Asset" data-view-mode="default">&nbsp;</drupal-media>';
+    $data = [
+      ['nid', 'body'],
+      [$this->node->id(), $embed],
+    ];
+    $import_file = $this->createCsvFile($data);
+    $mapping = [
+      ['target' => 'nid', 'source' => 'nid'],
+      ['target' => 'field_body', 'source' => 'body'],
+    ];
+
+    $result = $this->importCsvFile($import_file, $mapping);
+    $this->assertEquals(MigrationInterface::RESULT_COMPLETED, $result);
+
+    $updated_node = $this->entityTypeManager->getStorage('node')->load($this->node->id());
+    $body = $updated_node->get('field_body')->value;
+
+    $this->assertStringContainsString('data-entity-uuid="' . $this->mediaByName->uuid() . '"', $body);
+    $this->assertStringNotContainsString('data-entity-name=', $body);
+  }
+
+  /**
+   * Tests that data-entity-filename resolves to the correct UUID.
+   */
+  public function testResolveByFilename(): void {
+    $embed = '<drupal-media data-entity-type="media" data-entity-filename="filename-lookup.txt" data-view-mode="default">&nbsp;</drupal-media>';
+    $data = [
+      ['nid', 'body'],
+      [$this->node->id(), $embed],
+    ];
+    $import_file = $this->createCsvFile($data);
+    $mapping = [
+      ['target' => 'nid', 'source' => 'nid'],
+      ['target' => 'field_body', 'source' => 'body'],
+    ];
+
+    $result = $this->importCsvFile($import_file, $mapping);
+    $this->assertEquals(MigrationInterface::RESULT_COMPLETED, $result);
+
+    $updated_node = $this->entityTypeManager->getStorage('node')->load($this->node->id());
+    $body = $updated_node->get('field_body')->value;
+
+    $this->assertStringContainsString('data-entity-uuid="' . $this->mediaByFilename->uuid() . '"', $body);
+    $this->assertStringNotContainsString('data-entity-filename=', $body);
+  }
+
+  /**
+   * Tests that existing data-entity-uuid tags pass through unchanged.
+   */
+  public function testExistingUuidPassesThrough(): void {
+    $uuid = $this->mediaByName->uuid();
+    $embed = '<drupal-media data-entity-type="media" data-entity-uuid="' . $uuid . '" data-view-mode="default">&nbsp;</drupal-media>';
+    $data = [
+      ['nid', 'body'],
+      [$this->node->id(), $embed],
+    ];
+    $import_file = $this->createCsvFile($data);
+    $mapping = [
+      ['target' => 'nid', 'source' => 'nid'],
+      ['target' => 'field_body', 'source' => 'body'],
+    ];
+
+    $result = $this->importCsvFile($import_file, $mapping);
+    $this->assertEquals(MigrationInterface::RESULT_COMPLETED, $result);
+
+    $updated_node = $this->entityTypeManager->getStorage('node')->load($this->node->id());
+    $body = $updated_node->get('field_body')->value;
+
+    $this->assertStringContainsString('data-entity-uuid="' . $uuid . '"', $body);
+  }
+
+  /**
+   * Tests that an unknown name leaves the tag unchanged and migration completes.
+   */
+  public function testUnknownNameLeavesTagUnchanged(): void {
+    $embed = '<drupal-media data-entity-type="media" data-entity-name="Does Not Exist" data-view-mode="default">&nbsp;</drupal-media>';
+    $data = [
+      ['nid', 'body'],
+      [$this->node->id(), $embed],
+    ];
+    $import_file = $this->createCsvFile($data);
+    $mapping = [
+      ['target' => 'nid', 'source' => 'nid'],
+      ['target' => 'field_body', 'source' => 'body'],
+    ];
+
+    $result = $this->importCsvFile($import_file, $mapping);
+    $this->assertEquals(MigrationInterface::RESULT_COMPLETED, $result);
+
+    $updated_node = $this->entityTypeManager->getStorage('node')->load($this->node->id());
+    $body = $updated_node->get('field_body')->value;
+
+    $this->assertStringContainsString('data-entity-name="Does Not Exist"', $body);
+    $this->assertStringNotContainsString('data-entity-uuid=', $body);
+  }
+
+}

--- a/modules/mukurtu_import/tests/src/Kernel/ImportFormattedTextMediaEmbedTest.php
+++ b/modules/mukurtu_import/tests/src/Kernel/ImportFormattedTextMediaEmbedTest.php
@@ -206,6 +206,119 @@ class ImportFormattedTextMediaEmbedTest extends MukurtuImportTestBase {
   }
 
   /**
+   * Tests that {{media:Name}} resolves via name lookup.
+   */
+  public function testCurlyBraceShortcodeByName(): void {
+    $data = [
+      ['nid', 'body'],
+      [$this->node->id(), 'See {{media:My Named Asset}} for details.'],
+    ];
+    $import_file = $this->createCsvFile($data);
+    $mapping = [
+      ['target' => 'nid', 'source' => 'nid'],
+      ['target' => 'field_body', 'source' => 'body'],
+    ];
+
+    $result = $this->importCsvFile($import_file, $mapping);
+    $this->assertEquals(MigrationInterface::RESULT_COMPLETED, $result);
+
+    $body = $this->entityTypeManager->getStorage('node')->load($this->node->id())->get('field_body')->value;
+    $this->assertStringContainsString('data-entity-uuid="' . $this->mediaByName->uuid() . '"', $body);
+    $this->assertStringNotContainsString('{{media:', $body);
+  }
+
+  /**
+   * Tests that {{media:filename}} falls back to filename lookup when name fails.
+   */
+  public function testCurlyBraceShortcodeByFilename(): void {
+    // Use the filename as the shortcode value; no media entity has this as its
+    // name, so the plugin falls back to filename lookup.
+    $data = [
+      ['nid', 'body'],
+      [$this->node->id(), 'See {{media:filename-lookup.txt}} for details.'],
+    ];
+    $import_file = $this->createCsvFile($data);
+    $mapping = [
+      ['target' => 'nid', 'source' => 'nid'],
+      ['target' => 'field_body', 'source' => 'body'],
+    ];
+
+    $result = $this->importCsvFile($import_file, $mapping);
+    $this->assertEquals(MigrationInterface::RESULT_COMPLETED, $result);
+
+    $body = $this->entityTypeManager->getStorage('node')->load($this->node->id())->get('field_body')->value;
+    $this->assertStringContainsString('data-entity-uuid="' . $this->mediaByFilename->uuid() . '"', $body);
+    $this->assertStringNotContainsString('{{media:', $body);
+  }
+
+  /**
+   * Tests [media name="..."] square-bracket shortcode.
+   */
+  public function testSquareBracketShortcodeByName(): void {
+    $data = [
+      ['nid', 'body'],
+      [$this->node->id(), 'See [media name="My Named Asset"] for details.'],
+    ];
+    $import_file = $this->createCsvFile($data);
+    $mapping = [
+      ['target' => 'nid', 'source' => 'nid'],
+      ['target' => 'field_body', 'source' => 'body'],
+    ];
+
+    $result = $this->importCsvFile($import_file, $mapping);
+    $this->assertEquals(MigrationInterface::RESULT_COMPLETED, $result);
+
+    $body = $this->entityTypeManager->getStorage('node')->load($this->node->id())->get('field_body')->value;
+    $this->assertStringContainsString('data-entity-uuid="' . $this->mediaByName->uuid() . '"', $body);
+    $this->assertStringNotContainsString('[media ', $body);
+  }
+
+  /**
+   * Tests [media filename="..."] square-bracket shortcode.
+   */
+  public function testSquareBracketShortcodeByFilename(): void {
+    $data = [
+      ['nid', 'body'],
+      [$this->node->id(), '[media filename="filename-lookup.txt"]'],
+    ];
+    $import_file = $this->createCsvFile($data);
+    $mapping = [
+      ['target' => 'nid', 'source' => 'nid'],
+      ['target' => 'field_body', 'source' => 'body'],
+    ];
+
+    $result = $this->importCsvFile($import_file, $mapping);
+    $this->assertEquals(MigrationInterface::RESULT_COMPLETED, $result);
+
+    $body = $this->entityTypeManager->getStorage('node')->load($this->node->id())->get('field_body')->value;
+    $this->assertStringContainsString('data-entity-uuid="' . $this->mediaByFilename->uuid() . '"', $body);
+    $this->assertStringNotContainsString('[media ', $body);
+  }
+
+  /**
+   * Tests that view-mode and align attributes survive the shortcode expansion.
+   */
+  public function testSquareBracketShortcodePreservesAttributes(): void {
+    $data = [
+      ['nid', 'body'],
+      [$this->node->id(), '[media name="My Named Asset" view-mode="thumbnail" align="center"]'],
+    ];
+    $import_file = $this->createCsvFile($data);
+    $mapping = [
+      ['target' => 'nid', 'source' => 'nid'],
+      ['target' => 'field_body', 'source' => 'body'],
+    ];
+
+    $result = $this->importCsvFile($import_file, $mapping);
+    $this->assertEquals(MigrationInterface::RESULT_COMPLETED, $result);
+
+    $body = $this->entityTypeManager->getStorage('node')->load($this->node->id())->get('field_body')->value;
+    $this->assertStringContainsString('data-entity-uuid="' . $this->mediaByName->uuid() . '"', $body);
+    $this->assertStringContainsString('data-view-mode="thumbnail"', $body);
+    $this->assertStringContainsString('data-align="center"', $body);
+  }
+
+  /**
    * Tests that an unknown name leaves the tag unchanged and migration completes.
    */
   public function testUnknownNameLeavesTagUnchanged(): void {

--- a/modules/mukurtu_import/tests/src/Kernel/ImportFormattedTextMediaEmbedTest.php
+++ b/modules/mukurtu_import/tests/src/Kernel/ImportFormattedTextMediaEmbedTest.php
@@ -380,6 +380,10 @@ class ImportFormattedTextMediaEmbedTest extends MukurtuImportTestBase {
     $body = $this->entityTypeManager->getStorage('node')->load($this->node->id())->get('field_body')->value;
     $this->assertStringNotContainsString('data-entity-uuid=', $body);
     $this->assertStringContainsString('data-entity-name="My Named Asset"', $body);
+
+    $messages = iterator_to_array($this->lastMigration->getIdMap()->getMessages());
+    $this->assertCount(1, $messages);
+    $this->assertStringContainsString('"My Named Asset" is ambiguous', $messages[0]->message);
   }
 
   /**
@@ -422,6 +426,10 @@ class ImportFormattedTextMediaEmbedTest extends MukurtuImportTestBase {
     $body = $this->entityTypeManager->getStorage('node')->load($this->node->id())->get('field_body')->value;
     $this->assertStringNotContainsString('data-entity-uuid=', $body);
     $this->assertStringContainsString('data-entity-filename="filename-lookup.txt"', $body);
+
+    $messages = iterator_to_array($this->lastMigration->getIdMap()->getMessages());
+    $this->assertCount(1, $messages);
+    $this->assertStringContainsString('"filename-lookup.txt" is ambiguous', $messages[0]->message);
   }
 
   /**

--- a/modules/mukurtu_import/tests/src/Kernel/MukurtuImportTestBase.php
+++ b/modules/mukurtu_import/tests/src/Kernel/MukurtuImportTestBase.php
@@ -9,6 +9,7 @@ use Drupal\Core\Session\AccountInterface;
 use Drupal\file\Entity\File;
 use Drupal\file\FileInterface;
 use Drupal\migrate\MigrateMessage;
+use Drupal\migrate\Plugin\MigrationInterface;
 use Drupal\mukurtu_import\Entity\MukurtuImportStrategy;
 use Drupal\mukurtu_import\ImportBatchExecutable;
 use Drupal\mukurtu_protocol\Entity\Community;
@@ -30,6 +31,13 @@ class MukurtuImportTestBase extends MigrateTestBase {
     setCurrentUser as drupalSetCurrentUser;
     setUpCurrentUser as drupalSetUpCurrentUser;
   }
+  /**
+   * The migration used in the most recent importCsvFile() call.
+   *
+   * @var \Drupal\migrate\Plugin\MigrationInterface
+   */
+  protected MigrationInterface $lastMigration;
+
   /**
    * The user account set as the current user in the tests.
    *
@@ -266,6 +274,7 @@ class MukurtuImportTestBase extends MigrateTestBase {
     $message = new MigrateMessage();
     $migration_plugin_manager = \Drupal::service('plugin.manager.migration');
     $migration = $migration_plugin_manager->createStubMigration($definition);
+    $this->lastMigration = $migration;
     $time = \Drupal::service('datetime.time');
     $translation = \Drupal::service('string_translation');
     $executable = new ImportBatchExecutable(

--- a/modules/mukurtu_migrate/src/Plugin/migrate/process/MediaEmbed.php
+++ b/modules/mukurtu_migrate/src/Plugin/migrate/process/MediaEmbed.php
@@ -114,9 +114,9 @@ class MediaEmbed extends MigrationLookup {
     // JSON data as $value here. There is no harm here, as it will load, but
     // fail the xpath query.
     $doc = new DOMDocument();
-    libxml_use_internal_errors(TRUE);
+    $previous = libxml_use_internal_errors(TRUE);
     $doc->loadHTML('<?xml encoding="utf-8"?>' . $value, LIBXML_HTML_NODEFDTD);
-    libxml_use_internal_errors(FALSE);
+    libxml_use_internal_errors($previous);
     $xpath = new DOMXPath($doc);
     $scald_id_divs = $xpath->query("//div[@class='dnd-atom-wrapper']");
 

--- a/modules/mukurtu_migrate/src/Plugin/migrate/process/MediaEmbed.php
+++ b/modules/mukurtu_migrate/src/Plugin/migrate/process/MediaEmbed.php
@@ -114,7 +114,9 @@ class MediaEmbed extends MigrationLookup {
     // JSON data as $value here. There is no harm here, as it will load, but
     // fail the xpath query.
     $doc = new DOMDocument();
-    $doc->loadHTML($value, LIBXML_HTML_NODEFDTD);
+    libxml_use_internal_errors(TRUE);
+    $doc->loadHTML('<?xml encoding="utf-8"?>' . $value, LIBXML_HTML_NODEFDTD);
+    libxml_use_internal_errors(FALSE);
     $xpath = new DOMXPath($doc);
     $scald_id_divs = $xpath->query("//div[@class='dnd-atom-wrapper']");
 
@@ -153,7 +155,7 @@ class MediaEmbed extends MigrationLookup {
 
     if ($scald_atom_replaced) {
       $new_value = $doc->saveHTML();
-      $strip_these_tags = ["<html>", "</html>", "<body>", "</body>"];
+      $strip_these_tags = ['<?xml encoding="utf-8"?>', "<html>", "</html>", "<body>", "</body>"];
       $value = str_replace($strip_these_tags, "", $new_value);
     }
 


### PR DESCRIPTION
Closes #1513

## Summary

- Adds a new migrate process plugin `mukurtu_resolve_media_embeds` that runs on formatted text field values during CSV import
- Supports two new `drupal-media` tag attributes as alternatives to `data-entity-uuid`:
  - `data-entity-name="My Image"` — resolves by media entity label
  - `data-entity-filename="image.jpg"` — resolves by the filename of the media's source file
- Both attributes are resolved to a proper UUID and removed before the content is saved; existing `data-entity-uuid` tags are unaffected
- Unresolvable references (not found, ambiguous) log a migration message and leave the tag unchanged so the import still completes

## Supported in CSV sheets

| Syntax | Lookup | Attributes |
|---|---|---|
| `{{media:My Image}}` or `{{media:photo.jpg}}` | Name, then filename fallback | Default view mode |
| `[media name="My Image"]` | Name only | `view-mode`, `align`, `caption`, `alt` |
| `[media filename="photo.jpg"]` | Filename only | `view-mode`, `align`, `caption`, `alt` |
| `<drupal-media data-entity-name="...">` | Name only | Full tag control |
| `<drupal-media data-entity-filename="...">` | Filename only | Full tag control |

## Test plan

- [x] `testResolveByName` — `data-entity-name` resolves to correct UUID
- [x] `testResolveByFilename` — `data-entity-filename` resolves to correct UUID
- [x] `testExistingUuidPassesThrough` — existing UUID tags are unchanged
- [x] `testUnknownNameLeavesTagUnchanged` — unresolvable name leaves tag intact and migration completes

Run: `vendor/bin/phpunit --bootstrap web/core/tests/bootstrap.php web/profiles/mukurtu/modules/mukurtu_import/tests/src/Kernel/ImportFormattedTextMediaEmbedTest.php`

🤖 Generated with [Claude Code](https://claude.com/claude-code)