### PR TITLE
Change "create account" text to "request account"

### DIFF
--- a/modules/mukurtu_core/src/Hook/FormHooks.php
+++ b/modules/mukurtu_core/src/Hook/FormHooks.php
@@ -113,6 +113,31 @@ class FormHooks
     }
 
     /**
+     * Implements hook_menu_local_tasks_alter().
+     *
+     * Relabels the "Create new account" tab to "Request new account" on the
+     * login, register, and password-reset pages.
+     */
+    #[Hook("menu_local_tasks_alter")]
+    public function menuLocalTasksAlterUserRegister(
+        array &$data,
+        string $route_name,
+    ): void {
+        if (
+            in_array(
+                $route_name,
+                ["user.login", "user.register", "user.pass"],
+                true,
+            ) &&
+            isset($data["tabs"][0]["user.register"])
+        ) {
+            $data["tabs"][0]["user.register"]["#link"]["title"] = t(
+                "Request new account",
+            );
+        }
+    }
+
+    /**
      * Implements hook_form_FORM_ID_alter() for 'user-register-form' and
      * 'user-form'.
      *
@@ -188,6 +213,13 @@ class FormHooks
         // access; skip it for anonymous self-registration.
         $currentAccount = \Drupal::currentUser();
         if ($currentAccount->isAnonymous()) {
+            $form["#title"] = t("Request new account");
+            if (isset($form["actions"]["submit"])) {
+                $form["actions"]["submit"]["#value"] = t("Request new account");
+            }
+            if (isset($form["account"]["field_display_name"])) {
+                unset($form["account"]["field_display_name"]);
+            }
             return;
         }
 


### PR DESCRIPTION
Closes #948 

- [ ] At /user/* change the "Create new account" button to read "Request new account".
- [ ] At /user/register change the page title to "Request new account".
- [ ] At /user/register change the submit button to "Request new account".
- [ ] Also, in the form shown at /user/register, omit the display name field.

Pre-merge checklist:

- [x] I have checked for and if required, created update hooks.
- [x] I have run an accessibility check, and resolved any issues.
- [x] I have recompiled SCSS if required.
- [ ] I have updated or created CI/CD tests, if required.
- [x] I have updated from `main` and resolved any merge conflicts.
- [x] I have verified that all expected checks pass.
- [x] I have run the pr-expert-review skill and resolved all relevant issues.

