### PR TITLE
Remove duplicate module from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -77,7 +77,6 @@
         "drupal/admin_theme": "^1.1",
         "drupal/config_translation_po": "^1.0",
         "geocoder-php/nominatim-provider": "*",
-        "drupal/tagify": "^1.2",
         "drupal/genpass": "^2.1",
         "drupal/rebuild_cache_access": "^1.12",
         "drupal/notify_user_default": "^1.0",


### PR DESCRIPTION
Tiny change, just noticed that `"drupal/tagify": "^1.2",` was in the require list twice.