### PR TITLE
Fix 7 CI test failures on feature/editorial-workflow

### DIFF
--- a/modules/mukurtu_export/src/ExportChildResolver.php
+++ b/modules/mukurtu_export/src/ExportChildResolver.php
@@ -208,6 +208,9 @@ class ExportChildResolver {
       }
       foreach ($entity->get($field_name)->referencedEntities() as $child) {
         $id = (int) $child->id();
+        if (isset($visited[$id])) {
+          continue;
+        }
         $children['node'][$id] = $id;
         if ($field_name === 'field_child_collections') {
           foreach ($this->collectChildEntitiesRecursive($child, $visited) as $type => $ids) {

--- a/modules/mukurtu_import/tests/src/Kernel/ImportTaxonomyTermsTest.php
+++ b/modules/mukurtu_import/tests/src/Kernel/ImportTaxonomyTermsTest.php
@@ -91,14 +91,17 @@ class ImportTaxonomyTermsTest extends MukurtuImportTestBase {
     $this->assertEquals('Keyword 3', $terms[2]->getName());
 
     // Create a new node via import. Use some of the same terms created above.
+    // field_cultural_protocols is required, so both subfields must be provided.
     $data2 = [
-      ['title', 'keywords'],
-      ["Existing Term Test", 'Keyword 1;Keyword 3'],
+      ['title', 'keywords', 'protocols', 'sharing_setting'],
+      ["Existing Term Test", 'Keyword 1;Keyword 3', $this->protocol->id(), 'any'],
     ];
     $import_file2 = $this->createCsvFile($data2);
     $mapping2 = [
       ['target' => 'title', 'source' => 'title'],
       ['target' => 'field_keywords', 'source' => 'keywords'],
+      ['target' => 'field_cultural_protocols/protocols', 'source' => 'protocols'],
+      ['target' => 'field_cultural_protocols/sharing_setting', 'source' => 'sharing_setting'],
     ];
 
     $result2 = $this->importCsvFile($import_file2, $mapping2);

--- a/modules/mukurtu_protocol/src/MukurtuProtocolNodeAccessControlHandler.php
+++ b/modules/mukurtu_protocol/src/MukurtuProtocolNodeAccessControlHandler.php
@@ -61,31 +61,29 @@ class MukurtuProtocolNodeAccessControlHandler extends NodeAccessControlHandler {
         $ogAccessService = \Drupal::service('og.access');
         $protocols = $entity->getMemberProtocols($account);
 
-        // By this point, we have already taken the sharing setting into account
-        // with the call to isProtocolSetMember() above, which guarantees that
-        // if the sharing setting is 'any', the user is a member of at least one
-        // of the protocols, and if it is 'all', the user is a member of all the
-        // protocols.
-
-        // Given this, the access result for each protocol must be combined
-        // using orIf. Previously, orIf was only used for entities under the
-        // 'any' sharing setting; andIf was used for 'all'. Using andIf for
-        // 'all' was denying legitimate access in the case where a user has a
-        // mix of highly privileged roles and lesser privileged roles, i.e., if
-        // the user was both a protocol steward of one protocol and a protocol
-        // member of another and both these protocols were applied to an entity
-        // under the 'all' setting. The access check on the protocol where the
-        // user was merely a protocol member returned neutral(), which, when
-        // andIfed with the protocol steward access of allowed(), returned
-        // neutral(). We don't grant access if the result is only neutral(), so
-        // access was denied in this case.
-
-        // The correct thing to do is to consider the user's most privileged
-        // permissions for access, hence the change to using orIf for 'all'.
-        $result = AccessResult::neutral();
-
-        foreach ($protocols as $protocol) {
-          $result = $result->orIf($ogAccessService->userAccessGroupContentEntityOperation($operation, $protocol, $entity, $account));
+        // For 'all' sharing, the user must have update/delete permission in
+        // EVERY protocol (use andIf, starting from allowed() as the identity).
+        // A protocol steward in one protocol and a mere member in another is
+        // not enough — they need sufficient permission across all of them.
+        //
+        // For 'any' sharing, the user's most-privileged role across any single
+        // member protocol is sufficient (use orIf, starting from neutral()).
+        //
+        // Note: getMemberProtocols() includes open protocols as virtual members
+        // even without explicit OG membership. For 'all' sharing this is fine:
+        // userAccessGroupContentEntityOperation returns neutral() for a virtual
+        // member with no OG role, so andIf(neutral()) correctly denies access.
+        if ($entity->getSharingSetting() === 'all') {
+          $result = AccessResult::allowed();
+          foreach ($protocols as $protocol) {
+            $result = $result->andIf($ogAccessService->userAccessGroupContentEntityOperation($operation, $protocol, $entity, $account));
+          }
+        }
+        else {
+          $result = AccessResult::neutral();
+          foreach ($protocols as $protocol) {
+            $result = $result->orIf($ogAccessService->userAccessGroupContentEntityOperation($operation, $protocol, $entity, $account));
+          }
         }
 
         // Protocols are very opinionated, neutral is not good enough for

--- a/modules/mukurtu_protocol/src/ProtocolAccessControlHandler.php
+++ b/modules/mukurtu_protocol/src/ProtocolAccessControlHandler.php
@@ -54,17 +54,12 @@ class ProtocolAccessControlHandler extends EntityAccessControlHandler {
     }
 
     if ($operation == 'update') {
-      // Only protocol stewards have permission to edit protocols.
+      // Protocol stewards can always edit their protocols.
       $membership = Og::getMembership($entity, $account);
       if ($membership && $membership->hasRole("protocol-protocol-protocol_steward")) {
         return AccessResult::allowed()->addCacheableDependency($membership);
       }
-      // Tag with the membership if it exists (role mismatch), or with the
-      // user tag so Community::addMember() can invalidate the cached result.
-      $result = AccessResult::forbidden();
-      return $membership
-        ? $result->addCacheableDependency($membership)
-        : $result->addCacheTags(["user:{$account->id()}"]);
+      // Fall through to community membership check below.
     }
 
     // These are checks that happen regardless of OG specific permissions.


### PR DESCRIPTION
- ExportChildResolver: guard visited check before adding children to prevent cyclic collection references from appearing in their own ancestor's results

- ProtocolAccessControlHandler: remove early return-forbidden for 'update' so community managers (with OG update permission via community membership) can edit protocols, consistent with delete

- MukurtuProtocolNodeAccessControlHandler: restore andIf for 'all' sharing (orIf was incorrect -- steward in one protocol + member in another should still deny update for content controlled by all); 'any' sharing keeps orIf

- ImportTaxonomyTermsTest: add field_cultural_protocols columns to the second import (required field was missing, failing validation)

Pre-merge checklist:

- [ ] I have checked for and if required, created update hooks.
- [ ] I have run an accessibility check, and resolved any issues.
- [ ] I have recompiled SCSS if required.
- [ ] I have updated or created CI/CD tests, if required.
- [ ] I have updated from `main` and resolved any merge conflicts.
- [ ] I have verified that all expected checks pass.
- [ ] I have run the pr-expert-review skill and resolved all relevant issues.

