### PR TITLE
Grant community managers access to /admin/communities-protocols

### DIFF
--- a/modules/mukurtu_protocol/src/ProtocolHtmlRouteProvider.php
+++ b/modules/mukurtu_protocol/src/ProtocolHtmlRouteProvider.php
@@ -217,7 +217,7 @@ class ProtocolHtmlRouteProvider extends AdminHtmlRouteProvider {
           '_title_arguments' => $label->getArguments(),
           '_title_context' => $label->getOption('context'),
         ])
-        ->setRequirement('_mukurtu_permission', 'site:administer site configuration+protocol:update group+protocol:approve and deny subscription+protocol:manage members');
+        ->setRequirement('_mukurtu_permission', 'site:administer site configuration+protocol:update group+protocol:approve and deny subscription+protocol:manage members+community:update group+community:approve and deny subscription+community:manage members');
       return $route;
     }
   }


### PR DESCRIPTION
Closes https://github.com/MukurtuCMS/Mukurtu-CMS/issues/1587

To test:

- [x] Create a user with no site admin roles.
- [x] Make them a community manager, but NOT a protocol steward
- [x] As that user, via the dashboard, access "Manage communities and cultural protocols" link/page.

Pre-merge checklist:

- [x] I have checked for and if required, created update hooks.
- [x] I have run an accessibility check, and resolved any issues.
- [x] I have recompiled SCSS if required.
- [ ] I have updated or created CI/CD tests, if required.
- [x] I have updated from `main` and resolved any merge conflicts.
- [x] I have verified that all expected checks pass.
- [x] I have run the pr-expert-review skill and resolved all relevant issues.

