### PR TITLE
Show video/remote_video/soundcloud media as their native player by default, with manual thumbnail override (#1624)

### DIFF
--- a/config/install/core.entity_view_display.media.remote_video.browse.yml
+++ b/config/install/core.entity_view_display.media.remote_video.browse.yml
@@ -8,6 +8,7 @@ dependencies:
   module:
     - image
     - layout_builder
+    - media
 third_party_settings:
   layout_builder:
     enabled: false
@@ -17,7 +18,18 @@ targetEntityType: media
 bundle: remote_video
 mode: browse
 content:
-  thumbnail:
+  field_media_oembed_video:
+    type: oembed
+    label: hidden
+    settings:
+      max_width: 800
+      max_height: 0
+      loading:
+        attribute: eager
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  field_thumbnail:
     type: image
     label: hidden
     settings:
@@ -33,12 +45,11 @@ hidden:
   field_communities: true
   field_cultural_protocols: true
   field_identifier: true
-  field_media_oembed_video: true
   field_media_tags: true
   field_people: true
-  field_thumbnail: true
   flag_export_media: true
   langcode: true
   name: true
   search_api_excerpt: true
+  thumbnail: true
   uid: true

--- a/config/install/core.entity_view_display.media.soundcloud.browse.yml
+++ b/config/install/core.entity_view_display.media.soundcloud.browse.yml
@@ -4,7 +4,7 @@ dependencies:
   config:
     - core.entity_view_mode.media.browse
     - image.style.medium_480px_w_
-    - media.type.remote_video
+    - media.type.soundcloud
   module:
     - image
     - layout_builder
@@ -12,12 +12,12 @@ third_party_settings:
   layout_builder:
     enabled: false
     allow_custom: false
-id: media.remote_video.browse
+id: media.soundcloud.browse
 targetEntityType: media
-bundle: remote_video
+bundle: soundcloud
 mode: browse
 content:
-  thumbnail:
+  field_thumbnail:
     type: image
     label: hidden
     settings:
@@ -31,14 +31,15 @@ content:
 hidden:
   created: true
   field_communities: true
+  field_contributor: true
   field_cultural_protocols: true
   field_identifier: true
-  field_media_oembed_video: true
+  field_media_soundcloud: true
   field_media_tags: true
   field_people: true
-  field_thumbnail: true
   flag_export_media: true
   langcode: true
   name: true
   search_api_excerpt: true
+  thumbnail: true
   uid: true

--- a/config/install/core.entity_view_display.media.soundcloud.browse.yml
+++ b/config/install/core.entity_view_display.media.soundcloud.browse.yml
@@ -8,6 +8,7 @@ dependencies:
   module:
     - image
     - layout_builder
+    - media_entity_soundcloud
 third_party_settings:
   layout_builder:
     enabled: false
@@ -17,6 +18,18 @@ targetEntityType: media
 bundle: soundcloud
 mode: browse
 content:
+  field_media_soundcloud:
+    type: soundcloud_embed
+    label: hidden
+    settings:
+      type: visual
+      width: '100%'
+      height: '450'
+      color: '#ff5500'
+      options: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
   field_thumbnail:
     type: image
     label: hidden
@@ -34,7 +47,6 @@ hidden:
   field_contributor: true
   field_cultural_protocols: true
   field_identifier: true
-  field_media_soundcloud: true
   field_media_tags: true
   field_people: true
   flag_export_media: true

--- a/config/install/core.entity_view_display.media.video.browse.yml
+++ b/config/install/core.entity_view_display.media.video.browse.yml
@@ -6,6 +6,8 @@ dependencies:
     - image.style.medium_480px_w_
     - media.type.video
   module:
+    - blazy
+    - file
     - image
     - layout_builder
 third_party_settings:
@@ -17,7 +19,24 @@ targetEntityType: media
 bundle: video
 mode: browse
 content:
-  thumbnail:
+  field_media_video_file:
+    type: file_video
+    label: hidden
+    settings:
+      controls: true
+      autoplay: false
+      loop: false
+      multiple_file_display_type: tags
+      muted: false
+      width: 640
+      height: 480
+      playsinline: false
+    third_party_settings:
+      blazy:
+        blazy: false
+    weight: 1
+    region: content
+  field_thumbnail:
     type: image
     label: hidden
     settings:
@@ -34,11 +53,10 @@ hidden:
   field_cultural_protocols: true
   field_identifier: true
   field_media_tags: true
-  field_media_video_file: true
   field_people: true
-  field_thumbnail: true
   flag_export_media: true
   langcode: true
   name: true
   search_api_excerpt: true
+  thumbnail: true
   uid: true

--- a/config/install/core.entity_view_display.media.video.browse.yml
+++ b/config/install/core.entity_view_display.media.video.browse.yml
@@ -3,10 +3,10 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.media.browse
+    - image.style.medium_480px_w_
     - media.type.video
   module:
-    - blazy
-    - file
+    - image
     - layout_builder
 third_party_settings:
   layout_builder:
@@ -17,21 +17,15 @@ targetEntityType: media
 bundle: video
 mode: browse
 content:
-  field_media_video_file:
-    type: file_video
+  thumbnail:
+    type: image
     label: hidden
     settings:
-      controls: true
-      autoplay: false
-      loop: false
-      multiple_file_display_type: tags
-      muted: false
-      width: 640
-      height: 480
-      playsinline: false
-    third_party_settings:
-      blazy:
-        blazy: false
+      image_link: ''
+      image_style: medium_480px_w_
+      image_loading:
+        attribute: lazy
+    third_party_settings: {  }
     weight: 0
     region: content
 hidden:
@@ -40,11 +34,11 @@ hidden:
   field_cultural_protocols: true
   field_identifier: true
   field_media_tags: true
+  field_media_video_file: true
   field_people: true
   field_thumbnail: true
   flag_export_media: true
   langcode: true
   name: true
   search_api_excerpt: true
-  thumbnail: true
   uid: true

--- a/config/install/core.entity_view_display.node.digital_heritage.grid_browse.yml
+++ b/config/install/core.entity_view_display.node.digital_heritage.grid_browse.yml
@@ -30,7 +30,7 @@ content:
     type: entity_reference_entity_view
     label: hidden
     settings:
-      view_mode: digital_heritage_sidebar
+      view_mode: browse
       link: false
     third_party_settings: {  }
     weight: 0

--- a/modules/mukurtu_core/mukurtu_core.install
+++ b/modules/mukurtu_core/mukurtu_core.install
@@ -2034,8 +2034,9 @@ function mukurtu_core_update_40072(): void {
 }
 
 /**
- * Render video, remote_video, and soundcloud media as thumbnails (not full
- * players/embeds) in the "browse" view mode used by List/Grid/Map cards.
+ * Show a manually-provided thumbnail image for video, remote_video, and
+ * soundcloud media in the "browse" view mode used by List/Grid/Map cards,
+ * falling back to the native player/embed when no thumbnail is set.
  */
 function mukurtu_core_update_40073(): void {
   $config_source = new \Drupal\Core\Config\FileStorage(

--- a/modules/mukurtu_core/mukurtu_core.install
+++ b/modules/mukurtu_core/mukurtu_core.install
@@ -2058,8 +2058,9 @@ function mukurtu_core_update_40073(): void {
  * unrelated digital_heritage_sidebar mode.
  */
 function mukurtu_core_update_40074(): void {
-  \Drupal::configFactory()
-    ->getEditable('core.entity_view_display.node.digital_heritage.grid_browse')
-    ->set('content.field_representative_media.settings.view_mode', 'browse')
-    ->save();
+  $config = \Drupal::configFactory()->getEditable('core.entity_view_display.node.digital_heritage.grid_browse');
+  if ($config->isNew()) {
+    return;
+  }
+  $config->set('content.field_representative_media.settings.view_mode', 'browse')->save();
 }

--- a/modules/mukurtu_core/mukurtu_core.install
+++ b/modules/mukurtu_core/mukurtu_core.install
@@ -2032,3 +2032,34 @@ function mukurtu_core_update_40072(): void {
     }
   }
 }
+
+/**
+ * Render video, remote_video, and soundcloud media as thumbnails (not full
+ * players/embeds) in the "browse" view mode used by List/Grid/Map cards.
+ */
+function mukurtu_core_update_40073(): void {
+  $config_source = new \Drupal\Core\Config\FileStorage(
+    \Drupal::service('extension.list.profile')->getPath('mukurtu') . '/config/install'
+  );
+  $config_factory = \Drupal::configFactory();
+
+  foreach (['media.video.browse', 'media.remote_video.browse', 'media.soundcloud.browse'] as $name) {
+    $config_name = 'core.entity_view_display.' . $name;
+    $data = $config_source->read($config_name);
+    if ($data) {
+      $config_factory->getEditable($config_name)->setData($data)->save(TRUE);
+    }
+  }
+}
+
+/**
+ * Use the same "browse" media view mode for digital_heritage's Grid Browse
+ * representative media as every other content type, instead of the
+ * unrelated digital_heritage_sidebar mode.
+ */
+function mukurtu_core_update_40074(): void {
+  \Drupal::configFactory()
+    ->getEditable('core.entity_view_display.node.digital_heritage.grid_browse')
+    ->set('content.field_representative_media.settings.view_mode', 'browse')
+    ->save();
+}

--- a/themes/mukurtu_v4/components/02-molecules/horizontal-card/_horizontal-card.scss
+++ b/themes/mukurtu_v4/components/02-molecules/horizontal-card/_horizontal-card.scss
@@ -30,6 +30,16 @@
         block-size: auto;
       }
     }
+
+    .media--remote_video iframe,
+    .media--soundcloud iframe {
+      block-size: auto;
+      aspect-ratio: 16 / 9;
+    }
+
+    video {
+      max-block-size: 18rem;
+    }
   }
 
   &__content {

--- a/themes/mukurtu_v4/components/02-molecules/horizontal-card/_horizontal-card.scss
+++ b/themes/mukurtu_v4/components/02-molecules/horizontal-card/_horizontal-card.scss
@@ -30,15 +30,6 @@
         block-size: auto;
       }
     }
-
-    .media--remote_video iframe {
-      block-size: auto;
-      aspect-ratio: 16 / 9;
-    }
-
-    video {
-      max-block-size: 18rem;
-    }
   }
 
   &__content {

--- a/themes/mukurtu_v4/components/02-molecules/vertical-card/_vertical-card.scss
+++ b/themes/mukurtu_v4/components/02-molecules/vertical-card/_vertical-card.scss
@@ -16,19 +16,6 @@
     }
   }
 
-  &__media {
-    .media--remote_video {
-      width: 100%;
-      aspect-ratio: 16 / 9;
-      overflow: hidden;
-
-      iframe {
-        width: 100%;
-        height: 100%;
-      }
-    }
-  }
-
   &--no-border {
     padding-block-end: 0;
     margin-block-end: 0;

--- a/themes/mukurtu_v4/components/02-molecules/vertical-card/_vertical-card.scss
+++ b/themes/mukurtu_v4/components/02-molecules/vertical-card/_vertical-card.scss
@@ -16,6 +16,24 @@
     }
   }
 
+  &__media {
+    .media--remote_video,
+    .media--soundcloud {
+      width: 100%;
+      aspect-ratio: 16 / 9;
+      overflow: hidden;
+
+      iframe {
+        width: 100%;
+        height: 100%;
+      }
+    }
+
+    video {
+      max-block-size: 18rem;
+    }
+  }
+
   &--no-border {
     padding-block-end: 0;
     margin-block-end: 0;

--- a/themes/mukurtu_v4/css/style.css
+++ b/themes/mukurtu_v4/css/style.css
@@ -1449,6 +1449,14 @@ label.form-required::after {
     block-size: auto;
   }
 }
+.horizontal-card__media .media--remote_video iframe,
+.horizontal-card__media .media--soundcloud iframe {
+  block-size: auto;
+  aspect-ratio: 16/9;
+}
+.horizontal-card__media video {
+  max-block-size: 18rem;
+}
 .horizontal-card__content {
   grid-column: 1/span 1;
 }
@@ -3936,6 +3944,20 @@ body.is-fixed {
 .vertical-card__content-header h2 {
   font-size: var(--card-font-size);
   font-weight: var(--text-bold);
+}
+.vertical-card__media .media--remote_video,
+.vertical-card__media .media--soundcloud {
+  width: 100%;
+  aspect-ratio: 16/9;
+  overflow: hidden;
+}
+.vertical-card__media .media--remote_video iframe,
+.vertical-card__media .media--soundcloud iframe {
+  width: 100%;
+  height: 100%;
+}
+.vertical-card__media video {
+  max-block-size: 18rem;
 }
 .vertical-card--no-border {
   -webkit-padding-after: 0;

--- a/themes/mukurtu_v4/css/style.css
+++ b/themes/mukurtu_v4/css/style.css
@@ -1449,13 +1449,6 @@ label.form-required::after {
     block-size: auto;
   }
 }
-.horizontal-card__media .media--remote_video iframe {
-  block-size: auto;
-  aspect-ratio: 16/9;
-}
-.horizontal-card__media video {
-  max-block-size: 18rem;
-}
 .horizontal-card__content {
   grid-column: 1/span 1;
 }
@@ -3943,15 +3936,6 @@ body.is-fixed {
 .vertical-card__content-header h2 {
   font-size: var(--card-font-size);
   font-weight: var(--text-bold);
-}
-.vertical-card__media .media--remote_video {
-  width: 100%;
-  aspect-ratio: 16/9;
-  overflow: hidden;
-}
-.vertical-card__media .media--remote_video iframe {
-  width: 100%;
-  height: 100%;
 }
 .vertical-card--no-border {
   -webkit-padding-after: 0;

--- a/themes/mukurtu_v4/templates/content/_card-media.html.twig
+++ b/themes/mukurtu_v4/templates/content/_card-media.html.twig
@@ -4,8 +4,11 @@
  * Shared card media wrapper for List/Grid/Map cards.
  *
  * Wraps the representative media thumbnail in a link to the node so the
- * whole card is clickable. Audio is excluded because its native player
- * controls need to stay clickable/interactive rather than navigate away.
+ * whole card is clickable. Only bundles that always render a static image
+ * are wrapped. Audio, video, remote_video, and soundcloud are excluded
+ * because they can render a native, interactive player/embed (whenever no
+ * manual thumbnail override is set), whose controls need to stay
+ * clickable rather than navigate away.
  *
  * Expected variables:
  * - media_bundle: machine name of the representative media's bundle.
@@ -13,7 +16,7 @@
  * - url: node URL to link to.
  */
 #}
-{% if media_bundle and media_bundle is not same as 'audio' %}
+{% if media_bundle in ['image', 'document', 'external_embed'] %}
 <a href="{{ url }}" aria-hidden="true" tabindex="-1">
   {{ media }}
 </a>

--- a/themes/mukurtu_v4/templates/content/_card-media.html.twig
+++ b/themes/mukurtu_v4/templates/content/_card-media.html.twig
@@ -1,0 +1,22 @@
+{#
+/**
+ * @file
+ * Shared card media wrapper for List/Grid/Map cards.
+ *
+ * Wraps the representative media thumbnail in a link to the node so the
+ * whole card is clickable. Audio is excluded because its native player
+ * controls need to stay clickable/interactive rather than navigate away.
+ *
+ * Expected variables:
+ * - media_bundle: machine name of the representative media's bundle.
+ * - media: pre-rendered representative media field content.
+ * - url: node URL to link to.
+ */
+#}
+{% if media_bundle and media_bundle is not same as 'audio' %}
+<a href="{{ url }}" aria-hidden="true" tabindex="-1">
+  {{ media }}
+</a>
+{% else %}
+{{ media }}
+{% endif %}

--- a/themes/mukurtu_v4/templates/content/node--collection--browse.html.twig
+++ b/themes/mukurtu_v4/templates/content/node--collection--browse.html.twig
@@ -73,13 +73,11 @@
 
 <article{{ attributes.addClass("horizontal-card") }}>
   <div class="horizontal-card__media">
-    {% if media_bundle is same as 'image' %}
-    <a href="{{ url }}" aria-hidden="true" tabindex="-1">
-    {% endif %}
-      {{ content.field_collection_image }}
-    {% if media_bundle is same as 'image' %}
-    </a>
-    {% endif %}
+    {% include '@mukurtu_v4/content/_card-media.html.twig' with {
+      media_bundle: media_bundle,
+      media: content.field_collection_image,
+      url: url,
+    } %}
   </div>
 
   <div{{ content_attributes }} class="horizontal-card__content">

--- a/themes/mukurtu_v4/templates/content/node--dictionary-word--browse.html.twig
+++ b/themes/mukurtu_v4/templates/content/node--dictionary-word--browse.html.twig
@@ -76,13 +76,11 @@
 <article{{ attributes.addClass("horizontal-card") }}>
   <div class="horizontal-card__media">
     {% if has_rep_media %}
-      {% if media_bundle is same as 'image' %}
-      <a href="{{ url }}" aria-hidden="true" tabindex="-1">
-      {% endif %}
-        {{ content.field_representative_media }}
-      {% if media_bundle is same as 'image' %}
-      </a>
-      {% endif %}
+      {% include '@mukurtu_v4/content/_card-media.html.twig' with {
+        media_bundle: media_bundle,
+        media: content.field_representative_media,
+        url: url,
+      } %}
     {% elseif node.field_recording.0.entity is not empty %}
       {{ content.field_recording }}
     {% endif %}

--- a/themes/mukurtu_v4/templates/content/node--dictionary-word--grid-browse.html.twig
+++ b/themes/mukurtu_v4/templates/content/node--dictionary-word--grid-browse.html.twig
@@ -11,13 +11,11 @@
 <article{{ attributes.addClass("vertical-card") }}>
   <div class="vertical-card__media">
     {% if has_rep_media %}
-      {% if media_bundle is same as 'image' %}
-      <a href="{{ url }}" aria-hidden="true" tabindex="-1">
-      {% endif %}
-        {{ content.field_representative_media }}
-      {% if media_bundle is same as 'image' %}
-      </a>
-      {% endif %}
+      {% include '@mukurtu_v4/content/_card-media.html.twig' with {
+        media_bundle: media_bundle,
+        media: content.field_representative_media,
+        url: url,
+      } %}
     {% elseif node.field_recording.0.entity is not empty %}
       {{ content.field_recording }}
     {% endif %}

--- a/themes/mukurtu_v4/templates/content/node--digital-heritage--browse.html.twig
+++ b/themes/mukurtu_v4/templates/content/node--digital-heritage--browse.html.twig
@@ -74,13 +74,11 @@
 <article{{ attributes.addClass("horizontal-card") }}>
   {% if media_bundle or content.field_representative_media %}
     <div class="horizontal-card__media">
-      {% if media_bundle is same as 'image' %}
-      <a href="{{ url }}" aria-hidden="true" tabindex="-1">
-      {% endif %}
-        {{ content.field_representative_media }}
-      {% if media_bundle is same as 'image' %}
-      </a>
-      {% endif %}
+      {% include '@mukurtu_v4/content/_card-media.html.twig' with {
+        media_bundle: media_bundle,
+        media: content.field_representative_media,
+        url: url,
+      } %}
     </div>
   {% endif %}
 

--- a/themes/mukurtu_v4/templates/content/node--grid-browse.html.twig
+++ b/themes/mukurtu_v4/templates/content/node--grid-browse.html.twig
@@ -73,15 +73,11 @@
 
 <article{{ attributes.addClass("vertical-card") }}>
   <div class="vertical-card__media">
-    {% if media_bundle is same as 'image' %}
-    <a href="{{ url }}" aria-hidden="true" tabindex="-1">
-    {% endif %}
-
-    {{ content.field_representative_media }}
-
-    {% if media_bundle is same as 'image' %}
-    </a>
-    {% endif %}
+    {% include '@mukurtu_v4/content/_card-media.html.twig' with {
+      media_bundle: media_bundle,
+      media: content.field_representative_media,
+      url: url,
+    } %}
   </div>
 
   <div{{ content_attributes }} class="vertical-card__content">

--- a/themes/mukurtu_v4/templates/content/node--map-browse.html.twig
+++ b/themes/mukurtu_v4/templates/content/node--map-browse.html.twig
@@ -74,13 +74,11 @@
 <article{{ attributes.addClass(["vertical-card", "vertical-card--no-border", "vertical-card--large-font"]) }}>
   {% if media_bundle %}
     <div class="vertical-card__media">
-      {% if media_bundle is same as 'image' %}
-      <a href="{{ url }}" aria-hidden="true" tabindex="-1">
-      {% endif %}
-        {{ content.field_representative_media }}
-      {% if media_bundle is same as 'image' %}
-      </a>
-      {% endif %}
+      {% include '@mukurtu_v4/content/_card-media.html.twig' with {
+        media_bundle: media_bundle,
+        media: content.field_representative_media,
+        url: url,
+      } %}
     </div>
   {% endif %}
 

--- a/themes/mukurtu_v4/templates/content/node--person--browse.html.twig
+++ b/themes/mukurtu_v4/templates/content/node--person--browse.html.twig
@@ -73,13 +73,11 @@
 
 <article{{ attributes.addClass("horizontal-card") }}>
   <div class="horizontal-card__media">
-    {% if media_bundle is same as 'image' %}
-    <a href="{{ url }}" aria-hidden="true" tabindex="-1">
-    {% endif %}
-      {{ content.field_representative_media }}
-    {% if media_bundle is same as 'image' %}
-    </a>
-    {% endif %}
+    {% include '@mukurtu_v4/content/_card-media.html.twig' with {
+      media_bundle: media_bundle,
+      media: content.field_representative_media,
+      url: url,
+    } %}
   </div>
 
   <div{{ content_attributes }} class="horizontal-card__content">

--- a/themes/mukurtu_v4/templates/content/node--place--browse.html.twig
+++ b/themes/mukurtu_v4/templates/content/node--place--browse.html.twig
@@ -73,13 +73,11 @@
 
 <article{{ attributes.addClass("horizontal-card") }}>
   <div class="horizontal-card__media">
-    {% if media_bundle is same as 'image' %}
-    <a href="{{ url }}" aria-hidden="true" tabindex="-1">
-    {% endif %}
-      {{ content.field_representative_media }}
-    {% if media_bundle is same as 'image' %}
-    </a>
-    {% endif %}
+    {% include '@mukurtu_v4/content/_card-media.html.twig' with {
+      media_bundle: media_bundle,
+      media: content.field_representative_media,
+      url: url,
+    } %}
   </div>
 
   <div{{ content_attributes }} class="horizontal-card__content">

--- a/themes/mukurtu_v4/templates/content/node--word-list--browse.html.twig
+++ b/themes/mukurtu_v4/templates/content/node--word-list--browse.html.twig
@@ -75,13 +75,11 @@
 <article{{ attributes.addClass("horizontal-card") }}>
   <div class="horizontal-card__media">
     {% if has_rep_media %}
-      {% if media_bundle is same as 'image' %}
-      <a href="{{ url }}" aria-hidden="true" tabindex="-1">
-      {% endif %}
-        {{ content.field_representative_media }}
-      {% if media_bundle is same as 'image' %}
-      </a>
-      {% endif %}
+      {% include '@mukurtu_v4/content/_card-media.html.twig' with {
+        media_bundle: media_bundle,
+        media: content.field_representative_media,
+        url: url,
+      } %}
     {% elseif node.field_word_list_image.0.entity is not empty %}
       <a href="{{ url }}" aria-hidden="true" tabindex="-1">
         {{ content.field_word_list_image }}

--- a/themes/mukurtu_v4/templates/content/node--word-list--grid-browse.html.twig
+++ b/themes/mukurtu_v4/templates/content/node--word-list--grid-browse.html.twig
@@ -11,13 +11,11 @@
 <article{{ attributes.addClass("vertical-card") }}>
   <div class="vertical-card__media">
     {% if has_rep_media %}
-      {% if media_bundle is same as 'image' %}
-      <a href="{{ url }}" aria-hidden="true" tabindex="-1">
-      {% endif %}
-        {{ content.field_representative_media }}
-      {% if media_bundle is same as 'image' %}
-      </a>
-      {% endif %}
+      {% include '@mukurtu_v4/content/_card-media.html.twig' with {
+        media_bundle: media_bundle,
+        media: content.field_representative_media,
+        url: url,
+      } %}
     {% elseif node.field_word_list_image.0.entity is not empty %}
       <a href="{{ url }}" aria-hidden="true" tabindex="-1">
         {{ content.field_word_list_image }}

--- a/themes/mukurtu_v4/templates/content/node--word-list--map-browse.html.twig
+++ b/themes/mukurtu_v4/templates/content/node--word-list--map-browse.html.twig
@@ -3,13 +3,11 @@
 <article{{ attributes.addClass(["vertical-card", "vertical-card--no-border", "vertical-card--large-font"]) }}>
   {% if media_bundle %}
     <div class="vertical-card__media">
-      {% if media_bundle is same as 'image' %}
-      <a href="{{ url }}" aria-hidden="true" tabindex="-1">
-      {% endif %}
-        {{ content.field_representative_media }}
-      {% if media_bundle is same as 'image' %}
-      </a>
-      {% endif %}
+      {% include '@mukurtu_v4/content/_card-media.html.twig' with {
+        media_bundle: media_bundle,
+        media: content.field_representative_media,
+        url: url,
+      } %}
     </div>
   {% endif %}
 

--- a/themes/mukurtu_v4/templates/media/media--remote-video--browse.html.twig
+++ b/themes/mukurtu_v4/templates/media/media--remote-video--browse.html.twig
@@ -1,0 +1,23 @@
+{#
+/**
+ * @file
+ * Theme override for remote video media in the browse view mode.
+ * Shows the manually-provided thumbnail image if the editor set one;
+ * otherwise falls back to the native oEmbed player.
+ */
+#}
+{%
+  set classes = [
+    'media',
+    'media--' ~ bundle
+  ]
+%}
+
+<div{{ attributes.addClass(classes) }}>
+  {{ content.media_content_warnings }}
+  {% if media.field_thumbnail.isEmpty() %}
+    {{ content.field_media_oembed_video }}
+  {% else %}
+    {{ content.field_thumbnail }}
+  {% endif %}
+</div>

--- a/themes/mukurtu_v4/templates/media/media--soundcloud--browse.html.twig
+++ b/themes/mukurtu_v4/templates/media/media--soundcloud--browse.html.twig
@@ -1,0 +1,23 @@
+{#
+/**
+ * @file
+ * Theme override for soundcloud media in the browse view mode.
+ * Shows the manually-provided thumbnail image if the editor set one;
+ * otherwise falls back to the native SoundCloud embed.
+ */
+#}
+{%
+  set classes = [
+    'media',
+    'media--' ~ bundle
+  ]
+%}
+
+<div{{ attributes.addClass(classes) }}>
+  {{ content.media_content_warnings }}
+  {% if media.field_thumbnail.isEmpty() %}
+    {{ content.field_media_soundcloud }}
+  {% else %}
+    {{ content.field_thumbnail }}
+  {% endif %}
+</div>

--- a/themes/mukurtu_v4/templates/media/media--video--browse.html.twig
+++ b/themes/mukurtu_v4/templates/media/media--video--browse.html.twig
@@ -1,0 +1,23 @@
+{#
+/**
+ * @file
+ * Theme override for video media in the browse view mode.
+ * Shows the manually-provided thumbnail image if the editor set one;
+ * otherwise falls back to the native video player.
+ */
+#}
+{%
+  set classes = [
+    'media',
+    'media--' ~ bundle
+  ]
+%}
+
+<div{{ attributes.addClass(classes) }}>
+  {{ content.media_content_warnings }}
+  {% if media.field_thumbnail.isEmpty() %}
+    {{ content.field_media_video_file }}
+  {% else %}
+    {{ content.field_thumbnail }}
+  {% endif %}
+</div>


### PR DESCRIPTION
## Summary

Phase 1 of a multi-phase effort tracked in #1624 (unify content theming across content types, places, and modes). This PR targets media-type consistency in List/Grid/Map cards.

### This addresses ONLY:

- `/browse` and `/digital-heritage` pages.
- List, Grid, and Map views. 
- Tested with digital heritage items.
   - Other content types coming in phase 2.
- Only focused on getting media working.
   - The rest of the preview content and appearance is in phase 2.

## Details 

- `video`, `remote_video`, and `soundcloud` media now render their native player/embed by default in these card views, matching what editors expect to see. If an editor has manually uploaded an image via the existing `field_thumbnail` field on that media item, the card shows that thumbnail instead. A new conditional Twig template per bundle (`media--video--browse.html.twig`, `media--remote-video--browse.html.twig`, `media--soundcloud--browse.html.twig`) makes this choice based on `media.field_thumbnail.isEmpty()`.
  - An earlier version of this PR forced these three bundles to always show a thumbnail. That broke `soundcloud` entirely (no thumbnail is ever auto-generated for it, so cards showed nothing) and was the wrong default regardless — fixed based on testing feedback.
- Fixes `digital_heritage`'s Grid mode, which was using a different media view mode (`digital_heritage_sidebar`) than every other content type's Grid mode (`browse`) for its representative media — a real inconsistency bug found during investigation, now aligned with the rest. Confirmed matching between `/browse` and `/digital-heritage` Grid views.
- De-duplicates the repeated `aria-hidden`/`tabindex="-1"` thumbnail-link wrapper markup that was copy-pasted across 11 node card Twig templates into one shared include (`themes/mukurtu_v4/templates/content/_card-media.html.twig`). That include now only wraps bundles that are always static (`image`, `document`, `external_embed`) — `video`/`remote_video`/`soundcloud` are excluded because they can render a live interactive player, and wrapping interactive content in a full-card link would break its controls.
- Adds update hooks `mukurtu_core_update_40073`/`40074` to push the config changes to existing sites.

## Test plan

- [x] Visually confirmed video, remote_video, and soundcloud render correctly (native player by default) in List and Grid views on `/browse` and `/digital-heritage`.
- [x] Visually confirmed the same in Map view.
- [x] Confirmed `/digital-heritage` Grid mode now matches `/browse` Grid mode's representative-media rendering for the same content.
- [x] Confirmed accessibility/alt text look correct via manual testing.
- [x] Ran the WCAG accessibility skill against the final templates/include — no blocking issues. One non-blocking finding: when an editor manually sets `field_thumbnail` on a video/remote_video/soundcloud item, the resulting thumbnail renders like every other static-image card but isn't wrapped in the clickable overlay link (`_card-media.html.twig` decides the wrap based on bundle alone, one template above where the `isEmpty()` check happens, so it can't see that this particular instance is actually static). Narrow-impact — only affects manually-overridden thumbnails on these three bundles — tracked as a fast-follow rather than blocking this PR.
- [x] Ran a PR self-review pass on both the original and corrected commits — YAML configs and Twig templates checked for internal consistency; no blocking issues found.
- [ ] Spot-check alt text on the underlying thumbnail source images (pre-existing/out of scope for this diff).

## Pre-merge checklist:

- [x] I have checked for and if required, created update hooks.
- [x] I have run an accessibility check, and resolved any blocking issues (one non-blocking finding noted above, tracked as a fast-follow).
- [x] I have recompiled SCSS if required.
- [ ] I have updated or created CI/CD tests, if required.
- [x] I have updated from `main` and resolved any merge conflicts.
- [x] I have verified that all expected checks pass.
- [x] I have run the pr-expert-review skill and resolved all relevant issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)