### PR TITLE
Dashboard panels cleanup (#1577)

### DIFF
--- a/config/install/dashboards.dashboard.mukurtu_dashboard.yml
+++ b/config/install/dashboards.dashboard.mukurtu_dashboard.yml
@@ -12,7 +12,7 @@ third_party_settings:
       restricted_categories: {  }
       allowed_layouts: {  }
 _core:
-  default_config_hash: _O8NOA9JSEt9Zy3WdKUs4xOL7aHvfwUmBz1oifvnvEw
+  default_config_hash: rVGaJigae-beV372fO5BQUxNElb3GXG-yxGn7pPVzko
 id: mukurtu_dashboard
 admin_label: 'Mukurtu Dashboard'
 category: ''
@@ -25,19 +25,6 @@ sections:
       label: 'main content'
       context_mapping: {  }
     components:
-      0d6f9095-ddc7-4e04-b102-a47eab86f9dc:
-        uuid: 0d6f9095-ddc7-4e04-b102-a47eab86f9dc
-        region: three
-        configuration:
-          id: 'views_block:content_recent-block_1'
-          label: ''
-          label_display: visible
-          provider: views
-          context_mapping: {  }
-          views_label: ''
-          items_per_page: null
-        weight: 3
-        additional: {  }
       177c8838-ecba-43f7-9acb-813187ae16f3:
         uuid: 177c8838-ecba-43f7-9acb-813187ae16f3
         region: three
@@ -66,34 +53,6 @@ sections:
           expand_all_items: false
         weight: 7
         additional: {  }
-      7ea8f4fe-f816-4b62-80ed-597ea6d8d39a:
-        uuid: 7ea8f4fe-f816-4b62-80ed-597ea6d8d39a
-        region: two
-        configuration:
-          id: 'system_menu_block:dashboard-site-info'
-          label: 'Site information'
-          label_display: visible
-          provider: system
-          context_mapping: {  }
-          level: 1
-          depth: null
-          expand_all_items: false
-        weight: 8
-        additional: {  }
-      4baf6b8d-6deb-4742-aac9-5a4ca97be575:
-        uuid: 4baf6b8d-6deb-4742-aac9-5a4ca97be575
-        region: one
-        configuration:
-          id: 'system_menu_block:dashboard-users'
-          label: Users
-          label_display: visible
-          provider: system
-          context_mapping: {  }
-          level: 1
-          depth: null
-          expand_all_items: false
-        weight: 6
-        additional: {  }
       8e52ecf9-f13d-4974-b4e5-9ecff8af170a:
         uuid: 8e52ecf9-f13d-4974-b4e5-9ecff8af170a
         region: one
@@ -106,7 +65,7 @@ sections:
           level: 1
           depth: null
           expand_all_items: false
-        weight: 2
+        weight: 3
         additional: {  }
       9c53fff8-81e9-481e-b21c-2000b83a178e:
         uuid: 9c53fff8-81e9-481e-b21c-2000b83a178e
@@ -120,35 +79,7 @@ sections:
           level: 1
           depth: null
           expand_all_items: false
-        weight: 3
-        additional: {  }
-      bb1a29d8-00e8-4229-b1b0-20d69ca33db7:
-        uuid: bb1a29d8-00e8-4229-b1b0-20d69ca33db7
-        region: one
-        configuration:
-          id: 'system_menu_block:dashboard-content-settings'
-          label: 'Content settings'
-          label_display: visible
-          provider: system
-          context_mapping: {  }
-          level: 1
-          depth: null
-          expand_all_items: false
         weight: 4
-        additional: {  }
-      0339943d-08c4-45a9-9f08-052ad308db5e:
-        uuid: 0339943d-08c4-45a9-9f08-052ad308db5e
-        region: two
-        configuration:
-          id: 'system_menu_block:dashboard-site-settings'
-          label: 'Site settings'
-          label_display: visible
-          provider: system
-          context_mapping: {  }
-          level: 1
-          depth: null
-          expand_all_items: false
-        weight: 2
         additional: {  }
       6952fdbe-035a-4ccc-af26-e0dcd691187e:
         uuid: 6952fdbe-035a-4ccc-af26-e0dcd691187e
@@ -164,34 +95,6 @@ sections:
           expand_all_items: false
         weight: 4
         additional: {  }
-      a663f15a-8760-424c-9433-c3f97fa8b623:
-        uuid: a663f15a-8760-424c-9433-c3f97fa8b623
-        region: two
-        configuration:
-          id: 'system_menu_block:dashboard-multilingual'
-          label: Multilingual
-          label_display: visible
-          provider: system
-          context_mapping: {  }
-          level: 1
-          depth: null
-          expand_all_items: false
-        weight: 6
-        additional: {  }
-      02ce0aa5-8aec-43f3-b2e0-62d5dbf8efce:
-        uuid: 02ce0aa5-8aec-43f3-b2e0-62d5dbf8efce
-        region: two
-        configuration:
-          id: 'system_menu_block:dashboard-look-feel'
-          label: 'Look and feel'
-          label_display: visible
-          provider: system
-          context_mapping: {  }
-          level: 1
-          depth: null
-          expand_all_items: false
-        weight: 3
-        additional: {  }
       58ca9634-095d-4720-9aed-76c640314ac4:
         uuid: 58ca9634-095d-4720-9aed-76c640314ac4
         region: one
@@ -204,7 +107,7 @@ sections:
           level: 1
           depth: null
           expand_all_items: false
-        weight: 5
+        weight: 6
         additional: {  }
       50f4bbbe-2fa6-4b11-b0c5-221705fb726c:
         uuid: 50f4bbbe-2fa6-4b11-b0c5-221705fb726c
@@ -219,5 +122,102 @@ sections:
           depth: null
           expand_all_items: false
         weight: 1
+        additional: {  }
+      4baf6b8d-6deb-4742-aac9-5a4ca97be575:
+        uuid: 4baf6b8d-6deb-4742-aac9-5a4ca97be575
+        region: one
+        configuration:
+          id: 'system_menu_block:dashboard-users'
+          label: Users
+          label_display: visible
+          provider: system
+          context_mapping: {  }
+          level: 1
+          depth: null
+          expand_all_items: false
+        weight: 2
+        additional: {  }
+      0d6f9095-ddc7-4e04-b102-a47eab86f9dc:
+        uuid: 0d6f9095-ddc7-4e04-b102-a47eab86f9dc
+        region: two
+        configuration:
+          id: 'views_block:content_recent-block_1'
+          label: ''
+          label_display: visible
+          provider: views
+          context_mapping: {  }
+          views_label: ''
+          items_per_page: null
+        weight: 2
+        additional: {  }
+      0339943d-08c4-45a9-9f08-052ad308db5e:
+        uuid: 0339943d-08c4-45a9-9f08-052ad308db5e
+        region: three
+        configuration:
+          id: 'system_menu_block:dashboard-site-settings'
+          label: 'Site settings'
+          label_display: visible
+          provider: system
+          context_mapping: {  }
+          level: 1
+          depth: null
+          expand_all_items: false
+        weight: 6
+        additional: {  }
+      7ea8f4fe-f816-4b62-80ed-597ea6d8d39a:
+        uuid: 7ea8f4fe-f816-4b62-80ed-597ea6d8d39a
+        region: three
+        configuration:
+          id: 'system_menu_block:dashboard-site-info'
+          label: 'Site information'
+          label_display: visible
+          provider: system
+          context_mapping: {  }
+          level: 1
+          depth: null
+          expand_all_items: false
+        weight: 8
+        additional: {  }
+      02ce0aa5-8aec-43f3-b2e0-62d5dbf8efce:
+        uuid: 02ce0aa5-8aec-43f3-b2e0-62d5dbf8efce
+        region: three
+        configuration:
+          id: 'system_menu_block:dashboard-look-feel'
+          label: 'Look and feel'
+          label_display: visible
+          provider: system
+          context_mapping: {  }
+          level: 1
+          depth: null
+          expand_all_items: false
+        weight: 5
+        additional: {  }
+      a663f15a-8760-424c-9433-c3f97fa8b623:
+        uuid: a663f15a-8760-424c-9433-c3f97fa8b623
+        region: three
+        configuration:
+          id: 'system_menu_block:dashboard-multilingual'
+          label: Multilingual
+          label_display: visible
+          provider: system
+          context_mapping: {  }
+          level: 1
+          depth: null
+          expand_all_items: false
+        weight: 7
+        additional: {  }
+      bb1a29d8-00e8-4229-b1b0-20d69ca33db7:
+        uuid: bb1a29d8-00e8-4229-b1b0-20d69ca33db7
+        region: two
+        configuration:
+          id: 'system_menu_block:dashboard-content-settings'
+          label: 'Content settings'
+          label_display: visible
+          provider: system
+          context_mapping: {  }
+          level: 1
+          depth: null
+          expand_all_items: false
+        weight: 6
         additional: {  }
     third_party_settings: {  }

--- a/modules/mukurtu_core/mukurtu_core.install
+++ b/modules/mukurtu_core/mukurtu_core.install
@@ -519,3 +519,37 @@ function mukurtu_core_update_40013(): void {
     }
   }
 }
+
+/**
+ * Reorganize mukurtu_dashboard blocks: move admin panels to region three,
+ * recent content to region two, and update weights throughout.
+ */
+function mukurtu_core_update_40014(): void {
+  $config = \Drupal::configFactory()->getEditable('dashboards.dashboard.mukurtu_dashboard');
+  $sections = $config->get('sections');
+
+  // Map of component UUID => [region, weight] to apply.
+  $updates = [
+    '0d6f9095-ddc7-4e04-b102-a47eab86f9dc' => ['region' => 'two',   'weight' => 2],
+    '7ea8f4fe-f816-4b62-80ed-597ea6d8d39a' => ['region' => 'three', 'weight' => 8],
+    '4baf6b8d-6deb-4742-aac9-5a4ca97be575' => ['region' => 'one',   'weight' => 2],
+    '8e52ecf9-f13d-4974-b4e5-9ecff8af170a' => ['region' => 'one',   'weight' => 3],
+    '9c53fff8-81e9-481e-b21c-2000b83a178e' => ['region' => 'one',   'weight' => 4],
+    'bb1a29d8-00e8-4229-b1b0-20d69ca33db7' => ['region' => 'two',   'weight' => 6],
+    '0339943d-08c4-45a9-9f08-052ad308db5e' => ['region' => 'three', 'weight' => 6],
+    'a663f15a-8760-424c-9433-c3f97fa8b623' => ['region' => 'three', 'weight' => 7],
+    '02ce0aa5-8aec-43f3-b2e0-62d5dbf8efce' => ['region' => 'three', 'weight' => 5],
+    '58ca9634-095d-4720-9aed-76c640314ac4' => ['region' => 'one',   'weight' => 6],
+  ];
+
+  foreach ($sections as $section_key => $section) {
+    foreach ($section['components'] ?? [] as $uuid => $component) {
+      if (isset($updates[$uuid])) {
+        $sections[$section_key]['components'][$uuid]['region'] = $updates[$uuid]['region'];
+        $sections[$section_key]['components'][$uuid]['weight'] = $updates[$uuid]['weight'];
+      }
+    }
+  }
+
+  $config->set('sections', $sections)->save();
+}

--- a/modules/mukurtu_core/mukurtu_core.services.yml
+++ b/modules/mukurtu_core/mukurtu_core.services.yml
@@ -3,3 +3,8 @@ services:
     class: Drupal\mukurtu_core\Routing\RouteSubscriber
     tags:
       - { name: event_subscriber }
+  mukurtu_core.dashboard_block_access_subscriber:
+    class: Drupal\mukurtu_core\EventSubscriber\DashboardBlockAccessSubscriber
+    arguments: ['@current_user']
+    tags:
+      - { name: event_subscriber }

--- a/modules/mukurtu_core/src/EventSubscriber/DashboardBlockAccessSubscriber.php
+++ b/modules/mukurtu_core/src/EventSubscriber/DashboardBlockAccessSubscriber.php
@@ -28,7 +28,7 @@ class DashboardBlockAccessSubscriber implements EventSubscriberInterface {
    * Denies rendering of role-restricted dashboard panels.
    */
   public function onBuildRender(SectionComponentBuildRenderArrayEvent $event): void {
-    $plugin_id = $event->getComponent()->getConfiguration()['id'] ?? '';
+    $plugin_id = $event->getPlugin()->getPluginId();
     $roles = $this->currentUser->getRoles();
 
     $allowed = match ($plugin_id) {

--- a/modules/mukurtu_core/src/EventSubscriber/DashboardBlockAccessSubscriber.php
+++ b/modules/mukurtu_core/src/EventSubscriber/DashboardBlockAccessSubscriber.php
@@ -29,20 +29,23 @@ class DashboardBlockAccessSubscriber implements EventSubscriberInterface {
    */
   public function onBuildRender(SectionComponentBuildRenderArrayEvent $event): void {
     $plugin_id = $event->getPlugin()->getPluginId();
-    $roles = $this->currentUser->getRoles();
 
-    $allowed = match ($plugin_id) {
+    $restricted = [
       'system_menu_block:dashboard-migration' =>
-        in_array('administrator', $roles, TRUE),
+        in_array('administrator', $this->currentUser->getRoles(), TRUE),
       'system_menu_block:dashboard-site-settings' =>
-        !empty(array_intersect(['administrator', 'mukurtu_manager'], $roles)),
-      default => TRUE,
-    };
+        !empty(array_intersect(['administrator', 'mukurtu_manager'], $this->currentUser->getRoles())),
+    ];
 
-    if (!$allowed) {
-      $cacheability = new CacheableMetadata();
-      $cacheability->addCacheContexts(['user.roles']);
-      $event->addCacheableDependency($cacheability);
+    if (!array_key_exists($plugin_id, $restricted)) {
+      return;
+    }
+
+    $cacheability = new CacheableMetadata();
+    $cacheability->addCacheContexts(['user.roles']);
+    $event->addCacheableDependency($cacheability);
+
+    if (!$restricted[$plugin_id]) {
       $event->stopPropagation();
     }
   }

--- a/modules/mukurtu_core/src/EventSubscriber/DashboardBlockAccessSubscriber.php
+++ b/modules/mukurtu_core/src/EventSubscriber/DashboardBlockAccessSubscriber.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Drupal\mukurtu_core\EventSubscriber;
+
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\layout_builder\Event\SectionComponentBuildRenderArrayEvent;
+use Drupal\layout_builder\LayoutBuilderEvents;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Restricts specific dashboard panels by role.
+ */
+class DashboardBlockAccessSubscriber implements EventSubscriberInterface {
+
+  public function __construct(protected AccountInterface $currentUser) {}
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents(): array {
+    return [
+      LayoutBuilderEvents::SECTION_COMPONENT_BUILD_RENDER_ARRAY => ['onBuildRender', 200],
+    ];
+  }
+
+  /**
+   * Denies rendering of role-restricted dashboard panels.
+   */
+  public function onBuildRender(SectionComponentBuildRenderArrayEvent $event): void {
+    $plugin_id = $event->getComponent()->getConfiguration()['id'] ?? '';
+    $roles = $this->currentUser->getRoles();
+
+    $allowed = match ($plugin_id) {
+      'system_menu_block:dashboard-migration' =>
+        in_array('administrator', $roles, TRUE),
+      'system_menu_block:dashboard-site-settings' =>
+        !empty(array_intersect(['administrator', 'mukurtu_manager'], $roles)),
+      default => TRUE,
+    };
+
+    if (!$allowed) {
+      $cacheability = new CacheableMetadata();
+      $cacheability->addCacheContexts(['user.roles']);
+      $event->addCacheableDependency($cacheability);
+      $event->stopPropagation();
+    }
+  }
+
+}


### PR DESCRIPTION
## Summary

- [ ] Only administrators and mukurtu managers can see the "Site settings" block (this was exposing "view site-wide local contexts projects" to all users which was unnecessary).
   - [ ] The LC directory is still accessible as before, I anticipate people will be providing front end links when they use it.
- [ ] Only administrators can see the "migration" block (since that should only be run by UID one it seems to make sense).

## Details

- Adds a layout builder event subscriber (`DashboardBlockAccessSubscriber`) that intercepts `SECTION_COMPONENT_BUILD_RENDER_ARRAY` at priority 200 (before the standard subscriber at 100)
- The **Migration** panel (`system_menu_block:dashboard-migration`) is now hidden for all roles except `administrator`
- The **Site settings** panel (`system_menu_block:dashboard-site-settings`) is now hidden for all roles except `administrator` and `mukurtu_manager`
- `user.roles` cache context is applied when access is denied, so the page cache varies correctly per role

## Implementation notes

`hook_block_access` was not usable here — it only fires for block config entities, but the dashboard renders block plugins directly via layout builder's `SectionComponent::toRenderArray()`. The event subscriber approach intercepts the layout builder render pipeline before the block is built.

## Test plan

- [ ] Log in as `administrator` → both Migration and Site settings panels visible
- [ ] Log in as `mukurtu_manager` → Site settings panel visible, Migration panel hidden
- [ ] Log in as any other authenticated user → neither panel visible
- [ ] Confirm `/local-contexts/projects` remains publicly accessible (no route change)
- [ ] `ddev drush cr` after deploy (new service registered)

Closes #1577

🤖 Generated with [Claude Code](https://claude.com/claude-code)