### PR TITLE
Remove push-to-main trigger from Playwright workflow

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -2,9 +2,6 @@ name: "Tugboat Playwright Tests"
 
 on:
   # Run on pull requests against the main branch, to match Tugboat builds.
-  push:
-    branches:
-      - main
   pull_request:
     types: [opened, synchronize, reopened]
 

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,8 +1,9 @@
 name: "Tugboat Playwright Tests"
 
 on:
-  # Run on pull requests against the main branch, to match Tugboat builds.
   pull_request:
+    branches:
+      - main
     types: [opened, synchronize, reopened]
 
 jobs:


### PR DESCRIPTION
## Summary

- Removes the `push: branches: main` trigger from the Playwright workflow
- The workflow uses `github.event.pull_request.number` to find the Tugboat
  preview URL, which is null on push events — causing a 10-minute timeout
  failure on every merge to main
- Tugboat previews are PR-specific; tests run against the PR base preview
  before merge, which is the right time to catch regressions

## Test plan

- [ ] Confirm Playwright tests run on PR open/update (pull_request trigger)
- [ ] Confirm no Playwright workflow runs on next merge to main


Pre-merge checklist:

- [ ] I have checked for and if required, created update hooks.
- [ ] I have run an accessibility check, and resolved any issues.
- [ ] I have recompiled SCSS if required.
- [ ] I have updated or created CI/CD tests, if required.
- [ ] I have updated from `main` and resolved any merge conflicts.
- [ ] I have verified that all expected checks pass.
- [ ] I have run the pr-expert-review skill and resolved all relevant issues.

