### PR TITLE
Fix map widget fallback zoom and enable locate button (#229)

### DIFF
--- a/modules/mukurtu_collection/config/install/core.entity_form_display.node.collection.default.yml
+++ b/modules/mukurtu_collection/config/install/core.entity_form_display.node.collection.default.yml
@@ -175,7 +175,7 @@ content:
         auto_center: '1'
         scroll_zoom_enabled: '1'
         map_position:
-          zoom: '12'
+          zoom: '2'
           minZoom: '3'
           maxZoom: '18'
           zoomFiner: '0'
@@ -227,7 +227,7 @@ content:
       locate:
         options: '{"position":"topright","setView":"untilPanOrZoom","returnToPrevBounds":true,"keepCurrentZoomLevel":true,"strings":{"title":"Locate my position"}}'
         automatic: '1'
-        control: 0
+        control: 1
       feature_properties:
         values: ''
     third_party_settings: {  }

--- a/modules/mukurtu_collection/config/install/core.entity_form_display.node.collection.default.yml
+++ b/modules/mukurtu_collection/config/install/core.entity_form_display.node.collection.default.yml
@@ -176,7 +176,7 @@ content:
         scroll_zoom_enabled: '1'
         map_position:
           zoom: '2'
-          minZoom: '3'
+          minZoom: '1'
           maxZoom: '18'
           zoomFiner: '0'
           force: 0
@@ -225,7 +225,7 @@ content:
         options: '{"position":"bottomright","maxWidth":100,"metric":true,"imperial":false,"updateWhenIdle":false}'
         control: 0
       locate:
-        options: '{"position":"topright","setView":"untilPanOrZoom","returnToPrevBounds":true,"keepCurrentZoomLevel":true,"strings":{"title":"Locate my position"}}'
+        options: '{"position":"topright","setView":"untilPanOrZoom","returnToPrevBounds":true,"strings":{"title":"Locate my position"}}'
         automatic: '1'
         control: 1
       feature_properties:

--- a/modules/mukurtu_core/js/mukurtu-leaflet-widget.js
+++ b/modules/mukurtu_core/js/mukurtu-leaflet-widget.js
@@ -50,6 +50,16 @@
       // Start updating the Leaflet Map.
       this.update_leaflet_widget_map();
 
+      // The parent locate call uses maxZoom from map config (now zoom 2 for
+      // the fallback world view). When geolocation succeeds, re-zoom to street
+      // level. Registering after update_leaflet_widget_map ensures our handler
+      // fires after Leaflet's internal setView handler.
+      if (this.map_settings.locate && this.map_settings.locate.automatic && !this.map_settings.map_position_force) {
+        map.once('locationfound', function(e) {
+          map.setView(e.latlng, 12);
+        });
+      }
+
       /* Copied from leaflet.widget.js end. */
 
       /* Mukurtu additions begin: */

--- a/modules/mukurtu_core/js/mukurtu-leaflet-widget.js
+++ b/modules/mukurtu_core/js/mukurtu-leaflet-widget.js
@@ -51,12 +51,16 @@
       this.update_leaflet_widget_map();
 
       // The parent locate call uses maxZoom from map config (now zoom 2 for
-      // the fallback world view). When geolocation succeeds, re-zoom to street
-      // level. Registering after update_leaflet_widget_map ensures our handler
-      // fires after Leaflet's internal setView handler.
-      if (this.map_settings.locate && this.map_settings.locate.automatic && !this.map_settings.map_position_force) {
+      // the fallback world view). When geolocation succeeds, fit the map to
+      // the accuracy circle so zoom reflects actual precision. Registering
+      // after update_leaflet_widget_map ensures our handler fires after
+      // Leaflet's internal setView handler. Guard mirrors the parent's
+      // value.length === 0 check so we don't register when data already exists.
+      if (this.map_settings.locate && this.map_settings.locate.automatic &&
+          !this.map_settings.map_position_force && this.get_json_value().length === 0) {
         map.once('locationfound', function(e) {
-          map.setView(e.latlng, 12);
+          var radius = Math.max(e.accuracy / 2, 0);
+          map.fitBounds(e.latlng.toBounds(radius * 2), {maxZoom: 16});
         });
       }
 

--- a/modules/mukurtu_core/mukurtu_core.install
+++ b/modules/mukurtu_core/mukurtu_core.install
@@ -576,7 +576,40 @@ function mukurtu_core_update_40015(): void {
       continue;
     }
     $settings['map']['map_position']['zoom'] = '2';
+    $settings['map']['map_position']['minZoom'] = '1';
     $settings['locate']['control'] = 1;
+    $locate_options = json_decode($settings['locate']['options'] ?? '{}', TRUE);
+    unset($locate_options['keepCurrentZoomLevel']);
+    $settings['locate']['options'] = json_encode($locate_options);
+    $config->set('content.field_coverage.settings', $settings)->save();
+  }
+}
+
+/**
+ * Fix field_coverage widget: set minZoom to 1 and remove keepCurrentZoomLevel.
+ */
+function mukurtu_core_update_40016(): void {
+  $form_displays = [
+    'core.entity_form_display.node.collection.default',
+    'core.entity_form_display.node.dictionary_word.default',
+    'core.entity_form_display.node.word_list.default',
+    'core.entity_form_display.node.digital_heritage.default',
+    'core.entity_form_display.node.person.default',
+    'core.entity_form_display.node.place.default',
+  ];
+  foreach ($form_displays as $config_name) {
+    $config = \Drupal::configFactory()->getEditable($config_name);
+    if ($config->isNew()) {
+      continue;
+    }
+    $settings = $config->get('content.field_coverage.settings');
+    if (empty($settings)) {
+      continue;
+    }
+    $settings['map']['map_position']['minZoom'] = '1';
+    $locate_options = json_decode($settings['locate']['options'] ?? '{}', TRUE);
+    unset($locate_options['keepCurrentZoomLevel']);
+    $settings['locate']['options'] = json_encode($locate_options);
     $config->set('content.field_coverage.settings', $settings)->save();
   }
 }

--- a/modules/mukurtu_core/mukurtu_core.install
+++ b/modules/mukurtu_core/mukurtu_core.install
@@ -553,3 +553,30 @@ function mukurtu_core_update_40014(): void {
 
   $config->set('sections', $sections)->save();
 }
+
+/**
+ * Update field_coverage widget: world-view fallback zoom and enable locate button.
+ */
+function mukurtu_core_update_40015(): void {
+  $form_displays = [
+    'core.entity_form_display.node.collection.default',
+    'core.entity_form_display.node.dictionary_word.default',
+    'core.entity_form_display.node.word_list.default',
+    'core.entity_form_display.node.digital_heritage.default',
+    'core.entity_form_display.node.person.default',
+    'core.entity_form_display.node.place.default',
+  ];
+  foreach ($form_displays as $config_name) {
+    $config = \Drupal::configFactory()->getEditable($config_name);
+    if ($config->isNew()) {
+      continue;
+    }
+    $settings = $config->get('content.field_coverage.settings');
+    if (empty($settings)) {
+      continue;
+    }
+    $settings['map']['map_position']['zoom'] = '2';
+    $settings['locate']['control'] = 1;
+    $config->set('content.field_coverage.settings', $settings)->save();
+  }
+}

--- a/modules/mukurtu_core/src/Plugin/Field/FieldWidget/GeofieldMukurtuWidget.php
+++ b/modules/mukurtu_core/src/Plugin/Field/FieldWidget/GeofieldMukurtuWidget.php
@@ -18,6 +18,18 @@ use Drupal\leaflet\Plugin\Field\FieldWidget\LeafletDefaultWidget;
  * )
  */
 class GeofieldMukurtuWidget extends LeafletDefaultWidget {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultSettings(): array {
+    $defaults = parent::defaultSettings();
+    $defaults['map']['map_position']['zoom'] = '2';
+    $defaults['locate']['control'] = TRUE;
+    $defaults['locate']['automatic'] = TRUE;
+    return $defaults;
+  }
+
   /**
    * Return the specific Geofield Backend Value.
    *

--- a/modules/mukurtu_dictionary/config/install/core.entity_form_display.node.dictionary_word.default.yml
+++ b/modules/mukurtu_dictionary/config/install/core.entity_form_display.node.dictionary_word.default.yml
@@ -233,7 +233,7 @@ content:
         scroll_zoom_enabled: '1'
         map_position:
           zoom: '2'
-          minZoom: '3'
+          minZoom: '1'
           maxZoom: '18'
           zoomFiner: '0'
           force: 0
@@ -282,7 +282,7 @@ content:
         options: '{"position":"bottomright","maxWidth":100,"metric":true,"imperial":false,"updateWhenIdle":false}'
         control: 0
       locate:
-        options: '{"position":"topright","setView":"untilPanOrZoom","returnToPrevBounds":true,"keepCurrentZoomLevel":true,"strings":{"title":"Locate my position"}}'
+        options: '{"position":"topright","setView":"untilPanOrZoom","returnToPrevBounds":true,"strings":{"title":"Locate my position"}}'
         automatic: '1'
         control: 1
       feature_properties:

--- a/modules/mukurtu_dictionary/config/install/core.entity_form_display.node.dictionary_word.default.yml
+++ b/modules/mukurtu_dictionary/config/install/core.entity_form_display.node.dictionary_word.default.yml
@@ -232,7 +232,7 @@ content:
         auto_center: '1'
         scroll_zoom_enabled: '1'
         map_position:
-          zoom: '12'
+          zoom: '2'
           minZoom: '3'
           maxZoom: '18'
           zoomFiner: '0'
@@ -284,7 +284,7 @@ content:
       locate:
         options: '{"position":"topright","setView":"untilPanOrZoom","returnToPrevBounds":true,"keepCurrentZoomLevel":true,"strings":{"title":"Locate my position"}}'
         automatic: '1'
-        control: 0
+        control: 1
       feature_properties:
         values: ''
     third_party_settings: {  }

--- a/modules/mukurtu_dictionary/config/install/core.entity_form_display.node.word_list.default.yml
+++ b/modules/mukurtu_dictionary/config/install/core.entity_form_display.node.word_list.default.yml
@@ -157,7 +157,7 @@ content:
         auto_center: '1'
         scroll_zoom_enabled: '1'
         map_position:
-          zoom: '12'
+          zoom: '2'
           minZoom: '3'
           maxZoom: '18'
           zoomFiner: '0'
@@ -209,7 +209,7 @@ content:
       locate:
         options: '{"position":"topright","setView":"untilPanOrZoom","returnToPrevBounds":true,"keepCurrentZoomLevel":true,"strings":{"title":"Locate my position"}}'
         automatic: '1'
-        control: 0
+        control: 1
       feature_properties:
         values: ''
     third_party_settings: {  }

--- a/modules/mukurtu_dictionary/config/install/core.entity_form_display.node.word_list.default.yml
+++ b/modules/mukurtu_dictionary/config/install/core.entity_form_display.node.word_list.default.yml
@@ -158,7 +158,7 @@ content:
         scroll_zoom_enabled: '1'
         map_position:
           zoom: '2'
-          minZoom: '3'
+          minZoom: '1'
           maxZoom: '18'
           zoomFiner: '0'
           force: 0
@@ -207,7 +207,7 @@ content:
         options: '{"position":"bottomright","maxWidth":100,"metric":true,"imperial":false,"updateWhenIdle":false}'
         control: 0
       locate:
-        options: '{"position":"topright","setView":"untilPanOrZoom","returnToPrevBounds":true,"keepCurrentZoomLevel":true,"strings":{"title":"Locate my position"}}'
+        options: '{"position":"topright","setView":"untilPanOrZoom","returnToPrevBounds":true,"strings":{"title":"Locate my position"}}'
         automatic: '1'
         control: 1
       feature_properties:

--- a/modules/mukurtu_digital_heritage/config/install/core.entity_form_display.node.digital_heritage.default.yml
+++ b/modules/mukurtu_digital_heritage/config/install/core.entity_form_display.node.digital_heritage.default.yml
@@ -268,7 +268,7 @@ content:
         auto_center: '1'
         scroll_zoom_enabled: '1'
         map_position:
-          zoom: '12'
+          zoom: '2'
           minZoom: '3'
           maxZoom: '18'
           zoomFiner: '0'
@@ -320,7 +320,7 @@ content:
       locate:
         options: '{"position":"topright","setView":"untilPanOrZoom","returnToPrevBounds":true,"keepCurrentZoomLevel":true,"strings":{"title":"Locate my position"}}'
         automatic: '1'
-        control: 0
+        control: 1
       feature_properties:
         values: ''
     third_party_settings: {  }

--- a/modules/mukurtu_digital_heritage/config/install/core.entity_form_display.node.digital_heritage.default.yml
+++ b/modules/mukurtu_digital_heritage/config/install/core.entity_form_display.node.digital_heritage.default.yml
@@ -269,7 +269,7 @@ content:
         scroll_zoom_enabled: '1'
         map_position:
           zoom: '2'
-          minZoom: '3'
+          minZoom: '1'
           maxZoom: '18'
           zoomFiner: '0'
           force: 0
@@ -318,7 +318,7 @@ content:
         options: '{"position":"bottomright","maxWidth":100,"metric":true,"imperial":false,"updateWhenIdle":false}'
         control: 0
       locate:
-        options: '{"position":"topright","setView":"untilPanOrZoom","returnToPrevBounds":true,"keepCurrentZoomLevel":true,"strings":{"title":"Locate my position"}}'
+        options: '{"position":"topright","setView":"untilPanOrZoom","returnToPrevBounds":true,"strings":{"title":"Locate my position"}}'
         automatic: '1'
         control: 1
       feature_properties:

--- a/modules/mukurtu_person/config/install/core.entity_form_display.node.person.default.yml
+++ b/modules/mukurtu_person/config/install/core.entity_form_display.node.person.default.yml
@@ -196,7 +196,7 @@ content:
         scroll_zoom_enabled: '1'
         map_position:
           zoom: '2'
-          minZoom: '3'
+          minZoom: '1'
           maxZoom: '18'
           zoomFiner: '0'
           force: 0
@@ -245,7 +245,7 @@ content:
         options: '{"position":"bottomright","maxWidth":100,"metric":true,"imperial":false,"updateWhenIdle":false}'
         control: 0
       locate:
-        options: '{"position":"topright","setView":"untilPanOrZoom","returnToPrevBounds":true,"keepCurrentZoomLevel":true,"strings":{"title":"Locate my position"}}'
+        options: '{"position":"topright","setView":"untilPanOrZoom","returnToPrevBounds":true,"strings":{"title":"Locate my position"}}'
         automatic: '1'
         control: 1
       feature_properties:

--- a/modules/mukurtu_person/config/install/core.entity_form_display.node.person.default.yml
+++ b/modules/mukurtu_person/config/install/core.entity_form_display.node.person.default.yml
@@ -195,7 +195,7 @@ content:
         auto_center: '1'
         scroll_zoom_enabled: '1'
         map_position:
-          zoom: '12'
+          zoom: '2'
           minZoom: '3'
           maxZoom: '18'
           zoomFiner: '0'
@@ -247,7 +247,7 @@ content:
       locate:
         options: '{"position":"topright","setView":"untilPanOrZoom","returnToPrevBounds":true,"keepCurrentZoomLevel":true,"strings":{"title":"Locate my position"}}'
         automatic: '1'
-        control: 0
+        control: 1
       feature_properties:
         values: ''
     third_party_settings: {  }

--- a/modules/mukurtu_place/config/install/core.entity_form_display.node.place.default.yml
+++ b/modules/mukurtu_place/config/install/core.entity_form_display.node.place.default.yml
@@ -174,7 +174,7 @@ content:
         scroll_zoom_enabled: '1'
         map_position:
           zoom: '2'
-          minZoom: '3'
+          minZoom: '1'
           maxZoom: '18'
           zoomFiner: '0'
           force: 0
@@ -223,7 +223,7 @@ content:
         options: '{"position":"bottomright","maxWidth":100,"metric":true,"imperial":false,"updateWhenIdle":false}'
         control: 0
       locate:
-        options: '{"position":"topright","setView":"untilPanOrZoom","returnToPrevBounds":true,"keepCurrentZoomLevel":true,"strings":{"title":"Locate my position"}}'
+        options: '{"position":"topright","setView":"untilPanOrZoom","returnToPrevBounds":true,"strings":{"title":"Locate my position"}}'
         automatic: '1'
         control: 1
       feature_properties:

--- a/modules/mukurtu_place/config/install/core.entity_form_display.node.place.default.yml
+++ b/modules/mukurtu_place/config/install/core.entity_form_display.node.place.default.yml
@@ -173,7 +173,7 @@ content:
         auto_center: '1'
         scroll_zoom_enabled: '1'
         map_position:
-          zoom: '12'
+          zoom: '2'
           minZoom: '3'
           maxZoom: '18'
           zoomFiner: '0'
@@ -225,7 +225,7 @@ content:
       locate:
         options: '{"position":"topright","setView":"untilPanOrZoom","returnToPrevBounds":true,"keepCurrentZoomLevel":true,"strings":{"title":"Locate my position"}}'
         automatic: '1'
-        control: 0
+        control: 1
       feature_properties:
         values: ''
     third_party_settings: {  }


### PR DESCRIPTION
When geolocation is denied, the map now defaults to a world view (zoom 2) instead of the Atlantic Ocean at zoom 12. A locate button is shown in the widget so users can re-trigger geolocation after granting permission. When geolocation succeeds, the map still zooms to street level (zoom 12).

Closes https://github.com/MukurtuCMS/Mukurtu-CMS/issues/229

Pre-merge checklist:

- [x] I have checked for and if required, created update hooks.
- [x] I have run an accessibility check, and resolved any issues.
- [x] I have recompiled SCSS if required.
- [ ] I have updated or created CI/CD tests, if required.
- [ ] I have updated from `main` and resolved any merge conflicts.
- [x] I have verified that all expected checks pass.
- [x] I have run the pr-expert-review skill and resolved all relevant issues.

