### PR TITLE
Pin pathauto to ~1.14.0 to prevent install failure

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
         "drupal/migrate_tools": "^6.0",
         "drupal/og": "^1.x-dev",
         "drupal/paragraphs": "*",
-        "drupal/pathauto": "*",
+        "drupal/pathauto": "~1.14.0",
         "drupal/redirect": "*",
         "drupal/restui": "*",
         "drupal/search_api": "*",


### PR DESCRIPTION
pathauto 1.15.0 causes a synthetic kernel service error during drush site-install. Constraining to ~1.14.0 (>=1.14.0 <1.15.0) prevents Tugboat's composer update from picking up the broken release.

Pre-merge checklist:

- [ ] I have checked for and if required, created update hooks.
- [ ] I have run an accessibility check, and resolved any issues.
- [ ] I have recompiled SCSS if required.
- [ ] I have updated or created CI/CD tests, if required.
- [ ] I have updated from `main` and resolved any merge conflicts.
- [ ] I have verified that all expected checks pass.
- [ ] I have run the pr-expert-review skill and resolved all relevant issues.

