### PR TITLE
Update external links url helper text

### DIFF
--- a/modules/mukurtu_digital_heritage/src/Hook/FormHooks.php
+++ b/modules/mukurtu_digital_heritage/src/Hook/FormHooks.php
@@ -19,7 +19,7 @@ class FormHooks
         if (isset($form['field_external_links'])) {
             foreach (Element::children($form['field_external_links']) as $delta) {
                 if (isset($form['field_external_links'][$delta]['uri'])) {
-                    $form['field_external_links'][$delta]['uri']['#description'] = t('This must be an external URL starting with <em>https://</em> or <em>http://</em>. Eg: <em>https://mukurtu.org</em>.');
+                    $form['field_external_links'][$delta]['uri']['#description'] = t('This must be an external URL starting with <em>https://</em> or <em>http://</em>. For example: <em>https://mukurtu.org</em>.');
                 }
             }
         }

--- a/modules/mukurtu_digital_heritage/src/Hook/FormHooks.php
+++ b/modules/mukurtu_digital_heritage/src/Hook/FormHooks.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Drupal\mukurtu_digital_heritage\Hook;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Hook\Attribute\Hook;
+use Drupal\Core\Render\Element;
+
+/**
+ * Hook implementations for mukurtu_digital_heritage forms.
+ */
+class FormHooks
+{
+    #[Hook("form_node_digital_heritage_form_alter")]
+    public function formNodeDigitalHeritageFormAlter(
+        array &$form,
+        FormStateInterface $form_state,
+    ): void {
+        if (isset($form['field_external_links'])) {
+            foreach (Element::children($form['field_external_links']) as $delta) {
+                if (isset($form['field_external_links'][$delta]['uri'])) {
+                    $form['field_external_links'][$delta]['uri']['#description'] = t('This must be an external URL starting with <em>https://</em> or <em>http://</em>. Eg: <em>https://mukurtu.org</em>.');
+                }
+            }
+        }
+    }
+}

--- a/modules/mukurtu_import/src/Plugin/MukurtuImportFieldProcess/Link.php
+++ b/modules/mukurtu_import/src/Plugin/MukurtuImportFieldProcess/Link.php
@@ -10,41 +10,54 @@ use Drupal\Core\StringTranslation\TranslatableMarkup;
 /**
  * Plugin implementation of the mukurtu_import_field_process.
  */
-#[MukurtuImportFieldProcess(
-  id: 'link',
-  label: new TranslatableMarkup('Link'),
-  description: new TranslatableMarkup('Link.'),
-  field_types: ['link'],
-  weight: 0,
-)]
-class Link extends MukurtuImportFieldProcessPluginBase {
-  /**
-   * {@inheritdoc}
-   */
-  public function getProcess(FieldDefinitionInterface $field_config, $source, $context = []) {
-    $multivalue_delimiter = $context['multivalue_delimiter'] ?? self::MULTIVALUE_DELIMITER;
+#[
+    MukurtuImportFieldProcess(
+        id: "link",
+        label: new TranslatableMarkup("Link"),
+        description: new TranslatableMarkup("Link."),
+        field_types: ["link"],
+        weight: 0,
+    ),
+]
+class Link extends MukurtuImportFieldProcessPluginBase
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getProcess(
+        FieldDefinitionInterface $field_config,
+        $source,
+        $context = [],
+    ) {
+        $multivalue_delimiter =
+            $context["multivalue_delimiter"] ?? self::MULTIVALUE_DELIMITER;
 
-    $process = [];
-    if ($this->isMultiple($field_config)) {
-      $process[] = [
-        'plugin' => 'explode',
-        'delimiter' => $multivalue_delimiter,
-      ];
+        $process = [];
+        if ($this->isMultiple($field_config)) {
+            $process[] = [
+                "plugin" => "explode",
+                "delimiter" => $multivalue_delimiter,
+            ];
+        }
+        $process[] = [
+            "plugin" => "markdown_link",
+        ];
+        $process[0]["source"] = $source;
+        return $process;
     }
-    $process[] = [
-      'plugin' => 'markdown_link',
-    ];
-    $process[0]['source'] = $source;
-    return $process;
-  }
 
-  /**
-   * {@inheritdoc}
-   */
-  public function getFormatDescription(FieldDefinitionInterface $field_config, $field_property = NULL) {
-    $single_description = "The link in Markdown format: [Title](https://url.com)";
-    $description = $this->isMultiple($field_config) ? "$single_description, separated by your selected multi-value delimiter." : $single_description;
-    return t($description);
-  }
-
+    /**
+     * {@inheritdoc}
+     */
+    public function getFormatDescription(
+        FieldDefinitionInterface $field_config,
+        $field_property = null,
+    ) {
+        $single_description =
+            "The link in Markdown format using either the https:// or http:// header: [Title](https://url.com)";
+        $description = $this->isMultiple($field_config)
+            ? "$single_description, separated by your selected multi-value delimiter."
+            : $single_description;
+        return t($description);
+    }
 }


### PR DESCRIPTION
Closes https://github.com/MukurtuCMS/Mukurtu-CMS/issues/88 by updating the URL helper text to specify that https:// and http:// are the only accepted headers for external links.

Pre-merge checklist:

- [x] I have checked for and if required, created update hooks.
- [x] I have run an accessibility check, and resolved any issues.
- [x] I have recompiled SCSS if required.
- [ ] I have updated or created CI/CD tests, if required.
- [x] I have updated from `main` and resolved any merge conflicts.
- [x] I have verified that all expected checks pass.
- [x] I have run the pr-expert-review skill and resolved all relevant issues.

