### PR TITLE
Disable accidental Enter-to-submit on complex forms

### DIFF
--- a/modules/mukurtu_core/js/form-disable-enter-submit.js
+++ b/modules/mukurtu_core/js/form-disable-enter-submit.js
@@ -1,0 +1,38 @@
+(function (Drupal, once) {
+  // Input types where Enter would otherwise trigger form submission.
+  const TEXT_INPUT_TYPES = new Set([
+    'text', 'email', 'url', 'number', 'tel', 'password',
+    'date', 'datetime-local', 'month', 'week', 'time', 'color',
+  ]);
+
+  function isExemptForm(form) {
+    // Search forms and the login form: Enter-to-submit is expected behavior.
+    if (form.querySelector('input[type="search"]')) return true;
+    if (form.getAttribute('role') === 'search') return true;
+    if (form.id === 'user-login-form') return true;
+    // Single visible text input: Enter-to-submit is the expected keyboard interaction.
+    const visibleTextInputs = form.querySelectorAll(
+      'input:not([type="hidden"]):not([type="submit"]):not([type="button"]):not([type="reset"]):not([type="image"])'
+    );
+    if (visibleTextInputs.length === 1) return true;
+    return false;
+  }
+
+  function handleKeydown(event) {
+    if (event.key !== 'Enter') return;
+    const input = event.target;
+    if (!input.matches('input')) return;
+    if (!TEXT_INPUT_TYPES.has((input.type || 'text').toLowerCase())) return;
+    const form = input.closest('form');
+    if (!form || isExemptForm(form)) return;
+    event.preventDefault();
+  }
+
+  Drupal.behaviors.mukurtuFormDisableEnterSubmit = {
+    attach(context) {
+      once('mukurtu-disable-enter-submit', 'form', context).forEach((form) => {
+        form.addEventListener('keydown', handleKeydown);
+      });
+    },
+  };
+})(Drupal, once);

--- a/modules/mukurtu_core/mukurtu_core.info.yml
+++ b/modules/mukurtu_core/mukurtu_core.info.yml
@@ -6,6 +6,7 @@ package: 'Mukurtu CMS'
 version: 4.x-dev
 libraries:
   - mukurtu_core/mukurtu-leaflet-widget
+  - mukurtu_core/form-disable-enter-submit
 dependencies:
   - 'blazy:blazy'
   - 'drupal:block'

--- a/modules/mukurtu_core/mukurtu_core.libraries.yml
+++ b/modules/mukurtu_core/mukurtu_core.libraries.yml
@@ -35,3 +35,11 @@ entity_browser_view_decoration:
   version: 1.x
   js:
     js/entity_browser_view_decoration.js: {}
+
+form-disable-enter-submit:
+  version: 1.x
+  js:
+    js/form-disable-enter-submit.js: {}
+  dependencies:
+    - core/drupal
+    - core/once


### PR DESCRIPTION
Closes #1623

## Summary

- Adds a global Drupal JS behavior (`mukurtuFormDisableEnterSubmit`) in `mukurtu_core` that intercepts `keydown` on all forms and blocks Enter from submitting when focus is in a text-type input
- Registered as a new library (`form-disable-enter-submit`) and attached globally via `mukurtu_core.info.yml`
- Targets multi-field content/config forms where accidental Enter submission is the problem

## Exemptions (Enter-to-submit preserved)

| Condition | Why |
|---|---|
| `input[type="search"]` present | Standard search UX |
| `form[role="search"]` | Semantic search forms |
| `#user-login-form` | Login keyboard accessibility |
| Single visible text input | Newsletter signups, simple forms — Enter is expected |
| `textarea` | Enter adds a newline; unaffected by this handler |
| Tagify taxonomy widgets | Use a `contenteditable` div, not an `<input>`; handler exits early |

## Test plan

- [ ] `ddev drush cr` to pick up the new library
- [ ] Open a content create/edit form — press Enter in a text field — form should stay put
- [ ] Open the site search / browse page — press Enter in the search box — should submit
- [ ] Navigate to `/user/login` — press Enter after filling credentials — should submit
- [ ] Open a form with a Tagify taxonomy widget — press Enter to commit a term — tag should be created, form should not submit
- [ ] Open a form with a textarea — press Enter — should add a newline, not submit

🤖 Generated with [Claude Code](https://claude.com/claude-code)