### PR TITLE
Add taxonomy term export to mukurtu_export and mukurtu_import

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -161,6 +161,9 @@
             },
             "drupal/flat_taxonomy": {
                 "Fix null vocabulary crash in presave hook during migration": "web/profiles/mukurtu/patches/flat-taxonomy-null-vocabulary-presave.patch"
+            },
+            "drupal/migrate_source_csv": {
+                "Replace deprecated createFromStream() with from() for league/csv 9.27+": "patches/migrate_source_csv-createFromStream-deprecated-9.27.patch"
             }
         }
     }

--- a/config/install/user.role.mukurtu_manager.yml
+++ b/config/install/user.role.mukurtu_manager.yml
@@ -67,6 +67,7 @@ weight: 2
 is_admin: null
 permissions:
   - 'access mukurtu export'
+  - 'access mukurtu import'
   - 'administer mukurtu_media configuration'
   - 'administer mukurtu media download settings'
   - 'create article content'

--- a/config/install/user.role.mukurtu_manager.yml
+++ b/config/install/user.role.mukurtu_manager.yml
@@ -66,6 +66,7 @@ label: 'Mukurtu Manager'
 weight: 2
 is_admin: null
 permissions:
+  - 'access mukurtu export'
   - 'administer mukurtu_media configuration'
   - 'administer mukurtu media download settings'
   - 'create article content'

--- a/config/install/user.role.mukurtu_roundtrip_manager.yml
+++ b/config/install/user.role.mukurtu_roundtrip_manager.yml
@@ -11,6 +11,7 @@ weight: 3
 is_admin: null
 permissions:
   - 'access mukurtu export'
+  - 'access mukurtu import'
   - 'administer mukurtu_import_strategy'
   - 'flag export_content'
   - 'flag export_media'

--- a/modules/mukurtu_export/config/install/mukurtu_export.csv_exporter.recommended_settings_for_import.yml
+++ b/modules/mukurtu_export/config/install/mukurtu_export.csv_exporter.recommended_settings_for_import.yml
@@ -261,78 +261,112 @@ entity_fields_export_list:
     langcode: Locale
     name: Name
     description: Description
+    parent: Parent
   taxonomy_term__category:
     tid: 'Term ID'
     langcode: Locale
     name: Name
     description: Description
     default_langcode: 'Default translation'
+    field_thumbnail_image: Thumbnail
+    parent: Parent
   taxonomy_term__community_type:
     tid: 'Term ID'
     langcode: Locale
     name: Name
     description: Description
+    parent: Parent
   taxonomy_term__contributor:
     tid: 'Term ID'
     langcode: Locale
     name: Name
     description: Description
+    parent: Parent
   taxonomy_term__creator:
     tid: 'Term ID'
     langcode: Locale
     name: Name
     description: Description
+    parent: Parent
   taxonomy_term__format:
     tid: 'Term ID'
     langcode: Locale
     name: Name
     description: Description
     revision_default: 'Default revision'
+    parent: Parent
   taxonomy_term__interpersonal_relationship:
     tid: 'Term ID'
     langcode: Locale
     name: Name
     description: Description
+    parent: Parent
   taxonomy_term__keywords:
     tid: 'Term ID'
     langcode: Locale
     name: Name
     description: Description
+    parent: Parent
   taxonomy_term__language:
     tid: 'Term ID'
     langcode: Locale
     name: Name
     description: Description
+    parent: Parent
+  taxonomy_term__location:
+    tid: 'Term ID'
+    langcode: Locale
+    name: Name
+    description: Description
+    parent: Parent
+  taxonomy_term__media_tag:
+    tid: 'Term ID'
+    langcode: Locale
+    name: Name
+    description: Description
+    parent: Parent
   taxonomy_term__people:
     tid: 'Term ID'
     langcode: Locale
     name: Name
     description: Description
+    parent: Parent
+  taxonomy_term__place_type:
+    tid: 'Term ID'
+    langcode: Locale
+    name: Name
+    description: Description
+    parent: Parent
   taxonomy_term__publisher:
     tid: 'Term ID'
     langcode: Locale
     name: Name
     description: Description
+    parent: Parent
   taxonomy_term__subject:
     tid: 'Term ID'
     langcode: Locale
     name: Name
     description: Description
+    parent: Parent
   taxonomy_term__tags:
     tid: 'Term ID'
     langcode: Locale
     name: Name
     description: Description
+    parent: Parent
   taxonomy_term__type:
     tid: 'Term ID'
     langcode: Locale
     name: Name
     description: Description
+    parent: Parent
   taxonomy_term__word_type:
     tid: 'Term ID'
     langcode: Locale
     name: Name
     description: Description
+    parent: Parent
   user__user:
     uid: 'User ID'
     langcode: 'Language code'

--- a/modules/mukurtu_export/mukurtu_export.install
+++ b/modules/mukurtu_export/mukurtu_export.install
@@ -45,3 +45,52 @@ function mukurtu_export_update_40004() {
   }
 }
 
+/**
+ * Update the recommended CSV exporter settings for taxonomy term export.
+ *
+ * Adds missing vocabulary bundles (location, media_tag, place_type), adds
+ * field_thumbnail_image to the category bundle, and adds a reserved parent
+ * column to all taxonomy_term bundles for future hierarchy support.
+ *
+ * Also grants 'access mukurtu export' to the Mukurtu Manager role.
+ */
+function mukurtu_export_update_40005() {
+  $config = \Drupal::service('config.factory')
+    ->getEditable('mukurtu_export.csv_exporter.recommended_settings_for_import');
+
+  if ($config->isNew()) {
+    return;
+  }
+
+  $entity_fields = $config->get('entity_fields_export_list') ?? [];
+
+  // Add parent column to all existing taxonomy_term bundles that lack it.
+  foreach ($entity_fields as $key => $fields) {
+    if (str_starts_with($key, 'taxonomy_term__') && !isset($fields['parent'])) {
+      $entity_fields[$key]['parent'] = 'Parent';
+    }
+  }
+
+  // Add field_thumbnail_image to the category bundle if not already present.
+  if (isset($entity_fields['taxonomy_term__category']) && !isset($entity_fields['taxonomy_term__category']['field_thumbnail_image'])) {
+    $entity_fields['taxonomy_term__category']['field_thumbnail_image'] = 'Thumbnail';
+  }
+
+  // Add vocabulary bundles missing from the original config.
+  $base = ['tid' => 'Term ID', 'langcode' => 'Locale', 'name' => 'Name', 'description' => 'Description', 'parent' => 'Parent'];
+  foreach (['taxonomy_term__location', 'taxonomy_term__media_tag', 'taxonomy_term__place_type'] as $key) {
+    if (!isset($entity_fields[$key])) {
+      $entity_fields[$key] = $base;
+    }
+  }
+
+  $config->set('entity_fields_export_list', $entity_fields)->save();
+
+  // Grant taxonomy export access to the Mukurtu Manager role.
+  $role = \Drupal::entityTypeManager()->getStorage('user_role')->load('mukurtu_manager');
+  if ($role) {
+    $role->grantPermission('access mukurtu export');
+    $role->save();
+  }
+}
+

--- a/modules/mukurtu_export/mukurtu_export.links.menu.yml
+++ b/modules/mukurtu_export/mukurtu_export.links.menu.yml
@@ -12,3 +12,10 @@ mukurtu_export.export_lists:
   menu_name: dashboard-roundtrip
   parent: mukurtu_dashboard
   route_name: entity.export_list.collection
+
+mukurtu_export.taxonomy_export:
+  title: 'Export Taxonomy'
+  description: 'Export taxonomy terms to CSV.'
+  menu_name: dashboard-roundtrip
+  parent: mukurtu_dashboard
+  route_name: mukurtu_export.taxonomy_export_start

--- a/modules/mukurtu_export/mukurtu_export.routing.yml
+++ b/modules/mukurtu_export/mukurtu_export.routing.yml
@@ -96,3 +96,11 @@ mukurtu_export.remove_node_from_list:
         type: entity:node
   requirements:
     _permission: 'access mukurtu export'
+
+mukurtu_export.taxonomy_export_start:
+  path: '/admin/export/taxonomy'
+  defaults:
+    _title: 'Export Taxonomy'
+    _form: 'Drupal\mukurtu_export\Form\TaxonomyExportStartForm'
+  requirements:
+    _permission: 'access mukurtu export'

--- a/modules/mukurtu_export/src/Form/TaxonomyExportStartForm.php
+++ b/modules/mukurtu_export/src/Form/TaxonomyExportStartForm.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Drupal\mukurtu_export\Form;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\TempStore\PrivateTempStoreFactory;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Vocabulary picker form that initiates a taxonomy term CSV export.
+ *
+ * Selected vocabulary terms are stored as ad_hoc_items so the existing
+ * ExportSettingsForm and BatchExportExecutable handle the rest unchanged.
+ */
+class TaxonomyExportStartForm extends FormBase {
+
+  public function __construct(
+    protected readonly PrivateTempStoreFactory $tempStoreFactory,
+    protected readonly EntityTypeManagerInterface $entityTypeManager,
+  ) {}
+
+  public static function create(ContainerInterface $container): static {
+    return new static(
+      $container->get('tempstore.private'),
+      $container->get('entity_type.manager'),
+    );
+  }
+
+  public function getFormId(): string {
+    return 'mukurtu_taxonomy_export_start';
+  }
+
+  public function buildForm(array $form, FormStateInterface $form_state): array {
+    $vocabularies = $this->entityTypeManager->getStorage('taxonomy_vocabulary')->loadMultiple();
+
+    $options = [];
+    foreach ($vocabularies as $vocab) {
+      $options[$vocab->id()] = $vocab->label();
+    }
+    asort($options);
+
+    $form['vocabularies'] = [
+      '#type' => 'checkboxes',
+      '#title' => $this->t('Vocabularies'),
+      '#description' => $this->t('Select one or more vocabularies to export. All terms in the selected vocabularies will be included.'),
+      '#options' => $options,
+      '#required' => TRUE,
+    ];
+
+    $form['actions'] = ['#type' => 'actions'];
+    $form['actions']['submit'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Configure Export'),
+      '#button_type' => 'primary',
+    ];
+
+    return $form;
+  }
+
+  public function submitForm(array &$form, FormStateInterface $form_state): void {
+    $selected = array_filter($form_state->getValue('vocabularies'));
+
+    $ids = $this->entityTypeManager
+      ->getStorage('taxonomy_term')
+      ->getQuery()
+      ->condition('vid', array_values($selected), 'IN')
+      ->accessCheck(TRUE)
+      ->execute();
+
+    if (empty($ids)) {
+      $this->messenger()->addWarning($this->t('No terms found in the selected vocabularies.'));
+      return;
+    }
+
+    $ids = array_map('intval', array_values($ids));
+
+    $store = $this->tempStoreFactory->get('mukurtu_import');
+    $store->delete('export_list_id');
+    $store->set('ad_hoc_items', ['taxonomy_term' => array_combine($ids, $ids)]);
+    $store->set('exporter_id', 'csv');
+
+    $form_state->setRedirect('mukurtu_export.export_settings');
+  }
+
+}

--- a/modules/mukurtu_import/config/install/mukurtu_import.mukurtu_import_strategy.taxonomy_category_all_fields.yml
+++ b/modules/mukurtu_import/config/install/mukurtu_import.mukurtu_import_strategy.taxonomy_category_all_fields.yml
@@ -1,0 +1,36 @@
+langcode: en
+status: true
+dependencies: {  }
+id: taxonomy_category_all_fields
+uid: 1
+label: 'Taxonomy - Category'
+description: ''
+target_entity_type_id: taxonomy_term
+target_bundle: category
+mapping:
+  -
+    source: 'Term ID'
+    target: tid
+  -
+    source: Locale
+    target: langcode
+  -
+    source: Name
+    target: name
+  -
+    source: Description
+    target: description
+  -
+    source: Thumbnail
+    target: field_thumbnail_image
+  -
+    source: Parent
+    target: parent
+configuration:
+  delimiter: ','
+  enclosure: '"'
+  escape: \
+  multivalue_delimiter: '||'
+  default_format: basic_html
+  identifier_column: null
+  local_contexts_delimiter: '>'

--- a/modules/mukurtu_import/config/install/mukurtu_import.mukurtu_import_strategy.taxonomy_community_type_all_fields.yml
+++ b/modules/mukurtu_import/config/install/mukurtu_import.mukurtu_import_strategy.taxonomy_community_type_all_fields.yml
@@ -1,0 +1,33 @@
+langcode: en
+status: true
+dependencies: {  }
+id: taxonomy_community_type_all_fields
+uid: 1
+label: 'Taxonomy - Community Type'
+description: ''
+target_entity_type_id: taxonomy_term
+target_bundle: community_type
+mapping:
+  -
+    source: 'Term ID'
+    target: tid
+  -
+    source: Locale
+    target: langcode
+  -
+    source: Name
+    target: name
+  -
+    source: Description
+    target: description
+  -
+    source: Parent
+    target: parent
+configuration:
+  delimiter: ','
+  enclosure: '"'
+  escape: '\'
+  multivalue_delimiter: '||'
+  default_format: basic_html
+  identifier_column: null
+  local_contexts_delimiter: '>'

--- a/modules/mukurtu_import/config/install/mukurtu_import.mukurtu_import_strategy.taxonomy_contributor_all_fields.yml
+++ b/modules/mukurtu_import/config/install/mukurtu_import.mukurtu_import_strategy.taxonomy_contributor_all_fields.yml
@@ -1,0 +1,33 @@
+langcode: en
+status: true
+dependencies: {  }
+id: taxonomy_contributor_all_fields
+uid: 1
+label: 'Taxonomy - Contributor'
+description: ''
+target_entity_type_id: taxonomy_term
+target_bundle: contributor
+mapping:
+  -
+    source: 'Term ID'
+    target: tid
+  -
+    source: Locale
+    target: langcode
+  -
+    source: Name
+    target: name
+  -
+    source: Description
+    target: description
+  -
+    source: Parent
+    target: parent
+configuration:
+  delimiter: ','
+  enclosure: '"'
+  escape: '\'
+  multivalue_delimiter: '||'
+  default_format: basic_html
+  identifier_column: null
+  local_contexts_delimiter: '>'

--- a/modules/mukurtu_import/config/install/mukurtu_import.mukurtu_import_strategy.taxonomy_creator_all_fields.yml
+++ b/modules/mukurtu_import/config/install/mukurtu_import.mukurtu_import_strategy.taxonomy_creator_all_fields.yml
@@ -1,0 +1,33 @@
+langcode: en
+status: true
+dependencies: {  }
+id: taxonomy_creator_all_fields
+uid: 1
+label: 'Taxonomy - Creator'
+description: ''
+target_entity_type_id: taxonomy_term
+target_bundle: creator
+mapping:
+  -
+    source: 'Term ID'
+    target: tid
+  -
+    source: Locale
+    target: langcode
+  -
+    source: Name
+    target: name
+  -
+    source: Description
+    target: description
+  -
+    source: Parent
+    target: parent
+configuration:
+  delimiter: ','
+  enclosure: '"'
+  escape: '\'
+  multivalue_delimiter: '||'
+  default_format: basic_html
+  identifier_column: null
+  local_contexts_delimiter: '>'

--- a/modules/mukurtu_import/config/install/mukurtu_import.mukurtu_import_strategy.taxonomy_format_all_fields.yml
+++ b/modules/mukurtu_import/config/install/mukurtu_import.mukurtu_import_strategy.taxonomy_format_all_fields.yml
@@ -1,0 +1,33 @@
+langcode: en
+status: true
+dependencies: {  }
+id: taxonomy_format_all_fields
+uid: 1
+label: 'Taxonomy - Format'
+description: ''
+target_entity_type_id: taxonomy_term
+target_bundle: format
+mapping:
+  -
+    source: 'Term ID'
+    target: tid
+  -
+    source: Locale
+    target: langcode
+  -
+    source: Name
+    target: name
+  -
+    source: Description
+    target: description
+  -
+    source: Parent
+    target: parent
+configuration:
+  delimiter: ','
+  enclosure: '"'
+  escape: '\'
+  multivalue_delimiter: '||'
+  default_format: basic_html
+  identifier_column: null
+  local_contexts_delimiter: '>'

--- a/modules/mukurtu_import/config/install/mukurtu_import.mukurtu_import_strategy.taxonomy_interpersonal_relationship_all_fields.yml
+++ b/modules/mukurtu_import/config/install/mukurtu_import.mukurtu_import_strategy.taxonomy_interpersonal_relationship_all_fields.yml
@@ -1,0 +1,33 @@
+langcode: en
+status: true
+dependencies: {  }
+id: taxonomy_interpersonal_relationship_all_fields
+uid: 1
+label: 'Taxonomy - Interpersonal Relationship'
+description: ''
+target_entity_type_id: taxonomy_term
+target_bundle: interpersonal_relationship
+mapping:
+  -
+    source: 'Term ID'
+    target: tid
+  -
+    source: Locale
+    target: langcode
+  -
+    source: Name
+    target: name
+  -
+    source: Description
+    target: description
+  -
+    source: Parent
+    target: parent
+configuration:
+  delimiter: ','
+  enclosure: '"'
+  escape: '\'
+  multivalue_delimiter: '||'
+  default_format: basic_html
+  identifier_column: null
+  local_contexts_delimiter: '>'

--- a/modules/mukurtu_import/config/install/mukurtu_import.mukurtu_import_strategy.taxonomy_keywords_all_fields.yml
+++ b/modules/mukurtu_import/config/install/mukurtu_import.mukurtu_import_strategy.taxonomy_keywords_all_fields.yml
@@ -1,0 +1,33 @@
+langcode: en
+status: true
+dependencies: {  }
+id: taxonomy_keywords_all_fields
+uid: 1
+label: 'Taxonomy - Keywords'
+description: ''
+target_entity_type_id: taxonomy_term
+target_bundle: keywords
+mapping:
+  -
+    source: 'Term ID'
+    target: tid
+  -
+    source: Locale
+    target: langcode
+  -
+    source: Name
+    target: name
+  -
+    source: Description
+    target: description
+  -
+    source: Parent
+    target: parent
+configuration:
+  delimiter: ','
+  enclosure: '"'
+  escape: '\'
+  multivalue_delimiter: '||'
+  default_format: basic_html
+  identifier_column: null
+  local_contexts_delimiter: '>'

--- a/modules/mukurtu_import/config/install/mukurtu_import.mukurtu_import_strategy.taxonomy_language_all_fields.yml
+++ b/modules/mukurtu_import/config/install/mukurtu_import.mukurtu_import_strategy.taxonomy_language_all_fields.yml
@@ -1,0 +1,33 @@
+langcode: en
+status: true
+dependencies: {  }
+id: taxonomy_language_all_fields
+uid: 1
+label: 'Taxonomy - Language'
+description: ''
+target_entity_type_id: taxonomy_term
+target_bundle: language
+mapping:
+  -
+    source: 'Term ID'
+    target: tid
+  -
+    source: Locale
+    target: langcode
+  -
+    source: Name
+    target: name
+  -
+    source: Description
+    target: description
+  -
+    source: Parent
+    target: parent
+configuration:
+  delimiter: ','
+  enclosure: '"'
+  escape: '\'
+  multivalue_delimiter: '||'
+  default_format: basic_html
+  identifier_column: null
+  local_contexts_delimiter: '>'

--- a/modules/mukurtu_import/config/install/mukurtu_import.mukurtu_import_strategy.taxonomy_location_all_fields.yml
+++ b/modules/mukurtu_import/config/install/mukurtu_import.mukurtu_import_strategy.taxonomy_location_all_fields.yml
@@ -1,0 +1,33 @@
+langcode: en
+status: true
+dependencies: {  }
+id: taxonomy_location_all_fields
+uid: 1
+label: 'Taxonomy - Location'
+description: ''
+target_entity_type_id: taxonomy_term
+target_bundle: location
+mapping:
+  -
+    source: 'Term ID'
+    target: tid
+  -
+    source: Locale
+    target: langcode
+  -
+    source: Name
+    target: name
+  -
+    source: Description
+    target: description
+  -
+    source: Parent
+    target: parent
+configuration:
+  delimiter: ','
+  enclosure: '"'
+  escape: '\'
+  multivalue_delimiter: '||'
+  default_format: basic_html
+  identifier_column: null
+  local_contexts_delimiter: '>'

--- a/modules/mukurtu_import/config/install/mukurtu_import.mukurtu_import_strategy.taxonomy_media_tag_all_fields.yml
+++ b/modules/mukurtu_import/config/install/mukurtu_import.mukurtu_import_strategy.taxonomy_media_tag_all_fields.yml
@@ -1,0 +1,33 @@
+langcode: en
+status: true
+dependencies: {  }
+id: taxonomy_media_tag_all_fields
+uid: 1
+label: 'Taxonomy - Media Tag'
+description: ''
+target_entity_type_id: taxonomy_term
+target_bundle: media_tag
+mapping:
+  -
+    source: 'Term ID'
+    target: tid
+  -
+    source: Locale
+    target: langcode
+  -
+    source: Name
+    target: name
+  -
+    source: Description
+    target: description
+  -
+    source: Parent
+    target: parent
+configuration:
+  delimiter: ','
+  enclosure: '"'
+  escape: '\'
+  multivalue_delimiter: '||'
+  default_format: basic_html
+  identifier_column: null
+  local_contexts_delimiter: '>'

--- a/modules/mukurtu_import/config/install/mukurtu_import.mukurtu_import_strategy.taxonomy_people_all_fields.yml
+++ b/modules/mukurtu_import/config/install/mukurtu_import.mukurtu_import_strategy.taxonomy_people_all_fields.yml
@@ -1,0 +1,33 @@
+langcode: en
+status: true
+dependencies: {  }
+id: taxonomy_people_all_fields
+uid: 1
+label: 'Taxonomy - People'
+description: ''
+target_entity_type_id: taxonomy_term
+target_bundle: people
+mapping:
+  -
+    source: 'Term ID'
+    target: tid
+  -
+    source: Locale
+    target: langcode
+  -
+    source: Name
+    target: name
+  -
+    source: Description
+    target: description
+  -
+    source: Parent
+    target: parent
+configuration:
+  delimiter: ','
+  enclosure: '"'
+  escape: '\'
+  multivalue_delimiter: '||'
+  default_format: basic_html
+  identifier_column: null
+  local_contexts_delimiter: '>'

--- a/modules/mukurtu_import/config/install/mukurtu_import.mukurtu_import_strategy.taxonomy_place_type_all_fields.yml
+++ b/modules/mukurtu_import/config/install/mukurtu_import.mukurtu_import_strategy.taxonomy_place_type_all_fields.yml
@@ -1,0 +1,33 @@
+langcode: en
+status: true
+dependencies: {  }
+id: taxonomy_place_type_all_fields
+uid: 1
+label: 'Taxonomy - Place Type'
+description: ''
+target_entity_type_id: taxonomy_term
+target_bundle: place_type
+mapping:
+  -
+    source: 'Term ID'
+    target: tid
+  -
+    source: Locale
+    target: langcode
+  -
+    source: Name
+    target: name
+  -
+    source: Description
+    target: description
+  -
+    source: Parent
+    target: parent
+configuration:
+  delimiter: ','
+  enclosure: '"'
+  escape: '\'
+  multivalue_delimiter: '||'
+  default_format: basic_html
+  identifier_column: null
+  local_contexts_delimiter: '>'

--- a/modules/mukurtu_import/config/install/mukurtu_import.mukurtu_import_strategy.taxonomy_publisher_all_fields.yml
+++ b/modules/mukurtu_import/config/install/mukurtu_import.mukurtu_import_strategy.taxonomy_publisher_all_fields.yml
@@ -1,0 +1,33 @@
+langcode: en
+status: true
+dependencies: {  }
+id: taxonomy_publisher_all_fields
+uid: 1
+label: 'Taxonomy - Publisher'
+description: ''
+target_entity_type_id: taxonomy_term
+target_bundle: publisher
+mapping:
+  -
+    source: 'Term ID'
+    target: tid
+  -
+    source: Locale
+    target: langcode
+  -
+    source: Name
+    target: name
+  -
+    source: Description
+    target: description
+  -
+    source: Parent
+    target: parent
+configuration:
+  delimiter: ','
+  enclosure: '"'
+  escape: '\'
+  multivalue_delimiter: '||'
+  default_format: basic_html
+  identifier_column: null
+  local_contexts_delimiter: '>'

--- a/modules/mukurtu_import/config/install/mukurtu_import.mukurtu_import_strategy.taxonomy_subject_all_fields.yml
+++ b/modules/mukurtu_import/config/install/mukurtu_import.mukurtu_import_strategy.taxonomy_subject_all_fields.yml
@@ -1,0 +1,33 @@
+langcode: en
+status: true
+dependencies: {  }
+id: taxonomy_subject_all_fields
+uid: 1
+label: 'Taxonomy - Subject'
+description: ''
+target_entity_type_id: taxonomy_term
+target_bundle: subject
+mapping:
+  -
+    source: 'Term ID'
+    target: tid
+  -
+    source: Locale
+    target: langcode
+  -
+    source: Name
+    target: name
+  -
+    source: Description
+    target: description
+  -
+    source: Parent
+    target: parent
+configuration:
+  delimiter: ','
+  enclosure: '"'
+  escape: '\'
+  multivalue_delimiter: '||'
+  default_format: basic_html
+  identifier_column: null
+  local_contexts_delimiter: '>'

--- a/modules/mukurtu_import/config/install/mukurtu_import.mukurtu_import_strategy.taxonomy_type_all_fields.yml
+++ b/modules/mukurtu_import/config/install/mukurtu_import.mukurtu_import_strategy.taxonomy_type_all_fields.yml
@@ -1,0 +1,33 @@
+langcode: en
+status: true
+dependencies: {  }
+id: taxonomy_type_all_fields
+uid: 1
+label: 'Taxonomy - Type'
+description: ''
+target_entity_type_id: taxonomy_term
+target_bundle: type
+mapping:
+  -
+    source: 'Term ID'
+    target: tid
+  -
+    source: Locale
+    target: langcode
+  -
+    source: Name
+    target: name
+  -
+    source: Description
+    target: description
+  -
+    source: Parent
+    target: parent
+configuration:
+  delimiter: ','
+  enclosure: '"'
+  escape: '\'
+  multivalue_delimiter: '||'
+  default_format: basic_html
+  identifier_column: null
+  local_contexts_delimiter: '>'

--- a/modules/mukurtu_import/config/install/mukurtu_import.mukurtu_import_strategy.taxonomy_word_type_all_fields.yml
+++ b/modules/mukurtu_import/config/install/mukurtu_import.mukurtu_import_strategy.taxonomy_word_type_all_fields.yml
@@ -1,0 +1,33 @@
+langcode: en
+status: true
+dependencies: {  }
+id: taxonomy_word_type_all_fields
+uid: 1
+label: 'Taxonomy - Word Type'
+description: ''
+target_entity_type_id: taxonomy_term
+target_bundle: word_type
+mapping:
+  -
+    source: 'Term ID'
+    target: tid
+  -
+    source: Locale
+    target: langcode
+  -
+    source: Name
+    target: name
+  -
+    source: Description
+    target: description
+  -
+    source: Parent
+    target: parent
+configuration:
+  delimiter: ','
+  enclosure: '"'
+  escape: '\'
+  multivalue_delimiter: '||'
+  default_format: basic_html
+  identifier_column: null
+  local_contexts_delimiter: '>'

--- a/modules/mukurtu_import/config/install/views.view.mukurtu_import_results_taxonomy_terms.yml
+++ b/modules/mukurtu_import/config/install/views.view.mukurtu_import_results_taxonomy_terms.yml
@@ -1,0 +1,409 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+    - user
+id: mukurtu_import_results_taxonomy_terms
+label: 'Mukurtu Import Results: Taxonomy Terms'
+module: views
+description: ''
+tag: ''
+base_table: taxonomy_term_field_data
+base_field: tid
+display:
+  default:
+    id: default
+    display_title: Default
+    display_plugin: default
+    position: 0
+    display_options:
+      title: 'Taxonomy Terms'
+      fields:
+        name:
+          id: name
+          table: taxonomy_term_field_data
+          field: name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: taxonomy_term
+          entity_field: name
+          plugin_id: field
+          label: Name
+          exclude: false
+          alter:
+            alter_text: false
+            make_link: false
+            absolute: false
+            word_boundary: false
+            ellipsis: false
+            strip_tags: false
+            trim: false
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        vid:
+          id: vid
+          table: taxonomy_term_field_data
+          field: vid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: taxonomy_term
+          entity_field: vid
+          plugin_id: field
+          label: Vocabulary
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        changed:
+          id: changed
+          table: taxonomy_term_field_data
+          field: changed
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: taxonomy_term
+          entity_field: changed
+          plugin_id: field
+          label: Changed
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: timestamp
+          settings:
+            date_format: medium
+            custom_date_format: ''
+            timezone: ''
+            tooltip:
+              date_format: ''
+              custom_date_format: ''
+            time_diff:
+              enabled: false
+              future_format: '@interval hence'
+              past_format: '@interval ago'
+              granularity: 2
+              refresh: 60
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+      pager:
+        type: full
+        options:
+          offset: 0
+          items_per_page: 20
+          total_pages: null
+          id: 0
+          tags:
+            next: 'Next ›'
+            previous: '‹ Previous'
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
+          pagination_heading_level: h4
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'access mukurtu import'
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
+      sorts:
+        changed:
+          id: changed
+          table: taxonomy_term_field_data
+          field: changed
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: taxonomy_term
+          entity_field: changed
+          plugin_id: date
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
+          granularity: second
+      arguments:
+        revision_log_message:
+          id: revision_log_message
+          table: taxonomy_term_revision
+          field: revision_log_message
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: taxonomy_term
+          entity_field: revision_log_message
+          plugin_id: string
+          default_action: empty
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: fixed
+          default_argument_options:
+            argument: ''
+          summary_options:
+            base_path: ''
+            count: true
+            override: false
+            items_per_page: 25
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          glossary: false
+          limit: 0
+          case: none
+          path_case: none
+          transform_dash: false
+          break_phrase: false
+      filters: {  }
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          columns:
+            name: name
+            vid: vid
+            changed: changed
+          default: '-1'
+          info:
+            name:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            vid:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            changed:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          override: true
+          sticky: false
+          summary: ''
+          empty_table: false
+          caption: ''
+          description: ''
+          class: ''
+      row:
+        type: fields
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      use_ajax: true
+      header:
+        result:
+          id: result
+          table: views
+          field: result
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: result
+          empty: false
+          content: 'Taxonomy terms imported: @total'
+      footer:
+        result:
+          id: result
+          table: views
+          field: result
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: result
+          empty: false
+          content: 'Displaying @start - @end of @total'
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user.permissions
+      tags: {  }
+  results:
+    id: results
+    display_title: Block
+    display_plugin: block
+    position: 1
+    display_options:
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user.permissions
+      tags: {  }

--- a/modules/mukurtu_import/config/install/views.view.mukurtu_import_results_taxonomy_terms.yml
+++ b/modules/mukurtu_import/config/install/views.view.mukurtu_import_results_taxonomy_terms.yml
@@ -67,6 +67,37 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
+        mukurtu_import_term_status:
+          id: mukurtu_import_term_status
+          table: taxonomy_term_field_data
+          field: mukurtu_import_term_status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: mukurtu_import_term_status
+          label: Status
+          exclude: false
+          alter:
+            alter_text: false
+            make_link: false
+            absolute: false
+            word_boundary: false
+            ellipsis: false
+            strip_tags: false
+            trim: false
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
         vid:
           id: vid
           table: taxonomy_term_field_data
@@ -315,12 +346,20 @@ display:
           default_row_class: true
           columns:
             name: name
+            mukurtu_import_term_status: mukurtu_import_term_status
             vid: vid
             changed: changed
           default: '-1'
           info:
             name:
               sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            mukurtu_import_term_status:
+              sortable: false
               default_sort_order: asc
               align: ''
               separator: ''

--- a/modules/mukurtu_import/mukurtu_import.install
+++ b/modules/mukurtu_import/mukurtu_import.install
@@ -447,3 +447,17 @@ function mukurtu_import_update_40027(): void {
     }
   }
 }
+
+/**
+ * Install the taxonomy terms import results view.
+ */
+function mukurtu_import_update_40028(): void {
+  $config_name = 'views.view.mukurtu_import_results_taxonomy_terms';
+  $config = \Drupal::configFactory()->getEditable($config_name);
+  if ($config->isNew()) {
+    $path = \Drupal::service('extension.list.module')->getPath('mukurtu_import');
+    $yaml = file_get_contents("{$path}/config/install/{$config_name}.yml");
+    $data = \Drupal\Core\Serialization\Yaml::decode($yaml);
+    $config->setData($data)->save();
+  }
+}

--- a/modules/mukurtu_import/mukurtu_import.install
+++ b/modules/mukurtu_import/mukurtu_import.install
@@ -461,3 +461,14 @@ function mukurtu_import_update_40028(): void {
     $config->setData($data)->save();
   }
 }
+
+/**
+ * Add New/Updated status field to taxonomy terms import results view.
+ */
+function mukurtu_import_update_40029(): void {
+  $config_name = 'views.view.mukurtu_import_results_taxonomy_terms';
+  $path = \Drupal::service('extension.list.module')->getPath('mukurtu_import');
+  $yaml = file_get_contents("{$path}/config/install/{$config_name}.yml");
+  $data = \Drupal\Core\Serialization\Yaml::decode($yaml);
+  \Drupal::configFactory()->getEditable($config_name)->setData($data)->save();
+}

--- a/modules/mukurtu_import/mukurtu_import.install
+++ b/modules/mukurtu_import/mukurtu_import.install
@@ -399,3 +399,51 @@ function mukurtu_import_update_40025(): void {
     ->set('label', 'Roundtrip Manager')
     ->save();
 }
+
+/**
+ * Install pre-built import strategies for all Mukurtu taxonomy vocabularies.
+ */
+function mukurtu_import_update_40026(): void {
+  $path = \Drupal::service('extension.list.module')->getPath('mukurtu_import');
+  $vocabs = [
+    'taxonomy_category_all_fields',
+    'taxonomy_community_type_all_fields',
+    'taxonomy_contributor_all_fields',
+    'taxonomy_creator_all_fields',
+    'taxonomy_format_all_fields',
+    'taxonomy_interpersonal_relationship_all_fields',
+    'taxonomy_keywords_all_fields',
+    'taxonomy_language_all_fields',
+    'taxonomy_location_all_fields',
+    'taxonomy_media_tag_all_fields',
+    'taxonomy_people_all_fields',
+    'taxonomy_place_type_all_fields',
+    'taxonomy_publisher_all_fields',
+    'taxonomy_subject_all_fields',
+    'taxonomy_type_all_fields',
+    'taxonomy_word_type_all_fields',
+  ];
+
+  foreach ($vocabs as $id) {
+    $config_name = "mukurtu_import.mukurtu_import_strategy.{$id}";
+    $config = \Drupal::configFactory()->getEditable($config_name);
+    if ($config->isNew()) {
+      $yaml = file_get_contents("{$path}/config/install/{$config_name}.yml");
+      $data = \Drupal\Core\Serialization\Yaml::decode($yaml);
+      $config->setData($data)->save();
+    }
+  }
+}
+
+/**
+ * Grant 'access mukurtu import' to the Roundtrip Manager and Mukurtu Manager roles.
+ */
+function mukurtu_import_update_40027(): void {
+  foreach (['mukurtu_roundtrip_manager', 'mukurtu_manager'] as $role_id) {
+    $role = \Drupal::entityTypeManager()->getStorage('user_role')->load($role_id);
+    if ($role && !$role->hasPermission('access mukurtu import')) {
+      $role->grantPermission('access mukurtu import');
+      $role->save();
+    }
+  }
+}

--- a/modules/mukurtu_import/mukurtu_import.module
+++ b/modules/mukurtu_import/mukurtu_import.module
@@ -29,6 +29,19 @@ function mukurtu_import_migrate_destination_info_alter(array &$definitions) {
 }
 
 /**
+ * Implements hook_views_data_alter().
+ */
+function mukurtu_import_views_data_alter(array &$data): void {
+  $data['taxonomy_term_field_data']['mukurtu_import_term_status'] = [
+    'title' => t('Import status'),
+    'help' => t('Whether this term was newly created or updated during this import.'),
+    'field' => [
+      'id' => 'mukurtu_import_term_status',
+    ],
+  ];
+}
+
+/**
  * Implements hook_theme().
  */
 function mukurtu_import_theme($existing, $type, $theme, $path) {

--- a/modules/mukurtu_import/mukurtu_import.module
+++ b/modules/mukurtu_import/mukurtu_import.module
@@ -23,6 +23,9 @@ function mukurtu_import_migrate_destination_info_alter(array &$definitions) {
   if (isset($definitions['entity:multipage_item'])) {
     $definitions['entity:multipage_item']['class'] = ProtocolAwareEntityContent::class;
   }
+  if (isset($definitions['entity:taxonomy_term'])) {
+    $definitions['entity:taxonomy_term']['class'] = ProtocolAwareEntityContent::class;
+  }
 }
 
 /**

--- a/modules/mukurtu_import/src/Form/ExecuteImportForm.php
+++ b/modules/mukurtu_import/src/Form/ExecuteImportForm.php
@@ -19,6 +19,7 @@ use Drupal\migrate\MigrateMessage;
 use Drupal\mukurtu_import\MukurtuImportFieldProcessPluginManager;
 use Drupal\mukurtu_import\MukurtuImportStrategyInterface;
 use Exception;
+use League\Csv\Reader;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class ExecuteImportForm extends ImportBaseForm {
@@ -102,6 +103,7 @@ class ExecuteImportForm extends ImportBaseForm {
         $this->t('Filename'),
         $this->t('Import Settings'),
         $this->t('Destination Import Type'),
+        $this->t('Rows'),
       ],
       '#attributes' => [
         'id' => 'import-review',
@@ -135,6 +137,24 @@ class ExecuteImportForm extends ImportBaseForm {
       $form['table'][$fid]['destination'] = [
         '#type' => 'markup',
         '#markup' => "<div>$entity_label: $bundle_label</div>",
+      ];
+
+      // Row count.
+      $row_count = $this->t('—');
+      $file = $this->entityTypeManager->getStorage('file')->load($fid);
+      if ($file) {
+        try {
+          $csv = Reader::from($file->getFileUri(), 'r');
+          $csv->setHeaderOffset(0);
+          $row_count = count($csv);
+        }
+        catch (Exception $e) {
+          // Leave as em dash if the file can't be read.
+        }
+      }
+      $form['table'][$fid]['row_count'] = [
+        '#type' => 'markup',
+        '#markup' => "<div>{$row_count}</div>",
       ];
 
     }

--- a/modules/mukurtu_import/src/Form/ImportFormTrait.php
+++ b/modules/mukurtu_import/src/Form/ImportFormTrait.php
@@ -45,7 +45,7 @@ trait ImportFormTrait {
   protected function getEntityTypeIdOptions(): array {
     $definitions = $this->entityTypeManager->getDefinitions();
     $options = [];
-    foreach (['node', 'media', 'community', 'protocol', 'paragraph', 'multipage_item'] as $entity_type_id) {
+    foreach (['node', 'media', 'community', 'protocol', 'paragraph', 'multipage_item', 'taxonomy_term'] as $entity_type_id) {
       if (isset($definitions[$entity_type_id]) && $this->userCanCreateAnyBundleForEntityType($entity_type_id)) {
         $options[$entity_type_id] = $definitions[$entity_type_id]->getLabel();
 

--- a/modules/mukurtu_import/src/Form/ImportResultsForm.php
+++ b/modules/mukurtu_import/src/Form/ImportResultsForm.php
@@ -140,6 +140,15 @@ class ImportResultsForm extends ImportBaseForm {
       '#arguments' => [$message->render()],
     ];
     $form['multipage_results'] = $multipage_block;
+
+    $taxonomy_block = [
+      '#type' => 'view',
+      '#name' => 'mukurtu_import_results_taxonomy_terms',
+      '#display_id' => 'results',
+      '#embed' => TRUE,
+      '#arguments' => [$message->render()],
+    ];
+    $form['taxonomy_results'] = $taxonomy_block;
   }
 
 }

--- a/modules/mukurtu_import/src/Plugin/MukurtuImportFieldProcess/EntityReference.php
+++ b/modules/mukurtu_import/src/Plugin/MukurtuImportFieldProcess/EntityReference.php
@@ -94,7 +94,7 @@ class EntityReference extends MukurtuImportFieldProcessPluginBase implements Con
     if ($ref_type == 'taxonomy_term') {
       $target_bundles = $field_config->getSetting('handler_settings')['target_bundles'] ?? [];
       $all_target_bundles = array_keys($target_bundles);
-      $auto_create = $field_config->getSetting('handler_settings')['auto_create'];
+      $auto_create = $field_config->getSetting('handler_settings')['auto_create'] ?? FALSE;
       $auto_create_bundle = $field_config->getSetting('handler_settings')['auto_create_bundle'] ?? NULL;
 
       if (empty($auto_create_bundle)) {

--- a/modules/mukurtu_import/src/Plugin/views/field/TaxonomyTermImportStatus.php
+++ b/modules/mukurtu_import/src/Plugin/views/field/TaxonomyTermImportStatus.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\mukurtu_import\Plugin\views\field;
+
+use Drupal\Core\Database\Connection;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\views\Attribute\ViewsField;
+use Drupal\views\Plugin\views\field\FieldPluginBase;
+use Drupal\views\ResultRow;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Displays whether a taxonomy term was newly created or updated during import.
+ */
+#[ViewsField("mukurtu_import_term_status")]
+class TaxonomyTermImportStatus extends FieldPluginBase implements ContainerFactoryPluginInterface {
+
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    protected Connection $database,
+  ) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): static {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('database'),
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function query(): void {
+    $this->ensureMyTable();
+    $this->field_alias = $this->query->addField($this->tableAlias, 'tid');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function render(ResultRow $values): string {
+    $tid = (int) $this->getValue($values);
+    if (!$tid) {
+      return '';
+    }
+    $revision_count = (int) $this->database
+      ->select('taxonomy_term_revision', 'r')
+      ->condition('r.tid', $tid)
+      ->countQuery()
+      ->execute()
+      ->fetchField();
+    return $revision_count === 1
+      ? (string) $this->t('New')
+      : (string) $this->t('Updated');
+  }
+
+}

--- a/patches/migrate_source_csv-createFromStream-deprecated-9.27.patch
+++ b/patches/migrate_source_csv-createFromStream-deprecated-9.27.patch
@@ -1,0 +1,12 @@
+diff --git a/src/Plugin/migrate/source/CSV.php b/src/Plugin/migrate/source/CSV.php
+--- a/src/Plugin/migrate/source/CSV.php
++++ b/src/Plugin/migrate/source/CSV.php
+@@ -289,7 +289,7 @@
+     if (!$csv) {
+       throw new \RuntimeException(sprintf('File "%s" could not be opened.', $this->configuration['path']));
+     }
+-    return Reader::createFromStream($csv);
++    return Reader::from($csv);
+   }
+
+ }


### PR DESCRIPTION
Closes https://github.com/MukurtuCMS/Mukurtu-CMS/issues/1698

- [ ] Adds a vocabulary picker form at `/admin/export/taxonomy` (linked on dashboard) that lets Roundtrip Managers and Mukurtu Managers select one or more vocabularies and export all their terms to CSV using the existing batch export pipeline.
- [ ] Import uses the existing Import path and process. There are now taxonomy import settings that probably need to be brought in line with the others.

Summary

- TaxonomyExportStartForm: vocabulary checkboxes, stores selected term IDs as ad_hoc_items so the existing ExportSettingsForm and BatchExportExecutable handle the rest without modification
- New route and dashboard-roundtrip menu link for the form
- Recommended CSV exporter config updated: adds location, media_tag, place_type vocabulary entries; adds field_thumbnail_image to category; adds a reserved parent column to all taxonomy_term bundles for future hierarchy support
- update_40005: merges config changes into existing installs and grants access mukurtu export to the mukurtu_manager role
- user.role.mukurtu_manager.yml: grants permission on fresh installs

Pre-merge checklist:

- [ ] I have checked for and if required, created update hooks.
- [ ] I have run an accessibility check, and resolved any issues.
- [ ] I have recompiled SCSS if required.
- [ ] I have updated or created CI/CD tests, if required.
- [ ] I have updated from `main` and resolved any merge conflicts.
- [ ] I have verified that all expected checks pass.
- [ ] I have run the pr-expert-review skill and resolved all relevant issues.

