### PR TITLE
Fix Tugboat drush cr failing with missing database connection

### DIFF
--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -46,6 +46,12 @@ services:
         - ln -snf ~/mukurtu/web $DOCROOT
 
       update:
+        # Ensure settings.php is always present with the correct database
+        # credentials, guarding against site-install rewrites or refresh-only
+        # runs where the build phase did not execute.
+        - |
+          cp $TUGBOAT_ROOT/.tugboat/settings.tugboat.php ~/mukurtu/web/sites/default/settings.php
+          chown www-data:www-data ~/mukurtu/web/sites/default/settings.php
         # Set appropriate file permissions/ownership for the files directory.
         - |
           cd ~/mukurtu/web
@@ -121,6 +127,10 @@ services:
           # user to create files with the right permissions. Pass in the
           # environment variables from Tugboat using the -E option.
           sudo -E -u www-data ./vendor/bin/drush site-install mukurtu -y --account-pass="admin" --site-name="Mukurtu CMS"
+          # Restore settings.php after site-install, which rewrites the file
+          # and may drop Tugboat-specific settings added before install.
+          cp $TUGBOAT_ROOT/.tugboat/settings.tugboat.php web/sites/default/settings.php
+          chown www-data:www-data web/sites/default/settings.php
   mariadb:
     image: tugboatqa/mariadb:lts
     commands:

--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -65,7 +65,7 @@ services:
           find private_files -type d -exec chmod 2775 {} \;
           find private_files -type f -exec chmod 0664 {} \;
         # Clear Drupal caches so updated templates and code take effect.
-        - cd ~/mukurtu && sudo -u www-data ./vendor/bin/drush cr
+        - cd ~/mukurtu && sudo -E -u www-data ./vendor/bin/drush cr
       build:
         - |
           cd ~/mukurtu


### PR DESCRIPTION
drush site-install rewrites settings.php and can drop Tugboat-specific settings. Re-copy settings.tugboat.php after site-install in the build phase, and also at the start of the update phase so refresh-only runs always have a valid database connection before drush cr runs.

Pre-merge checklist:

- [ ] I have checked for and if required, created update hooks.
- [ ] I have run an accessibility check, and resolved any issues.
- [ ] I have recompiled SCSS if required.
- [ ] I have updated or created CI/CD tests, if required.
- [ ] I have updated from `main` and resolved any merge conflicts.
- [ ] I have verified that all expected checks pass.
- [ ] I have run the pr-expert-review skill and resolved all relevant issues.

