### PR TITLE
Community-level OG block now cascades to child protocols (#952)

### DIFF
--- a/modules/mukurtu_protocol/config/install/views.view.og_members_overview.yml
+++ b/modules/mukurtu_protocol/config/install/views.view.og_members_overview.yml
@@ -1,0 +1,593 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - og
+    - options
+    - user
+id: og_members_overview
+label: 'Members overview'
+module: views
+description: 'Overview of the existing group members'
+tag: ''
+base_table: og_membership
+base_field: id
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Master
+    position: 0
+    display_options:
+      access:
+        type: perm
+        options:
+          perm: 'access user profiles'
+      cache:
+        type: none
+        options: {  }
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_comment: ''
+          query_tags: {  }
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      pager:
+        type: full
+        options:
+          items_per_page: 50
+          offset: 0
+          id: 0
+          total_pages: null
+          tags:
+            previous: ‹‹
+            next: ››
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          override: true
+          sticky: false
+          caption: ''
+          summary: ''
+          description: ''
+          columns:
+            og_membership_bulk_form: og_membership_bulk_form
+            name: name
+          info:
+            og_membership_bulk_form:
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            name:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          default: '-1'
+          empty_table: false
+      row:
+        type: fields
+        options:
+          inline: {  }
+          separator: ''
+          hide_empty: false
+          default_field_elements: true
+      fields:
+        og_membership_bulk_form:
+          id: og_membership_bulk_form
+          table: og_membership
+          field: og_membership_bulk_form
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: 'Bulk update'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          action_title: Action
+          include_exclude: include
+          selected_actions:
+            - og_membership_add_multiple_roles_action
+            - og_membership_approve_pending_action
+            - og_membership_block_action
+            - og_membership_delete_action
+          entity_type: og_membership
+          plugin_id: og_membership_bulk_form
+        name:
+          id: name
+          table: users_field_data
+          field: name
+          relationship: uid
+          group_type: group
+          admin_label: ''
+          label: Name
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: user_name
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: user
+          entity_field: name
+          plugin_id: field
+        created:
+          id: created
+          table: og_membership
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: 'Member since'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: timestamp
+          settings:
+            date_format: medium
+            custom_date_format: ''
+            timezone: ''
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: og_membership
+          entity_field: created
+          plugin_id: field
+        state:
+          id: state
+          table: og_membership
+          field: state
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: State
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: og_membership
+          entity_field: state
+          plugin_id: field
+        roles_target_id:
+          id: roles_target_id
+          table: og_membership__roles
+          field: roles_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Roles
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: true
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: og_membership
+          entity_field: roles
+          plugin_id: field
+        operations:
+          id: operations
+          table: og_membership
+          field: operations
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: 'Operations links'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          destination: true
+          entity_type: og_membership
+          plugin_id: entity_operations
+      filters: {  }
+      sorts: {  }
+      header: {  }
+      footer: {  }
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: 'No results text'
+          empty: true
+          tokenize: false
+          content: 'There are no members that belong to this group.'
+          plugin_id: text_custom
+      relationships:
+        uid:
+          id: uid
+          table: og_membership
+          field: uid
+          relationship: none
+          group_type: group
+          admin_label: User
+          required: true
+          entity_type: og_membership
+          entity_field: uid
+          plugin_id: standard
+      arguments:
+        entity_type:
+          id: entity_type
+          table: og_membership
+          field: entity_type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          default_action: 'access denied'
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: fixed
+          default_argument_options:
+            argument: ''
+          summary_options:
+            base_path: ''
+            count: true
+            items_per_page: 25
+            override: false
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          glossary: false
+          limit: 0
+          case: none
+          path_case: none
+          transform_dash: false
+          break_phrase: false
+          entity_type: og_membership
+          entity_field: entity_type
+          plugin_id: string
+        entity_id:
+          id: entity_id
+          table: og_membership
+          field: entity_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          default_action: 'access denied'
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: fixed
+          default_argument_options:
+            argument: ''
+          summary_options:
+            base_path: ''
+            count: true
+            items_per_page: 25
+            override: false
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          glossary: false
+          limit: 0
+          case: none
+          path_case: none
+          transform_dash: false
+          break_phrase: false
+          entity_type: og_membership
+          entity_field: entity_id
+          plugin_id: string
+      display_extenders: {  }
+    cache_metadata:
+      max-age: 0
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user.permissions
+      tags: {  }

--- a/modules/mukurtu_protocol/config/install/views.view.og_members_overview.yml
+++ b/modules/mukurtu_protocol/config/install/views.view.og_members_overview.yml
@@ -73,7 +73,7 @@ display:
           default_row_class: true
           override: true
           sticky: false
-          caption: ''
+          caption: 'Group members'
           summary: ''
           description: ''
           columns:

--- a/modules/mukurtu_protocol/css/protocol-list.css
+++ b/modules/mukurtu_protocol/css/protocol-list.css
@@ -69,3 +69,30 @@ html.gin--dark-mode tr.community-row button:focus-visible {
     outline-color: #7ab8f5;
   }
 }
+
+/* Badge shown in the protocol members list when a member is blocked at the
+ * community level but still holds an active protocol membership. */
+.community-blocked-badge {
+  display: inline-block;
+  padding: 0.1em 0.45em;
+  font-size: 0.75em;
+  font-weight: 600;
+  line-height: 1.4;
+  vertical-align: middle;
+  background-color: var(--gin-color-warning-background, #fdf8ed);
+  color: var(--gin-color-warning, #734c00);
+  border: 1px solid currentColor;
+  border-radius: 2px;
+}
+
+html.gin--dark-mode .community-blocked-badge {
+  background-color: var(--gin-color-warning-background, #3d2e00);
+  color: var(--gin-color-warning, #f5c518);
+}
+
+@media (prefers-color-scheme: dark) {
+  .community-blocked-badge {
+    background-color: var(--gin-color-warning-background, #3d2e00);
+    color: var(--gin-color-warning, #f5c518);
+  }
+}

--- a/modules/mukurtu_protocol/mukurtu_protocol.install
+++ b/modules/mukurtu_protocol/mukurtu_protocol.install
@@ -290,3 +290,13 @@ function mukurtu_protocol_update_40007(): void {
 function mukurtu_protocol_update_40008(): void {
   node_access_rebuild(TRUE);
 }
+
+/**
+ * Re-import og_members_overview view: remove Unblock bulk action.
+ */
+function mukurtu_protocol_update_40009(): void {
+  $module_path = \Drupal::service('extension.list.module')->getPath('mukurtu_protocol');
+  $config_file = $module_path . '/config/install/views.view.og_members_overview.yml';
+  $data = \Symfony\Component\Yaml\Yaml::parseFile($config_file);
+  \Drupal::configFactory()->getEditable('views.view.og_members_overview')->setData($data)->save(TRUE);
+}

--- a/modules/mukurtu_protocol/mukurtu_protocol.install
+++ b/modules/mukurtu_protocol/mukurtu_protocol.install
@@ -283,3 +283,10 @@ function mukurtu_protocol_update_40006(): void {
 function mukurtu_protocol_update_40007(): void {
   \Drupal::service('router.builder')->rebuild();
 }
+
+/**
+ * Rebuild node access grants so community-blocked users lose protocol access.
+ */
+function mukurtu_protocol_update_40008(): void {
+  node_access_rebuild(TRUE);
+}

--- a/modules/mukurtu_protocol/mukurtu_protocol.module
+++ b/modules/mukurtu_protocol/mukurtu_protocol.module
@@ -20,6 +20,7 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Url;
 use Drupal\og\Og;
+use Drupal\og\OgMembershipInterface;
 use Drupal\mukurtu_protocol\Plugin\Action\MukurtuDeleteOgMembershipAction;
 
 /**
@@ -834,6 +835,73 @@ function add_protocol_member_form_validate(&$form, FormStateInterface $form_stat
 function mukurtu_protocol_action_info_alter(array &$definitions): void {
   if (isset($definitions['og_membership_delete_action'])) {
     $definitions['og_membership_delete_action']['class'] = MukurtuDeleteOgMembershipAction::class;
+  }
+}
+
+/**
+ * Implements hook_entity_operation().
+ *
+ * Adds per-row Block and Approve links to OG membership rows on the community
+ * and protocol member list pages.
+ */
+function mukurtu_protocol_entity_operation(\Drupal\Core\Entity\EntityInterface $entity) {
+  $operations = [];
+
+  if ($entity->getEntityTypeId() !== 'og_membership') {
+    return $operations;
+  }
+
+  /** @var \Drupal\og\Entity\OgMembership $entity */
+  $group_type = $entity->getGroupEntityType();
+  if ($group_type !== 'community' && $group_type !== 'protocol') {
+    return $operations;
+  }
+
+  $state = $entity->getState();
+
+  if ($state !== OgMembershipInterface::STATE_BLOCKED) {
+    $operations['block'] = [
+      'title' => t('Block'),
+      'url' => Url::fromRoute('mukurtu_protocol.og_membership.block', ['og_membership' => $entity->id()]),
+      'weight' => 20,
+    ];
+  }
+
+  if ($state === OgMembershipInterface::STATE_PENDING) {
+    $operations['approve'] = [
+      'title' => t('Approve'),
+      'url' => Url::fromRoute('mukurtu_protocol.og_membership.approve', ['og_membership' => $entity->id()]),
+      'weight' => 25,
+    ];
+  }
+
+  return $operations;
+}
+
+/**
+ * Implements hook_entity_operation_alter().
+ *
+ * Renames the default OG membership "Edit" and "Delete" operations to use
+ * Mukurtu-appropriate labels on community and protocol member pages.
+ */
+function mukurtu_protocol_entity_operation_alter(array &$operations, \Drupal\Core\Entity\EntityInterface $entity) {
+  if ($entity->getEntityTypeId() !== 'og_membership') {
+    return;
+  }
+
+  /** @var \Drupal\og\Entity\OgMembership $entity */
+  $group_type = $entity->getGroupEntityType();
+  if ($group_type !== 'community' && $group_type !== 'protocol') {
+    return;
+  }
+
+  if (isset($operations['edit'])) {
+    $operations['edit']['title'] = t('Manage roles');
+  }
+
+  if (isset($operations['delete'])) {
+    $label = $group_type === 'community' ? t('Remove from community') : t('Remove from protocol');
+    $operations['delete']['title'] = $label;
   }
 }
 

--- a/modules/mukurtu_protocol/mukurtu_protocol.module
+++ b/modules/mukurtu_protocol/mukurtu_protocol.module
@@ -22,6 +22,7 @@ use Drupal\Core\Url;
 use Drupal\og\Og;
 use Drupal\og\OgMembershipInterface;
 use Drupal\mukurtu_protocol\Plugin\Action\MukurtuDeleteOgMembershipAction;
+use Drupal\Core\Render\Markup;
 
 /**
  * @file
@@ -80,6 +81,10 @@ function mukurtu_protocol_entity_bundle_info_alter(array &$bundles)
  * abandoned operation; plain row selections do not set this key.
  */
 function mukurtu_protocol_views_pre_render(\Drupal\views\ViewExecutable $view): void {
+  if ($view->id() === 'og_members_overview') {
+    $view->element['#attached']['library'][] = 'mukurtu_protocol/protocol-list';
+  }
+
   // Todo: fetch the display id programmatically instead of hardcoding it to page_1.
   if ($view->id() !== 'mukurtu_people' || $view->current_display !== 'page_1') {
     return;
@@ -948,4 +953,37 @@ function mukurtu_protocol_entity_access(\Drupal\Core\Entity\EntityInterface $ent
   }
 
   return AccessResult::neutral();
+}
+
+/**
+ * Implements hook_preprocess_views_view_field().
+ */
+function mukurtu_protocol_preprocess_views_view_field(&$variables) {
+  if ($variables['view']->id() !== 'og_members_overview') {
+    return;
+  }
+  if ($variables['field']->field !== 'state') {
+    return;
+  }
+
+  $membership_id = $variables['row']->id ?? NULL;
+  if (!$membership_id) {
+    return;
+  }
+
+  $membership = \Drupal::entityTypeManager()->getStorage('og_membership')->load($membership_id);
+  if (!$membership) {
+    return;
+  }
+
+  $group = $membership->getGroup();
+  $owner = $membership->getOwner();
+  if (!$group || !$owner || $group->getEntityTypeId() !== 'protocol') {
+    return;
+  }
+
+  if (CulturalProtocols::isUserBlockedFromProtocolViaCommunity($owner, $group)) {
+    $badge = '<span class="community-blocked-badge">' . t('Community blocked') . '</span>';
+    $variables['output'] = Markup::create((string) $variables['output'] . ' ' . $badge);
+  }
 }

--- a/modules/mukurtu_protocol/mukurtu_protocol.module
+++ b/modules/mukurtu_protocol/mukurtu_protocol.module
@@ -550,6 +550,20 @@ function mukurtu_protocol_query_protocol_access_alter(AlterableInterface $query)
       ->condition($strict_conditions)
       ->condition($open_conditions);
     $query->condition($open_or_strict);
+
+    // Exclude strict protocols where the user is blocked in a parent community.
+    // Open protocols remain accessible regardless of community membership.
+    $community_block_exempt = $query->orConditionGroup()
+      ->condition('pf.field_access_mode', 'open')
+      ->where("NOT EXISTS (
+        SELECT 1 FROM {protocol__field_communities} pfc
+        INNER JOIN {og_membership} ogc ON pfc.field_communities_target_id = ogc.entity_id
+          AND ogc.entity_type = 'community'
+          AND ogc.uid = :community_block_uid
+          AND ogc.state = 'blocked'
+        WHERE pfc.entity_id = {$protocolTable}.id
+      )", [':community_block_uid' => $account->id()]);
+    $query->condition($community_block_exempt);
   }
 }
 

--- a/modules/mukurtu_protocol/mukurtu_protocol.module
+++ b/modules/mukurtu_protocol/mukurtu_protocol.module
@@ -771,8 +771,12 @@ function mukurtu_protocol_form_og_membership_form_alter(&$form, FormStateInterfa
   // adding them first to the protocol owning communities.
   $group = \Drupal::requestStack()->getCurrentRequest()->attributes->get('group');
   if ($group instanceof ProtocolInterface) {
-    // Only add the form validator if this form is in the protocol context.
-    $form['#validate'][] = 'add_protocol_member_form_validate';
+    // Only validate community membership when adding a new member, not when
+    // editing roles on an existing (possibly blocked) membership.
+    $entity = $form_state->getFormObject()->getEntity();
+    if ($entity->isNew()) {
+      $form['#validate'][] = 'add_protocol_member_form_validate';
+    }
   }
 
   // Sort roles checkboxes by weight for both protocol and community forms.

--- a/modules/mukurtu_protocol/mukurtu_protocol.module
+++ b/modules/mukurtu_protocol/mukurtu_protocol.module
@@ -987,7 +987,7 @@ function mukurtu_protocol_preprocess_views_view_field(&$variables) {
   }
 
   if (CulturalProtocols::isUserBlockedFromProtocolViaCommunity($owner, $group)) {
-    $badge = '<span class="community-blocked-badge">' . t('Community blocked') . '</span>';
+    $badge = '<span class="community-blocked-badge" role="img" aria-label="' . t('Status: Community blocked') . '">' . t('Community blocked') . '</span>';
     $variables['output'] = Markup::create((string) $variables['output'] . ' ' . $badge);
   }
 }

--- a/modules/mukurtu_protocol/mukurtu_protocol.routing.yml
+++ b/modules/mukurtu_protocol/mukurtu_protocol.routing.yml
@@ -198,6 +198,32 @@ mukurtu_protocol.protocol_add_membership:
       group:
         type: entity:protocol
 
+mukurtu_protocol.og_membership.block:
+  path: '/admin/members/{og_membership}/block'
+  defaults:
+    _form: '\Drupal\mukurtu_protocol\Form\MukurtuOgMembershipBlockForm'
+    _title: 'Block membership'
+  requirements:
+    _entity_access: 'og_membership.update'
+  options:
+    _admin_route: TRUE
+    parameters:
+      og_membership:
+        type: entity:og_membership
+
+mukurtu_protocol.og_membership.approve:
+  path: '/admin/members/{og_membership}/approve'
+  defaults:
+    _form: '\Drupal\mukurtu_protocol\Form\MukurtuOgMembershipApproveForm'
+    _title: 'Approve membership'
+  requirements:
+    _entity_access: 'og_membership.update'
+  options:
+    _admin_route: TRUE
+    parameters:
+      og_membership:
+        type: entity:og_membership
+
 mukurtu_protocol.comment_settings:
   path: '/admin/config/mukurtu/commenting/settings'
   defaults:

--- a/modules/mukurtu_protocol/src/CulturalProtocolControlledTrait.php
+++ b/modules/mukurtu_protocol/src/CulturalProtocolControlledTrait.php
@@ -120,6 +120,10 @@ trait CulturalProtocolControlledTrait {
 
       // Strict protocol, need to lookup actual membership.
       if (Og::getMembership($protocol, $user)) {
+        // Skip if the user is blocked in any parent community.
+        if (CulturalProtocols::isUserBlockedFromProtocolViaCommunity($user, $protocol)) {
+          continue;
+        }
         $memberships[$protocol->id()] = $protocol;
       }
     }

--- a/modules/mukurtu_protocol/src/CulturalProtocols.php
+++ b/modules/mukurtu_protocol/src/CulturalProtocols.php
@@ -4,7 +4,9 @@ namespace Drupal\mukurtu_protocol;
 
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\mukurtu_protocol\Entity\ProtocolInterface;
 use Drupal\og\Og;
+use Drupal\og\OgMembershipInterface;
 use Drupal\user\Entity\User;
 
 class CulturalProtocols {
@@ -105,6 +107,21 @@ class CulturalProtocols {
     return $compoundProtocols;
   }
 
+  /**
+   * Returns TRUE if the account is OG-blocked in any of a protocol's parent communities.
+   *
+   * A community-level block takes precedence over an active protocol membership,
+   * so this check must be applied wherever protocol access is evaluated.
+   */
+  public static function isUserBlockedFromProtocolViaCommunity(AccountInterface $account, ProtocolInterface $protocol): bool {
+    foreach ($protocol->getCommunities() as $community) {
+      if (Og::getMembership($community, $account, [OgMembershipInterface::STATE_BLOCKED]) !== NULL) {
+        return TRUE;
+      }
+    }
+    return FALSE;
+  }
+
   public static function getAccountGrantIds(AccountInterface $account) {
     $grants = [];
 
@@ -114,6 +131,12 @@ class CulturalProtocols {
     /** @var \Drupal\og\OgMembershipInterface[] $memberships */
     $memberships = Og::getMemberships($account);
     $memberships = array_filter($memberships, fn ($e) => $e->getGroupEntityType() == 'protocol');
+
+    // Exclude protocols where the user is blocked in a parent community.
+    $memberships = array_filter($memberships, function ($m) use ($account) {
+      $protocol = $m->getGroup();
+      return $protocol && !self::isUserBlockedFromProtocolViaCommunity($account, $protocol);
+    });
 
     // Get the protocol NID list and sort them.
     $protocols = array_map(fn ($e) => $e->getGroupId(), $memberships);

--- a/modules/mukurtu_protocol/src/Form/MukurtuOgMembershipApproveForm.php
+++ b/modules/mukurtu_protocol/src/Form/MukurtuOgMembershipApproveForm.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Drupal\mukurtu_protocol\Form;
+
+use Drupal\Core\Form\ConfirmFormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
+use Drupal\og\Entity\OgMembership;
+use Drupal\og\OgMembershipInterface;
+
+/**
+ * Confirm form for approving a single pending OG membership.
+ */
+class MukurtuOgMembershipApproveForm extends ConfirmFormBase {
+
+  protected OgMembership $membership;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'mukurtu_og_membership_approve_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getQuestion() {
+    return $this->t('Approve membership request for %user in %group?', [
+      '%user' => $this->membership->getOwner()->getDisplayName(),
+      '%group' => $this->membership->getGroup()->label(),
+    ]);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getConfirmText() {
+    return $this->t('Approve');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCancelUrl() {
+    return $this->getMembersListUrl();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state, ?OgMembership $og_membership = NULL) {
+    $this->membership = $og_membership;
+
+    if ($this->membership->getState() !== OgMembershipInterface::STATE_PENDING) {
+      $this->messenger()->addWarning($this->t('%user does not have a pending membership request for %group.', [
+        '%user' => $this->membership->getOwner()->getDisplayName(),
+        '%group' => $this->membership->getGroup()->label(),
+      ]));
+      return $this->redirect($this->getMembersListUrl()->getRouteName(), $this->getMembersListUrl()->getRouteParameters());
+    }
+
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $this->membership->setState(OgMembershipInterface::STATE_ACTIVE)->save();
+
+    $this->messenger()->addStatus($this->t('%user has been approved as a member of %group.', [
+      '%user' => $this->membership->getOwner()->getDisplayName(),
+      '%group' => $this->membership->getGroup()->label(),
+    ]));
+
+    $form_state->setRedirectUrl($this->getMembersListUrl());
+  }
+
+  protected function getMembersListUrl(): Url {
+    $group_type = $this->membership->getGroupEntityType();
+    $group_id = $this->membership->getGroupId();
+
+    if ($group_type === 'community') {
+      return Url::fromRoute('mukurtu_protocol.community_members_list', ['group' => $group_id]);
+    }
+    return Url::fromRoute('mukurtu_protocol.protocol_members_list', ['group' => $group_id]);
+  }
+
+}

--- a/modules/mukurtu_protocol/src/Form/MukurtuOgMembershipBlockForm.php
+++ b/modules/mukurtu_protocol/src/Form/MukurtuOgMembershipBlockForm.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Drupal\mukurtu_protocol\Form;
+
+use Drupal\Core\Form\ConfirmFormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
+use Drupal\og\Entity\OgMembership;
+use Drupal\og\OgMembershipInterface;
+
+/**
+ * Confirm form for blocking a single OG membership.
+ */
+class MukurtuOgMembershipBlockForm extends ConfirmFormBase {
+
+  protected OgMembership $membership;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'mukurtu_og_membership_block_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getQuestion() {
+    return $this->t('Block %user from %group?', [
+      '%user' => $this->membership->getOwner()->getDisplayName(),
+      '%group' => $this->membership->getGroup()->label(),
+    ]);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getConfirmText() {
+    return $this->t('Block');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCancelUrl() {
+    return $this->getMembersListUrl();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state, ?OgMembership $og_membership = NULL) {
+    $this->membership = $og_membership;
+
+    if ($this->membership->getState() === OgMembershipInterface::STATE_BLOCKED) {
+      $this->messenger()->addWarning($this->t('%user is already blocked from %group.', [
+        '%user' => $this->membership->getOwner()->getDisplayName(),
+        '%group' => $this->membership->getGroup()->label(),
+      ]));
+      return $this->redirect($this->getMembersListUrl()->getRouteName(), $this->getMembersListUrl()->getRouteParameters());
+    }
+
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $this->membership->setState(OgMembershipInterface::STATE_BLOCKED)->save();
+
+    $this->messenger()->addStatus($this->t('%user has been blocked from %group.', [
+      '%user' => $this->membership->getOwner()->getDisplayName(),
+      '%group' => $this->membership->getGroup()->label(),
+    ]));
+
+    $form_state->setRedirectUrl($this->getMembersListUrl());
+  }
+
+  protected function getMembersListUrl(): Url {
+    $group_type = $this->membership->getGroupEntityType();
+    $group_id = $this->membership->getGroupId();
+
+    if ($group_type === 'community') {
+      return Url::fromRoute('mukurtu_protocol.community_members_list', ['group' => $group_id]);
+    }
+    return Url::fromRoute('mukurtu_protocol.protocol_members_list', ['group' => $group_id]);
+  }
+
+}

--- a/modules/mukurtu_protocol/src/Form/MukurtuOgMembershipBlockForm.php
+++ b/modules/mukurtu_protocol/src/Form/MukurtuOgMembershipBlockForm.php
@@ -35,6 +35,16 @@ class MukurtuOgMembershipBlockForm extends ConfirmFormBase {
   /**
    * {@inheritdoc}
    */
+  public function getDescription() {
+    if ($this->membership->getGroupEntityType() === 'community') {
+      return $this->t('The user will not be able to access content from this community or its closed protocols. You can unblock them at any time from the members list.');
+    }
+    return $this->t('The user will not be able to access content from this protocol. You can unblock them at any time from the members list.');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function getConfirmText() {
     return $this->t('Block');
   }

--- a/modules/mukurtu_protocol/src/MukurtuProtocolMediaAccessControlHandler.php
+++ b/modules/mukurtu_protocol/src/MukurtuProtocolMediaAccessControlHandler.php
@@ -9,6 +9,7 @@ use Drupal\Core\Access\AccessResult;
 use Drupal\media\MediaAccessControlHandler;
 use Drupal\og\Og;
 use Drupal\mukurtu_protocol\CulturalProtocolControlledInterface;
+use Drupal\mukurtu_protocol\CulturalProtocols;
 
 /**
  * Access controller for media entities under Mukurtu protocol control.
@@ -97,6 +98,12 @@ class MukurtuProtocolMediaAccessControlHandler extends MediaAccessControlHandler
       }
 
       $cacheability->addCacheableDependency($membership);
+
+      // Skip if the user is blocked in any parent community.
+      $protocol = $membership->getGroup();
+      if (!$protocol || CulturalProtocols::isUserBlockedFromProtocolViaCommunity($account, $protocol)) {
+        continue;
+      }
 
       // Account must be permitted to use the protocol on content.
       if (!$membership->hasPermission("apply protocol")) {

--- a/modules/mukurtu_protocol/src/MukurtuProtocolNodeAccessControlHandler.php
+++ b/modules/mukurtu_protocol/src/MukurtuProtocolNodeAccessControlHandler.php
@@ -9,6 +9,7 @@ use Drupal\Core\Access\AccessResult;
 use Drupal\node\NodeAccessControlHandler;
 use Drupal\og\Og;
 use Drupal\mukurtu_protocol\CulturalProtocolControlledInterface;
+use Drupal\mukurtu_protocol\CulturalProtocols;
 
 /**
  * Access controller for node entities under Mukurtu protocol control.
@@ -126,6 +127,12 @@ class MukurtuProtocolNodeAccessControlHandler extends NodeAccessControlHandler {
       }
 
       $cacheability->addCacheableDependency($membership);
+
+      // Skip if the user is blocked in any parent community.
+      $protocol = $membership->getGroup();
+      if (!$protocol || CulturalProtocols::isUserBlockedFromProtocolViaCommunity($account, $protocol)) {
+        continue;
+      }
 
       // Account must be permitted to use the protocol on content.
       if (!$membership->hasPermission("apply protocol")) {

--- a/modules/mukurtu_protocol/src/ProtocolAccessControlHandler.php
+++ b/modules/mukurtu_protocol/src/ProtocolAccessControlHandler.php
@@ -8,6 +8,7 @@ use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Access\AccessResult;
 use Drupal\og\Og;
+use Drupal\mukurtu_protocol\CulturalProtocols;
 
 /**
  * Access controller for the Protocol entity.
@@ -34,9 +35,15 @@ class ProtocolAccessControlHandler extends EntityAccessControlHandler {
         return AccessResult::allowed()->addCacheableDependency($entity);
       }
 
-      // Users with an active membership in the protocol can view.
+      // Users with an active membership in the protocol can view,
+      // unless they are blocked in a parent community.
       $membership = Og::getMembership($entity, $account);
       if ($membership) {
+        if (CulturalProtocols::isUserBlockedFromProtocolViaCommunity($account, $entity)) {
+          return AccessResult::forbidden()
+            ->addCacheableDependency($entity)
+            ->addCacheTags(["user:{$account->id()}"]);
+        }
         return AccessResult::allowed()->addCacheableDependency($membership);
       }
 


### PR DESCRIPTION
- When you block a user at the community level, they are tacitly blocked in all child protocols.
- When they are unblocked in the community, their protocol access is restores.
- The community block cannot be bypassed within protocols.

Closes https://github.com/MukurtuCMS/Mukurtu-CMS/issues/952

(Working on updating the operations and actions labels still)

Pre-merge checklist:

- [ ] I have checked for and if required, created update hooks.
- [ ] I have run an accessibility check, and resolved any issues.
- [ ] I have recompiled SCSS if required.
- [ ] I have updated or created CI/CD tests, if required.
- [ ] I have updated from `main` and resolved any merge conflicts.
- [ ] I have verified that all expected checks pass.
- [ ] I have run the pr-expert-review skill and resolved all relevant issues.

