### PR TITLE
Guard against Layout Builder breaking content type full views (#1807)

### DIFF
--- a/modules/mukurtu_core/src/Hook/FormHooks.php
+++ b/modules/mukurtu_core/src/Hook/FormHooks.php
@@ -1362,4 +1362,46 @@ class FormHooks
             }
         }
     }
+
+    /**
+     * Implements hook_form_FORM_ID_alter() for 'entity_view_display_edit_form'.
+     *
+     * Disables the "Use Layout Builder" option on Manage Display for content
+     * types whose custom full-view templates directly reference fields by
+     * name and are not yet compatible with Layout Builder's section-based
+     * rendering (see issue #1807).
+     */
+    #[Hook("form_entity_view_display_edit_form_alter")]
+    public function formEntityViewDisplayEditFormAlter(
+        array &$form,
+        FormStateInterface $form_state,
+    ): void {
+        if (!isset($form["layout"]["enabled"])) {
+            return;
+        }
+
+        $display = $form_state->getFormObject()->getEntity();
+        if ($display->getTargetEntityTypeId() !== "node") {
+            return;
+        }
+
+        $unsupportedBundles = [
+            "article",
+            "page",
+            "dictionary_word",
+            "word_list",
+            "collection",
+            "digital_heritage",
+            "person",
+            "place",
+        ];
+        if (!in_array($display->getTargetBundle(), $unsupportedBundles, TRUE)) {
+            return;
+        }
+
+        $form["layout"]["enabled"]["#disabled"] = TRUE;
+        $form["layout"]["enabled"]["#description"] = t(
+            "Layout Builder is not yet supported for this content type.",
+        );
+    }
 }

--- a/modules/mukurtu_core/tests/src/Kernel/FormHooksLayoutBuilderGuardTest.php
+++ b/modules/mukurtu_core/tests/src/Kernel/FormHooksLayoutBuilderGuardTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\mukurtu_core\Kernel;
+
+use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
+use Drupal\Core\Entity\EntityFormInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\mukurtu_core\Hook\FormHooks;
+
+/**
+ * Tests the Layout Builder guard rail on Manage Display forms.
+ *
+ * @see \Drupal\mukurtu_core\Hook\FormHooks::formEntityViewDisplayEditFormAlter()
+ * @group mukurtu_core
+ */
+class FormHooksLayoutBuilderGuardTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'text',
+    'filter',
+    'node',
+    'mukurtu_core',
+  ];
+
+  /**
+   * Tests that the checkbox is disabled only for unsupported node bundles.
+   *
+   * @dataProvider bundleProvider
+   */
+  public function testLayoutBuilderCheckboxGuard(string $entityTypeId, string $bundle, bool $expectDisabled): void {
+    $display = $this->createMock(EntityViewDisplayInterface::class);
+    $display->method('getTargetEntityTypeId')->willReturn($entityTypeId);
+    $display->method('getTargetBundle')->willReturn($bundle);
+
+    $formObject = $this->createMock(EntityFormInterface::class);
+    $formObject->method('getEntity')->willReturn($display);
+
+    $formState = $this->createMock(FormStateInterface::class);
+    $formState->method('getFormObject')->willReturn($formObject);
+
+    $form = ['layout' => ['enabled' => ['#type' => 'checkbox']]];
+
+    (new FormHooks())->formEntityViewDisplayEditFormAlter($form, $formState);
+
+    if ($expectDisabled) {
+      $this->assertTrue($form['layout']['enabled']['#disabled']);
+      $this->assertNotEmpty((string) $form['layout']['enabled']['#description']);
+    }
+    else {
+      $this->assertArrayNotHasKey('#disabled', $form['layout']['enabled']);
+    }
+  }
+
+  /**
+   * Data provider of node bundles and entity types.
+   *
+   * Covers the Layout Builder guard rail's unsupported list, plus a
+   * supported node bundle and a non-node entity type for contrast.
+   */
+  public static function bundleProvider(): array {
+    return [
+      'unsupported bundle: article' => ['node', 'article', TRUE],
+      'unsupported bundle: page' => ['node', 'page', TRUE],
+      'unsupported bundle: digital_heritage' => ['node', 'digital_heritage', TRUE],
+      'unsupported bundle: place' => ['node', 'place', TRUE],
+      'supported node bundle is left alone' => ['node', 'landing_page', FALSE],
+      'non-node entity type is left alone' => ['media', 'article', FALSE],
+    ];
+  }
+
+  /**
+   * Tests that forms without a Layout Builder element are left untouched.
+   *
+   * The display entity should never be inspected in that case.
+   */
+  public function testFormWithoutLayoutElementIsLeftAlone(): void {
+    $formState = $this->createMock(FormStateInterface::class);
+    $formState->expects($this->never())->method('getFormObject');
+
+    $form = [];
+    (new FormHooks())->formEntityViewDisplayEditFormAlter($form, $formState);
+
+    $this->assertSame([], $form);
+  }
+
+}

--- a/modules/mukurtu_protocol/src/Hook/CommunityProtocolList.php
+++ b/modules/mukurtu_protocol/src/Hook/CommunityProtocolList.php
@@ -58,7 +58,7 @@ class CommunityProtocolList implements ContainerInjectionInterface {
    * @return array
    *   Render array for the community protocol list.
    */
-  protected function buildCommunityProtocolList(CulturalProtocolControlledInterface $node): array {
+  public function buildCommunityProtocolList(CulturalProtocolControlledInterface $node): array {
     $items = [];
     $protocols = $node->getProtocolEntities();
     foreach ($protocols as $protocol) {

--- a/modules/mukurtu_protocol/src/Plugin/Block/CommunityProtocolListBlock.php
+++ b/modules/mukurtu_protocol/src/Plugin/Block/CommunityProtocolListBlock.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\mukurtu_protocol\Plugin\Block;
+
+use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Plugin\Context\ContextDefinition;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\mukurtu_protocol\CulturalProtocolControlledInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Provides the Communities and Cultural Protocols sidebar block.
+ *
+ * Lists the communities and cultural protocols applied to a node, for use in
+ * Layout Builder-managed displays. Reuses the same rendering logic as
+ * \Drupal\mukurtu_protocol\Hook\CommunityProtocolList, which injects this
+ * list directly for content types not yet using Layout Builder.
+ *
+ * @Block(
+ *   id = "mukurtu_community_protocol_list",
+ *   admin_label = @Translation("Communities and Cultural Protocols"),
+ *   category = @Translation("Mukurtu"),
+ *   context_definitions = {
+ *     "node" = @ContextDefinition("entity:node", label = @Translation("Node"))
+ *   }
+ * )
+ */
+class CommunityProtocolListBlock extends BlockBase implements ContainerFactoryPluginInterface {
+
+  use StringTranslationTrait;
+
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    protected AccountInterface $currentUser,
+  ) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): static {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('current_user'),
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build(): array {
+    $node = $this->getContextValue('node');
+    if (!$node instanceof CulturalProtocolControlledInterface) {
+      return [];
+    }
+
+    $items = [];
+    $protocols = $node->getProtocolEntities();
+    foreach ($protocols as $protocol) {
+      // Check access to the protocol and community, since some
+      // protocols/communities applied to content may not be accessible to the
+      // current user. In the case where the protocol/community is not
+      // accessible, just display the protocol/community label.
+      $protocol_access = $protocol->access('view', $this->currentUser, TRUE);
+      $protocol_display = $protocol_access->isAllowed()
+        ? $protocol->toLink()->toString()
+        : $protocol->label();
+      $communities = $protocol->getCommunities();
+      foreach ($communities as $community) {
+        $community_access = $community->access('view', $this->currentUser, TRUE);
+        $community_display = $community_access->isAllowed()
+          ? $community->toLink()->toString()
+          : $community->label();
+        $item_render_array = ['#markup' => sprintf('%s: %s', $community_display, $protocol_display)];
+        CacheableMetadata::createFromRenderArray($item_render_array)
+          ->addCacheableDependency($protocol)
+          ->addCacheableDependency($community)
+          ->addCacheContexts(['user'])
+          ->applyTo($item_render_array);
+        $items[] = $item_render_array;
+      }
+    }
+
+    return [
+      '#theme' => 'community_protocol_list',
+      '#title' => $this->t('Communities and Cultural Protocols'),
+      '#items' => $items,
+    ];
+  }
+
+}

--- a/modules/mukurtu_protocol/src/Plugin/Block/CommunityProtocolListBlock.php
+++ b/modules/mukurtu_protocol/src/Plugin/Block/CommunityProtocolListBlock.php
@@ -5,12 +5,10 @@ declare(strict_types=1);
 namespace Drupal\mukurtu_protocol\Plugin\Block;
 
 use Drupal\Core\Block\BlockBase;
-use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Plugin\Context\ContextDefinition;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
-use Drupal\Core\Session\AccountInterface;
-use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\mukurtu_protocol\CulturalProtocolControlledInterface;
+use Drupal\mukurtu_protocol\Hook\CommunityProtocolList;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -32,13 +30,11 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class CommunityProtocolListBlock extends BlockBase implements ContainerFactoryPluginInterface {
 
-  use StringTranslationTrait;
-
   public function __construct(
     array $configuration,
     $plugin_id,
     $plugin_definition,
-    protected AccountInterface $currentUser,
+    protected CommunityProtocolList $communityProtocolList,
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
   }
@@ -51,7 +47,7 @@ class CommunityProtocolListBlock extends BlockBase implements ContainerFactoryPl
       $configuration,
       $plugin_id,
       $plugin_definition,
-      $container->get('current_user'),
+      $container->get('class_resolver')->getInstanceFromDefinition(CommunityProtocolList::class),
     );
   }
 
@@ -64,38 +60,7 @@ class CommunityProtocolListBlock extends BlockBase implements ContainerFactoryPl
       return [];
     }
 
-    $items = [];
-    $protocols = $node->getProtocolEntities();
-    foreach ($protocols as $protocol) {
-      // Check access to the protocol and community, since some
-      // protocols/communities applied to content may not be accessible to the
-      // current user. In the case where the protocol/community is not
-      // accessible, just display the protocol/community label.
-      $protocol_access = $protocol->access('view', $this->currentUser, TRUE);
-      $protocol_display = $protocol_access->isAllowed()
-        ? $protocol->toLink()->toString()
-        : $protocol->label();
-      $communities = $protocol->getCommunities();
-      foreach ($communities as $community) {
-        $community_access = $community->access('view', $this->currentUser, TRUE);
-        $community_display = $community_access->isAllowed()
-          ? $community->toLink()->toString()
-          : $community->label();
-        $item_render_array = ['#markup' => sprintf('%s: %s', $community_display, $protocol_display)];
-        CacheableMetadata::createFromRenderArray($item_render_array)
-          ->addCacheableDependency($protocol)
-          ->addCacheableDependency($community)
-          ->addCacheContexts(['user'])
-          ->applyTo($item_render_array);
-        $items[] = $item_render_array;
-      }
-    }
-
-    return [
-      '#theme' => 'community_protocol_list',
-      '#title' => $this->t('Communities and Cultural Protocols'),
-      '#items' => $items,
-    ];
+    return $this->communityProtocolList->buildCommunityProtocolList($node);
   }
 
 }

--- a/modules/mukurtu_protocol/tests/src/Kernel/CommunityProtocolListBlockTest.php
+++ b/modules/mukurtu_protocol/tests/src/Kernel/CommunityProtocolListBlockTest.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace Drupal\Tests\mukurtu_protocol\Kernel;
+
+use Drupal\node\Entity\Node;
+use Drupal\mukurtu_protocol\Entity\Community;
+use Drupal\mukurtu_protocol\Entity\Protocol;
+use Drupal\mukurtu_protocol\Hook\CommunityProtocolList;
+use Drupal\user\Entity\Role;
+
+/**
+ * Tests the CommunityProtocolListBlock plugin.
+ *
+ * Verifies the block reuses
+ * \Drupal\mukurtu_protocol\Hook\CommunityProtocolList::buildCommunityProtocolList()
+ * instead of duplicating its logic.
+ *
+ * @group mukurtu_protocol
+ */
+class CommunityProtocolListBlockTest extends ProtocolAwareEntityTestBase {
+
+  /**
+   * A protocol/community pair visible to any user.
+   *
+   * @var \Drupal\mukurtu_protocol\Entity\ProtocolInterface
+   */
+  protected $openProtocol;
+
+  /**
+   * A protocol/community pair only visible to members.
+   *
+   * @var \Drupal\mukurtu_protocol\Entity\ProtocolInterface
+   */
+  protected $strictProtocol;
+
+  /**
+   * The node under test.
+   *
+   * @var \Drupal\node\Entity\Node
+   */
+  protected $entity;
+
+  /**
+   * A plain, non-privileged user.
+   *
+   * The base class's current user is UID 1, which bypasses all access
+   * checks via core's superuser access policy.
+   *
+   * @var \Drupal\Core\Session\AccountInterface
+   */
+  protected $viewer;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    // Required by the block plugin manager's block_content deriver, which
+    // queries this table when discovering block plugin definitions.
+    $this->installEntitySchema('block_content');
+
+    // Grant the authenticated role permission to view public communities,
+    // so the "open" case below can actually resolve to a link.
+    Role::load('authenticated')
+      ->grantPermission('view published community entities')
+      ->save();
+
+    $viewer = $this->createUser();
+    $viewer->save();
+    $this->viewer = $viewer;
+
+    $openCommunity = Community::create([
+      'name' => 'Open Community',
+      'status' => TRUE,
+      'field_access_mode' => 'public',
+    ]);
+    $openCommunity->save();
+    $this->openProtocol = Protocol::create([
+      'name' => 'Open Protocol',
+      'field_communities' => [$openCommunity->id()],
+      'field_access_mode' => 'open',
+    ]);
+    $this->openProtocol->save();
+
+    $strictCommunity = Community::create([
+      'name' => 'Strict Community',
+      'status' => TRUE,
+      'field_access_mode' => 'community-only',
+    ]);
+    $strictCommunity->save();
+    $this->strictProtocol = Protocol::create([
+      'name' => 'Strict Protocol',
+      'field_communities' => [$strictCommunity->id()],
+      'field_access_mode' => 'strict',
+    ]);
+    $this->strictProtocol->save();
+
+    $entity = Node::create([
+      'title' => $this->randomString(),
+      'type' => 'protocol_aware_content',
+      'status' => TRUE,
+      'uid' => $this->currentUser->id(),
+    ]);
+    $entity->setSharingSetting('any');
+    $entity->setProtocols([$this->openProtocol->id(), $this->strictProtocol->id()]);
+    $entity->save();
+    $this->entity = $entity;
+
+    $this->setCurrentUser($this->viewer);
+  }
+
+  /**
+   * The block should produce the same render array as the shared builder.
+   */
+  public function testBlockDelegatesToSharedBuilder(): void {
+    $expected = $this->container
+      ->get('class_resolver')
+      ->getInstanceFromDefinition(CommunityProtocolList::class)
+      ->buildCommunityProtocolList($this->entity);
+
+    $block = $this->container->get('plugin.manager.block')
+      ->createInstance('mukurtu_community_protocol_list', []);
+    $block->setContextValue('node', $this->entity);
+    $build = $block->build();
+
+    $this->assertEquals($expected, $build);
+  }
+
+  /**
+   * Tests that access-restricted items fall back to a plain label.
+   *
+   * Accessible (open) protocols/communities render as links; inaccessible
+   * (strict, non-member) ones fall back to their plain label.
+   */
+  public function testBlockRespectsProtocolAndCommunityAccess(): void {
+    $block = $this->container->get('plugin.manager.block')
+      ->createInstance('mukurtu_community_protocol_list', []);
+    $block->setContextValue('node', $this->entity);
+    $build = $block->build();
+
+    $this->assertCount(2, $build['#items']);
+
+    $rendered_items = array_map(
+      fn(array $item) => (string) $item['#markup'],
+      $build['#items']
+    );
+
+    $this->assertTrue(
+      (bool) array_filter($rendered_items, fn($markup) => substr_count($markup, '<a href') === 2 && str_contains($markup, 'Open Community') && str_contains($markup, 'Open Protocol')),
+      'Open community/protocol pair should both render as links.'
+    );
+    $this->assertTrue(
+      (bool) array_filter($rendered_items, fn($markup) => $markup === 'Strict Community: Strict Protocol'),
+      'Strict community/protocol pair should fall back to plain labels for a non-member.'
+    );
+  }
+
+}

--- a/themes/mukurtu_v4/templates/content/node--landing-page--full.html.twig
+++ b/themes/mukurtu_v4/templates/content/node--landing-page--full.html.twig
@@ -67,34 +67,4 @@
  *
  */
 #}
-{% if content.field_hero_full_width == 'Yes' %}
-  {% set hero_width = "full-width" %}
-{% endif %}
-
-{% set attributes = attributes
-  .addClass('landing-hero')
-  .addClass(hero_width)
-%}
-
-<article {{ attributes }} aria-labelledby="landing-hero-title">
-  {% if node.field_hero_image %}
-    <div class="landing-hero__image">
-      {{ node.field_hero_image.value }}
-    </div>
-  {% endif %}
-  {% if node.field_hero_title or node.field_hero_text %}
-    <div class="landing-hero__content-section">
-      {% if node.field_hero_title %}
-        <div class="landing-hero__title" id="landing-hero-title">
-          {{ node.field_hero_title.value }}
-        </div>
-      {% endif %}
-      {% if node.field_hero_text %}
-        <div class="landing-hero__text">
-          {{ node.field_hero_text.value|raw }}
-        </div>
-      {% endif %}
-    </div>
-  {% endif %}
-</article>
 {{ content }}


### PR DESCRIPTION
Layout Builder replaces field-keyed content with layout sections, which breaks the custom full-view templates for article, page, dictionary_word, word_list, collection, digital_heritage, person, and place (they hard-code direct field access). Disable the "Use Layout Builder" option on Manage Display for these content types until their templates are made compatible.

Also removes dead hero markup from the landing_page full template that referenced fields which don't exist, and converts the community/protocol sidebar list into a Block plugin as groundwork for a future Layout Builder rollout, without changing current rendering.

## Pre-merge checklist:

- [ ] I have checked for and if required, created update hooks.
- [ ] I have run an accessibility check, and resolved any issues.
- [ ] I have recompiled SCSS if required.
- [ ] I have updated or created CI/CD tests, if required.
- [ ] I have updated from `main` and resolved any merge conflicts.
- [ ] I have verified that all expected checks pass.
- [ ] I have run the pr-expert-review skill and resolved all relevant issues.

