### PR TITLE
Fix fatal ZipArchive crash during export packaging

### DIFF
--- a/modules/mukurtu_export/src/BatchExportExecutable.php
+++ b/modules/mukurtu_export/src/BatchExportExecutable.php
@@ -5,6 +5,7 @@ namespace Drupal\mukurtu_export;
 use ZipArchive;
 use Exception;
 use Drupal\file\Entity\File;
+use Drupal\Core\File\FileSystemInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 
 class BatchExportExecutable implements MukurtuExportExecutableInterface
@@ -82,11 +83,20 @@ class BatchExportExecutable implements MukurtuExportExecutableInterface
       $context['sandbox']['packaged'] = 0;
       $zipName = 'export-' . date('m-d-Y_hia') . '.zip';
       $context['sandbox']['download'] = "private://exports/{$context['results']['uid']}/$zipName";
+
+      // Make sure the destination directory exists before we try to
+      // resolve a real path for it below.
+      $directory = $fs->dirname($context['sandbox']['download']);
+      $fs->prepareDirectory($directory, FileSystemInterface::CREATE_DIRECTORY);
     }
 
     // Open the Zip archive.
     $zipPath = $fs->realpath($context['sandbox']['download']);
-    $zip->open($zipPath, ZipArchive::CREATE);
+    if (!$zipPath || $zip->open($zipPath, ZipArchive::CREATE) !== TRUE) {
+      \Drupal::logger('mukurtu_export')->error('Unable to open zip archive at %uri for export packaging.', ['%uri' => $context['sandbox']['download']]);
+      $context['finished'] = 1;
+      return;
+    }
 
     // Get the batch of files to zip and remove from the global list.
     $filesBatch = array_slice($context['sandbox']['deliverables'], 0, $batchSize);

--- a/modules/mukurtu_export/src/Plugin/MukurtuExporter/CSV.php
+++ b/modules/mukurtu_export/src/Plugin/MukurtuExporter/CSV.php
@@ -211,8 +211,10 @@ class CSV extends ExporterBase {
 
     }
 
-    // @todo error handling here?
-    $fs->prepareDirectory($context['results']['basepath'], FileSystemInterface::CREATE_DIRECTORY);
+    if (!$fs->prepareDirectory($context['results']['basepath'], FileSystemInterface::CREATE_DIRECTORY)) {
+      \Drupal::logger('mukurtu_export')->error('Unable to create export working directory at %uri.', ['%uri' => $context['results']['basepath']]);
+      throw new Exception('Failed to create export working directory.');
+    }
 
     $context['message'] = t('Setting up the export.');
   }
@@ -260,9 +262,13 @@ class CSV extends ExporterBase {
     $filename = sprintf("%s - %s.csv", $entityLabel, $bundleLabel);
     $filepath = "{$context['results']['basepath']}/$filename";
 
-    // @todo handle error.
     $output = fopen($filepath, 'a');
     $context['sandbox']['batch']['output_files'][$entity_type_id][$bundle] = $output;
+
+    if (!$output) {
+      \Drupal::logger('mukurtu_export')->error('Unable to open export output file at %filepath.', ['%filepath' => $filepath]);
+      return $output;
+    }
 
     // Add file as deliverable.
     $context['results']['deliverables']['metadata'][] = ['uri' => $filepath, 'entryname' => basename($filepath)];


### PR DESCRIPTION
## Summary
- `BatchExportExecutable::package()` assumed the `private://exports/{uid}` destination directory already existed and passed `realpath()`'s result straight into `ZipArchive::open()` with no validation. When that directory didn't exist yet (e.g. a user's first export, or a fresh install), `realpath()` returned `FALSE`, and PHP threw an uncaught `ValueError`, crashing the whole batch with a 500 error.
- The directory is now created up front, and the resolved zip path plus the `ZipArchive::open()` call are validated. On failure, the batch now ends cleanly with a logged error instead of a fatal error page.
- Also stopped swallowing two related silent failures in the CSV exporter (`exportSetup()`'s `prepareDirectory()` and `getOutputFile()`'s `fopen()`) so a broken/unwritable private filesystem is caught early with a clear watchdog message instead of silently producing missing files or only surfacing as the fatal crash above.

## Test plan
- [x] Reproduced the crash on a fresh site where the `exports/{uid}` directory had never been created; confirmed the fix resolves it and produces a downloadable zip.
- [x] Confirmed `php -l` passes on both modified files.
- [x] Verified no config/schema changes, so no update hook is required.
- [x] Ran the pr-review-expert skill against the diff (blast radius, security, correctness); found and fixed one bug caught during review (a PHP "pass by reference" notice from an intermediate fix) before opening this PR.
- [ ] Reviewer: run a normal export end-to-end to confirm no regression in the happy path.

Pre-merge checklist:
- [x] I have checked for and if required, created update hooks. (Not required — no schema/config changes.)
- [ ] I have run an accessibility check, and resolved any issues. (Not applicable — no UI/template changes.)
- [ ] I have recompiled SCSS if required. (Not applicable — no SCSS changes.)
- [ ] I have updated or created CI/CD tests, if required.
- [x] I have updated from `main` and resolved any merge conflicts.
- [ ] I have verified that all expected checks pass.
- [x] I have run the pr-expert-review skill and resolved all relevant issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)