### PR TITLE
Account menu cleanup and login redirect (#1566, #1576)

### DIFF
--- a/modules/mukurtu_core/mukurtu_core.install
+++ b/modules/mukurtu_core/mukurtu_core.install
@@ -495,6 +495,10 @@ function mukurtu_core_update_40012(): void {
 
 /**
  * Reorder account menu: Create Content first (-1000), Dashboard second (-100).
+ *
+ * Matches by title in the account menu. Admins may have renamed these links,
+ * in which case this hook silently skips them — no manual follow-up needed
+ * since custom names imply intentional customization.
  */
 function mukurtu_core_update_40013(): void {
   $storage = \Drupal::entityTypeManager()->getStorage('menu_link_content');

--- a/modules/mukurtu_core/mukurtu_core.install
+++ b/modules/mukurtu_core/mukurtu_core.install
@@ -464,3 +464,31 @@ function mukurtu_core_update_40011(): void {
     $old_menu->delete();
   }
 }
+
+/**
+ * Remove "Add Component" and child links from the account menu.
+ */
+function mukurtu_core_update_40012(): void {
+  $storage = \Drupal::entityTypeManager()->getStorage('menu_link_content');
+
+  $ids = $storage->getQuery()
+    ->accessCheck(FALSE)
+    ->condition('menu_name', 'account')
+    ->condition('title', 'Add Component')
+    ->execute();
+
+  foreach ($ids as $id) {
+    $parent = $storage->load($id);
+    if (!$parent) {
+      continue;
+    }
+    $child_ids = $storage->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('parent', 'menu_link_content:' . $parent->uuid())
+      ->execute();
+    foreach ($storage->loadMultiple($child_ids) as $child) {
+      $child->delete();
+    }
+    $parent->delete();
+  }
+}

--- a/modules/mukurtu_core/mukurtu_core.install
+++ b/modules/mukurtu_core/mukurtu_core.install
@@ -492,3 +492,26 @@ function mukurtu_core_update_40012(): void {
     $parent->delete();
   }
 }
+
+/**
+ * Reorder account menu: Create Content first (-1000), Dashboard second (-100).
+ */
+function mukurtu_core_update_40013(): void {
+  $storage = \Drupal::entityTypeManager()->getStorage('menu_link_content');
+
+  $weights = [
+    'Create Content' => -1000,
+    'Dashboard' => -100,
+  ];
+
+  foreach ($weights as $title => $weight) {
+    $ids = $storage->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('menu_name', 'account')
+      ->condition('title', $title)
+      ->execute();
+    foreach ($storage->loadMultiple($ids) as $link) {
+      $link->set('weight', $weight)->save();
+    }
+  }
+}

--- a/modules/mukurtu_core/mukurtu_core.module
+++ b/modules/mukurtu_core/mukurtu_core.module
@@ -201,11 +201,10 @@ function mukurtu_core_form_user_login_form_alter(&$form, FormStateInterface $for
 }
 
 /**
- * Custom submit handler to redirect to dashboard on login.
+ * Custom submit handler to redirect to the front page on login.
  */
 function mukurtu_core_user_login_form_submit($form, FormStateInterface $form_state) {
-  $url = Url::fromRoute('entity.dashboard.canonical', ['dashboard' => 'mukurtu_dashboard']);
-  $form_state->setRedirectUrl($url);
+  $form_state->setRedirectUrl(Url::fromRoute('<front>'));
 }
 
 /**

--- a/modules/mukurtu_core/mukurtu_core.module
+++ b/modules/mukurtu_core/mukurtu_core.module
@@ -202,9 +202,15 @@ function mukurtu_core_form_user_login_form_alter(&$form, FormStateInterface $for
 
 /**
  * Custom submit handler to redirect to the front page on login.
+ *
+ * Only redirects when no ?destination parameter is present, so mid-session
+ * redirects (e.g. access-denied bounces) still land the user where they
+ * were headed.
  */
 function mukurtu_core_user_login_form_submit($form, FormStateInterface $form_state) {
-  $form_state->setRedirectUrl(Url::fromRoute('<front>'));
+  if (!\Drupal::request()->query->has('destination')) {
+    $form_state->setRedirectUrl(Url::fromRoute('<front>'));
+  }
 }
 
 /**

--- a/mukurtu.install
+++ b/mukurtu.install
@@ -132,7 +132,7 @@ function mukurtu_install() {
     'menu_name' => 'account',
     'description' => 'Dashboard',
     'expanded' => FALSE,
-    'weight' => -1000,
+    'weight' => -100,
   ])->save();
 
   // Create Content (parent)
@@ -142,7 +142,7 @@ function mukurtu_install() {
     'menu_name' => 'account',
     'description' => 'Create content',
     'expanded' => TRUE,
-    'weight' => -100,
+    'weight' => -1000,
   ]);
   $create_content_menu->save();
 

--- a/mukurtu.install
+++ b/mukurtu.install
@@ -223,61 +223,6 @@ function mukurtu_install() {
     'weight' => 50,
   ])->save();
 
-  // Add Component (parent)
-  $add_component_menu = MenuLinkContent::create([
-    'title' => 'Add Component',
-    'link' => ['uri' => 'internal:' . '/dashboard/mukurtu_dashboard'],
-    'menu_name' => 'account',
-    'description' => 'Add component',
-    'expanded' => FALSE,
-    'weight' => -90,
-  ]);
-  $add_component_menu->save();
-
-  // Community (under Add Component)
-  MenuLinkContent::create([
-    'title' => 'Community',
-    'link' => ['uri' => 'internal:' . '/communities/community/add'],
-    'menu_name' => 'account',
-    'description' => 'Add community',
-    'parent' => 'menu_link_content:' . $add_component_menu->uuid(),
-    'expanded' => FALSE,
-    'weight' => 0,
-  ])->save();
-
-  // Cultural protocol (under Add Component)
-  MenuLinkContent::create([
-    'title' => 'Cultural protocol',
-    'link' => ['uri' => 'internal:' . '/protocols/protocol/add'],
-    'menu_name' => 'account',
-    'description' => 'Add cultural protocol',
-    'parent' => 'menu_link_content:' . $add_component_menu->uuid(),
-    'expanded' => FALSE,
-    'weight' => 10,
-  ])->save();
-
-  // Category (under Add Component)
-  MenuLinkContent::create([
-    'title' => 'Category',
-    'link' => ['uri' => 'internal:' . '/admin/structure/taxonomy/manage/category/add'],
-    'menu_name' => 'account',
-    'description' => 'Add category',
-    'parent' => 'menu_link_content:' . $add_component_menu->uuid(),
-    'expanded' => FALSE,
-    'weight' => 20,
-  ])->save();
-
-  // User (under Add Component)
-  MenuLinkContent::create([
-    'title' => 'User',
-    'link' => ['uri' => 'internal:' . '/admin/people/create'],
-    'menu_name' => 'account',
-    'description' => 'Add user',
-    'parent' => 'menu_link_content:' . $add_component_menu->uuid(),
-    'expanded' => FALSE,
-    'weight' => 30,
-  ])->save();
-
   // Delete unused user flags that crash user registration page.
   $flagStorage = \Drupal::entityTypeManager()->getStorage('flag');
   foreach (['email_user', 'subscribe_user'] as $userFlagID) {


### PR DESCRIPTION
## Summary

- Removes the **Add Component** dropdown and its four child links (Community, Cultural protocol, Category, User) from the account menu (#1576)
- Reorders the remaining account menu items: **Create Content → Dashboard → Log Out** (#1576)
- Redirects users to the **front page** on login instead of `/dashboard` (#1566); respects `?destination` so mid-session bounces still land correctly

## Files changed

- `mukurtu.install` — removes Add Component block from install function; swaps Dashboard/Create Content weights
- `modules/mukurtu_core/mukurtu_core.install` — adds `mukurtu_core_update_40012` (delete links) and `mukurtu_core_update_40013` (reorder weights)
- `modules/mukurtu_core/mukurtu_core.module` — updates login submit handler to redirect to `<front>`, preserving `?destination`

## Update hooks

| Hook | Action |
|------|--------|
| `mukurtu_core_update_40012` | Deletes "Add Component" and its children from the account menu on existing sites |
| `mukurtu_core_update_40013` | Sets Create Content weight -1000, Dashboard weight -100 on existing sites |

## Test plan

- [ ] Run `ddev drush updb` — confirm both update hooks run without error
- [ ] Check the account menu as a logged-in user — Add Component dropdown should be gone, order should be Create Content → Dashboard → Log Out
- [ ] Log in without a `?destination` param — should land on the front page
- [ ] Log in with a `?destination=/some/page` (e.g. by visiting a protected page while logged out) — should land on `/some/page`, not the front page
- [ ] Fresh install — confirm Add Component is absent and menu order is correct from the start

## PR review summary

Reviewed on branch prior to opening. No blocking issues found.

**Fixed before opening:**
- Login redirect now skips `setRedirectUrl` when `?destination` is present, avoiding regression for mid-session flows
- Added docblock to `mukurtu_core_update_40013` noting the title-match assumption (admins who renamed the links won't be affected — intentional)

**Acknowledged non-blocking notes:**
- Update hooks match by title in the account menu; custom-named links will be silently skipped, which is the correct behaviour for customised sites
- No tests exist for these paths in the test suite; manual verification above covers the scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)