### PR TITLE
Fix pathauto_pattern missing source_module blocking migration UI

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -147,6 +147,9 @@
             },
             "drupal/field_group": {
                 "Fix EntityViewDisplay/EntityFormDisplay::load() incompatibility with Drupal 11.3.x": "web/profiles/mukurtu/patches/field_group-entity-load-11-3.patch"
+            },
+            "drupal/pathauto": {
+                "Fix missing source_module in PHP 8 MigrateSource attribute on PathautoPattern": "web/profiles/mukurtu/patches/pathauto-source-module-missing-php8-attribute.patch"
             }
         }
     }

--- a/patches/pathauto-source-module-missing-php8-attribute.patch
+++ b/patches/pathauto-source-module-missing-php8-attribute.patch
@@ -1,0 +1,10 @@
+--- a/migrations/d7_pathauto_patterns.yml
++++ b/migrations/d7_pathauto_patterns.yml
+@@ -5,6 +5,7 @@
+   - Configuration
+ source:
+   plugin: pathauto_pattern
++  source_module: pathauto
+   constants:
+     status: true
+     selection_logic: 'and'


### PR DESCRIPTION
Drupal 11 prefers PHP 8 attributes over docblock annotations. The pathauto PathautoPattern source plugin's PHP 8 attribute omits source_module (and the MigrateSource attribute class doesn't accept it as a parameter), so Drupal core throws BadPluginDefinitionException during migration discovery, blocking /admin/migrate entirely.

Patch adds source_module: pathauto to d7_pathauto_patterns.yml's source section, satisfying the processDefinition check at the migration-definition level.

Pre-merge checklist:

- [ ] I have checked for and if required, created update hooks.
- [ ] I have run an accessibility check, and resolved any issues.
- [ ] I have recompiled SCSS if required.
- [ ] I have updated or created CI/CD tests, if required.
- [ ] I have updated from `main` and resolved any merge conflicts.
- [ ] I have verified that all expected checks pass.
- [ ] I have run the pr-expert-review skill and resolved all relevant issues.

