### PR TITLE
Revert accidental direct push of action-version bumps to main

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -43,7 +43,7 @@ jobs:
         run: echo "COMPCACHE=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache composer dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@v4
         with:
           path: $COMPCACHE
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -59,7 +59,7 @@ jobs:
       # Usually checkout is the first action, but we set up the mukurtu-template
       # first, then put the checkout inside of it.
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
         with:
           path: web/profiles/mukurtu
 

--- a/.github/workflows/issuelabeler-general.yml
+++ b/.github/workflows/issuelabeler-general.yml
@@ -19,7 +19,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v3
 
       - name: Parse issue form
         uses: stefanbuck/github-issue-parser@v3

--- a/.github/workflows/issuelabeler-hubs.yml
+++ b/.github/workflows/issuelabeler-hubs.yml
@@ -19,7 +19,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v3
 
       - name: Parse issue form
         uses: stefanbuck/github-issue-parser@v3


### PR DESCRIPTION
## Summary
- Reverts commit 85085a351 (\"Bump actions/checkout and actions/cache to Node 24 majors\"), which was accidentally pushed directly to \`main\` rather than through a branch/PR
- Restores \`build-and-test.yml\`, \`issuelabeler-general.yml\`, and \`issuelabeler-hubs.yml\` to their prior state on \`main\`
- The same fix will be reopened properly as its own PR from a feature branch after this merges

## Test plan
- [ ] Confirm the three workflow files match their pre-85085a351 state on \`main\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)