### PR TITLE
Fix Tagify click-to-focus in Paragraphs subforms on Drupal 11.3

### DIFF
--- a/modules/mukurtu_gin_custom/js/mukurtu-tagify-focus.js
+++ b/modules/mukurtu_gin_custom/js/mukurtu-tagify-focus.js
@@ -1,0 +1,40 @@
+/**
+ * @file
+ * Restores click-to-focus on Tagify fields inside Paragraphs subforms.
+ *
+ * In Drupal 11.3, a mousedown handler in the Paragraphs/tabledrag stack calls
+ * preventDefault(), stopping the browser from setting focus on the Tagify
+ * contenteditable span when clicked. Tab navigation is unaffected.
+ *
+ * Fix: a single delegated click listener on document explicitly focuses the
+ * contenteditable span after any click inside a <tags.tagify> element. Using
+ * delegation means it works for both paragraphs present at page load and
+ * those added later via AJAX, regardless of behavior-attachment order.
+ *
+ * See https://github.com/MukurtuCMS/Mukurtu-CMS/issues/1684
+ */
+(function (Drupal, once) {
+  'use strict';
+
+  Drupal.behaviors.mukurtuTagifyFocus = {
+    attach: function (context) {
+      once('mukurtu-tagify-focus', document.body).forEach(function () {
+        document.addEventListener('click', function (e) {
+          const tagsEl = e.target.closest('tags.tagify');
+          if (!tagsEl) {
+            return;
+          }
+          // Don't steal focus from tag removal buttons or the dropdown.
+          if (e.target.closest('.tagify__tag') || e.target.closest('.tagify__dropdown')) {
+            return;
+          }
+          const input = tagsEl.querySelector('.tagify__input');
+          if (input && document.activeElement !== input) {
+            input.focus();
+          }
+        });
+      });
+    },
+  };
+
+})(Drupal, once);

--- a/modules/mukurtu_gin_custom/js/mukurtu-tagify-focus.js
+++ b/modules/mukurtu_gin_custom/js/mukurtu-tagify-focus.js
@@ -1,15 +1,17 @@
 /**
  * @file
- * Restores click-to-focus on Tagify fields inside Paragraphs subforms.
+ * Restores click-to-focus on form fields inside Paragraphs subforms.
  *
  * In Drupal 11.3, a mousedown handler in the Paragraphs/tabledrag stack calls
- * preventDefault(), stopping the browser from setting focus on the Tagify
- * contenteditable span when clicked. Tab navigation is unaffected.
+ * preventDefault(), stopping the browser from setting focus on any interactive
+ * element inside a draggable row when the user clicks it. This affects text
+ * inputs, textareas, and Tagify contenteditable spans alike. Tab navigation
+ * is unaffected because keyboard focus bypasses mousedown.
  *
  * Fix: a single delegated click listener on document explicitly focuses the
- * contenteditable span after any click inside a <tags.tagify> element. Using
- * delegation means it works for both paragraphs present at page load and
- * those added later via AJAX, regardless of behavior-attachment order.
+ * clicked element (or the Tagify contenteditable span) after any click inside
+ * a Paragraphs content cell. Using delegation means it works for paragraphs
+ * present at page load and those added later via AJAX.
  *
  * See https://github.com/MukurtuCMS/Mukurtu-CMS/issues/1684
  */
@@ -20,17 +22,32 @@
     attach: function (context) {
       once('mukurtu-tagify-focus', document.body).forEach(function () {
         document.addEventListener('click', function (e) {
+          // Only act inside Paragraphs draggable content cells (not the drag
+          // handle column).
+          if (!e.target.closest('tr.draggable > td:not(.field-multiple-drag)')) {
+            return;
+          }
+
+          // Tagify fields: focus the contenteditable span, not the hidden input.
           const tagsEl = e.target.closest('tags.tagify');
-          if (!tagsEl) {
+          if (tagsEl) {
+            // Don't steal focus from tag removal buttons or the dropdown.
+            if (e.target.closest('.tagify__tag') || e.target.closest('.tagify__dropdown')) {
+              return;
+            }
+            const input = tagsEl.querySelector('.tagify__input');
+            if (input && document.activeElement !== input) {
+              input.focus();
+            }
             return;
           }
-          // Don't steal focus from tag removal buttons or the dropdown.
-          if (e.target.closest('.tagify__tag') || e.target.closest('.tagify__dropdown')) {
-            return;
-          }
-          const input = tagsEl.querySelector('.tagify__input');
-          if (input && document.activeElement !== input) {
-            input.focus();
+
+          // Regular form fields: re-focus the element the click landed on.
+          const focusable = e.target.closest(
+            'input:not([type="hidden"]), textarea, select, [contenteditable]'
+          );
+          if (focusable && document.activeElement !== focusable) {
+            focusable.focus();
           }
         });
       });

--- a/modules/mukurtu_gin_custom/mukurtu_gin_custom.libraries.yml
+++ b/modules/mukurtu_gin_custom/mukurtu_gin_custom.libraries.yml
@@ -3,6 +3,11 @@ mukurtu-gin-custom:
   css:
     base:
       css/mukurtu-gin-custom.css: {}
+  js:
+    js/mukurtu-tagify-focus.js: {}
+  dependencies:
+    - core/drupal
+    - core/once
 
 entity-browser-toggle:
   version: 1.x


### PR DESCRIPTION
Closes #1684

## Summary

- Adds a delegated `click` listener on `document` that explicitly re-focuses any interactive form field after a click inside a Paragraphs draggable content cell
- Handles Tagify fields as a special case (focuses the `contenteditable` span rather than the hidden backing input)
- Single JS file added to `mukurtu_gin_custom`; listener registers once via `once(document.body)`

## Root cause

In Drupal 11.3, a `mousedown` handler in the Paragraphs/tabledrag stack calls `preventDefault()`, preventing the browser from setting focus on any interactive element inside a `tr.draggable` row when clicked. This affects Tagify fields, regular text inputs, textareas, and entity reference fields alike (Definition, Pronunciation, Contributor, Biography body, Relationship Type, Word Type, etc.). Tab navigation works normally because keyboard focus bypasses `mousedown`.

The fix intercepts the `click` event (which fires even after a prevented `mousedown`) and explicitly restores focus on the clicked element.

Using event delegation on `document` rather than per-element listeners ensures the fix covers both paragraphs present at page load and those added later via AJAX, regardless of behavior-attachment order.

## Maintenance notes

**Low risk — the fix is additive.** Calling `.focus()` on an already-focused element is a no-op, so if core, Paragraphs, or tabledrag ever fixes the underlying `mousedown` prevention, this handler silently becomes harmless rather than conflicting.

**Things to watch for:**
- **Tagify DOM changes** — if `tags.tagify` or `.tagify__input` class names change in a future Tagify release, the Tagify branch of the handler will stop working (the regular-field branch uses stable browser-native selectors and is unaffected)
- **Paragraphs table restructure** — if `tr.draggable` or `td.field-multiple-drag` are renamed or removed, the outer guard stops matching and the fix silently becomes a no-op
- **New widgets that intentionally prevent focus** — if a future widget blocks focus on click to open a modal instead, an exclusion selector would need to be added
- **Drupal 11.4+ core fix** — if the underlying `mousedown` prevention in tabledrag is fixed upstream, test Paragraphs subform fields and remove this workaround, noting the minimum core version

An upstream issue should be filed with Drupal core or Paragraphs pointing at the `mousedown preventDefault` as the root cause.

## Test plan

- [ ] Open a Person record, add a Related Person paragraph — confirm clicking Relationship Type and Biography body fields works without tabbing first
- [ ] Open a Dictionary Word — confirm clicking Definition, Word Type, Pronunciation, and Contributor in Word Entry paragraphs all work on click
- [ ] Confirm tag removal (× button) on Tagify fields still works
- [ ] Confirm autocomplete suggestions dropdown still works
- [ ] Confirm Tab navigation still works for all affected fields