### PR TITLE
Fix scaffolded index.php/update.php failing to find autoload_runtime.php

### DIFF
--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -97,6 +97,15 @@ services:
             // the transitive-dependency resolver does not drop it.
             \$d['require']['doctrine/annotations'] = '^2.0';
             \$d['require']['composer/installers'] = '^2.0';
+            // Allow the mukurtu/mukurtu profile (a dependency here, not the
+            // root package) to apply its own scaffold file-mapping override
+            // for web/index.php and web/update.php. Without this, Composer's
+            // scaffold plugin silently ignores that package's file-mapping,
+            // and drupal/core's own scaffolded index.php ships a bare
+            // require_once('autoload_runtime.php') that fails to resolve
+            // once PHP's working directory is the docroot rather than the
+            // directory containing vendor/autoload_runtime.php.
+            \$d['extra']['drupal-scaffold']['allowed-packages'][] = 'mukurtu/mukurtu';
             file_put_contents('composer.json',
               json_encode(\$d, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . PHP_EOL);
           "

--- a/composer.json
+++ b/composer.json
@@ -109,6 +109,10 @@
         "drupal-scaffold": {
             "locations": {
                 "web-root": "web/"
+            },
+            "file-mapping": {
+                "[web-root]/index.php": "scaffold/index.php",
+                "[web-root]/update.php": "scaffold/update.php"
             }
         },
         "installer-paths": {

--- a/scaffold/index.php
+++ b/scaffold/index.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * @file
+ * The PHP page that serves all page requests on a Drupal installation.
+ *
+ * All Drupal code is released under the GNU General Public License.
+ * See COPYRIGHT.txt and LICENSE.txt files in the "core" directory.
+ *
+ * This is a local override of drupal/core's scaffolded index.php. Core's
+ * version requires 'autoload_runtime.php' with no path prefix, which only
+ * resolves if PHP's current working directory happens to match the
+ * directory containing vendor/autoload_runtime.php. Real web server
+ * requests set the working directory to the docroot (this file's own
+ * directory), one level below vendor/, so the bare require fails with
+ * "Failed opening required 'autoload_runtime.php'". Using an explicit
+ * path makes this independent of the working directory.
+ */
+
+use Drupal\Core\DrupalKernel;
+
+require_once __DIR__ . '/../vendor/autoload_runtime.php';
+
+return static function () {
+  return new DrupalKernel('prod', require __DIR__ . '/autoload.php');
+};

--- a/scaffold/update.php
+++ b/scaffold/update.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * @file
+ * The PHP page that handles updating the Drupal installation.
+ *
+ * All Drupal code is released under the GNU General Public License.
+ * See COPYRIGHT.txt and LICENSE.txt files in the "core" directory.
+ *
+ * This is a local override of drupal/core's scaffolded update.php. See
+ * scaffold/index.php for why the bare 'autoload_runtime.php' require is
+ * replaced with an explicit path.
+ */
+
+use Drupal\Core\Update\UpdateKernel;
+
+require_once __DIR__ . '/../vendor/autoload_runtime.php';
+
+// Disable garbage collection during test runs. Under certain circumstances the
+// update path will create so many objects that garbage collection causes
+// segmentation faults.
+if (drupal_valid_test_ua()) {
+  gc_collect_cycles();
+  gc_disable();
+}
+
+return static function () {
+  return new UpdateKernel('prod', require __DIR__ . '/autoload.php', FALSE);
+};


### PR DESCRIPTION
## Summary

Fixes a build-blocking bug affecting **every** Tugboat preview (confirmed on `main` as well as PR previews) — unrelated to any recent theming work, this is a gap in how Drupal core's own scaffolded entry points interact with this project's composer layout.

- `web/index.php` and `web/update.php`, as scaffolded by `drupal/core` 11.4.x, do a bare `require_once('autoload_runtime.php')` with no path prefix. This only resolves if PHP's working directory happens to match the directory containing `vendor/autoload_runtime.php`. Real web server requests set the working directory to the docroot (`web/`), one level *below* `vendor/`, so the require fails with `Failed opening required 'autoload_runtime.php'`. I reproduced this exact error locally with a minimal PHP web server using the same directory layout (docroot as a subdirectory, vendor as a sibling) to confirm the mechanism.
- Added `scaffold/index.php` and `scaffold/update.php` — copies of the upstream files with the one meaningful change: an explicit `__DIR__ . '/../vendor/autoload_runtime.php'` path instead of the bare one. Wired in via `composer.json`'s `extra.drupal-scaffold.file-mapping`, the standard/supported mechanism for overriding a scaffolded file.
- Since this profile (`mukurtu/mukurtu`) is a *dependency* of the separate `mukurtu-template` root project in the real Tugboat/production build (not the root package), Composer's scaffold plugin will silently ignore its file-mapping unless the root project's composer.json explicitly lists it in `allowed-packages` (confirmed by reading `drupal/core-composer-scaffold`'s own `AllowedPackages.php` source, and by checking `mukurtu-template`'s current composer.json, which doesn't list it). `.tugboat/config.yml` already patches the root composer.json programmatically at build time for other reasons (pinning `drupal/core` etc.), so I added one more line there to also add `mukurtu/mukurtu` to `allowed-packages`.

## Follow-up needed in a separate repo

`mukurtu-template` itself likely needs the same `allowed-packages` addition for any deployment that doesn't go through `.tugboat/config.yml`'s patch step (e.g. production/other hosting). I don't have access to that repo from here — recommend opening a matching fix there.

## Test plan

- [x] Validated `composer.json` JSON syntax and ran `composer validate`.
- [x] Validated `.tugboat/config.yml` YAML syntax.
- [x] Ran `composer drupal:scaffold` locally against this repo and confirmed the override takes effect: `Skip [web-root]/index.php: overridden in mukurtu/mukurtu` / `Copy [web-root]/index.php from scaffold/index.php`, and confirmed the resulting `web/index.php`/`web/update.php` content matches the fixed version.
- [x] Simulated the `.tugboat/config.yml` PHP patch script against a real copy of `mukurtu-template`'s composer.json and confirmed it correctly adds `mukurtu/mukurtu` to `allowed-packages` without disturbing existing config.
- [x] Reproduced the underlying bug mechanism in isolation: a minimal PHP built-in web server with a docroot subdirectory and a target file one level up, matching the exact error text/format from the live Tugboat error.
- [ ] Trigger a Tugboat rebuild on this PR and confirm the preview loads without the `autoload_runtime.php` error.

## Pre-merge checklist:

- [x] I have checked for and if required, created update hooks. (N/A — build/infra config only, no Drupal config or schema changes.)
- [x] I have run an accessibility check, and resolved any issues. (N/A — no markup/UI changes.)
- [x] I have recompiled SCSS if required. (N/A — no SCSS changes.)
- [ ] I have updated or created CI/CD tests, if required.
- [x] I have updated from `main` and resolved any merge conflicts.
- [ ] I have verified that all expected checks pass.
- [ ] I have run the pr-expert-review skill and resolved all relevant issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)