### PR TITLE
Fix wait-for-tugboat CI gate to poll commit status and fail fast

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -52,7 +52,7 @@ jobs:
               # --paginate is required: without it this call silently only
               # sees the first 30 PR comments, so the URL is invisible on
               # any PR whose conversation has grown past that.
-              PREVIEW_URL=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" --paginate | jq -r '.[].body' | grep -Po 'https://(?!www\.)[a-zA-Z0-9.-]+\.tugboatqa.com' | tail -n 1 || true)
+              PREVIEW_URL=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" --paginate | jq -r '.[].body' | grep -Po 'https://(?!www\.|dashboard\.)[a-zA-Z0-9.-]+\.tugboatqa.com' | tail -n 1 || true)
               if [[ ! -z "$PREVIEW_URL" ]]; then
                 echo "Preview URL found: $PREVIEW_URL"
                 break

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -16,6 +16,7 @@ jobs:
     permissions:
       contents: read
       issues: read
+      statuses: read
     outputs:
       preview_url: ${{ steps.wait-for-preview.outputs.preview_url }}
     steps:
@@ -25,24 +26,48 @@ jobs:
       - name: Wait for Tugboat Preview
         id: wait-for-preview
         run: |
-          # Define the maximum wait time (20 minutes) for the preview comment.
-          MAX_WAIT=1200
+          # Poll the "Tugboat" commit status and, once it reports success,
+          # look for the PR comment containing the live preview URL (the
+          # status's target_url only points at the Tugboat dashboard, not
+          # the preview host itself). This fails fast on a real build error
+          # instead of always waiting out the full timeout. The status has
+          # been observed to flip success -> pending -> success while a
+          # rebuild is still in progress, so an early "success" reading is
+          # not trusted as final until the preview URL comment actually
+          # shows up; if it hasn't yet, we just keep polling within the
+          # same overall budget rather than failing outright.
+          MAX_WAIT=2400
           INTERVAL=30
           ELAPSED=0
           PREVIEW_URL=""
           while [ $ELAPSED -lt $MAX_WAIT ]; do
-            PREVIEW_URL=$(gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments | jq -r '.[].body' | grep -Po 'https://(?!www\.)[a-zA-Z0-9.-]+\.tugboatqa.com' | head -n 1 || true)
-            if [[ ! -z "$PREVIEW_URL" ]]; then
-              echo "Preview URL found: $PREVIEW_URL"
-              break
+            TUGBOAT_STATE=$(gh api "repos/${{ github.repository }}/commits/${{ github.event.pull_request.head.sha }}/status" --jq '[.statuses[] | select(.context=="Tugboat")][0].state // "pending"' 2>/dev/null || echo "pending")
+
+            if [[ "$TUGBOAT_STATE" == "failure" || "$TUGBOAT_STATE" == "error" ]]; then
+              echo "Tugboat build failed (status: $TUGBOAT_STATE). See the Tugboat commit status check for details."
+              exit 1
             fi
-            echo "Waiting for Tugboat preview comment..."
+
+            if [[ "$TUGBOAT_STATE" == "success" ]]; then
+              # --paginate is required: without it this call silently only
+              # sees the first 30 PR comments, so the URL is invisible on
+              # any PR whose conversation has grown past that.
+              PREVIEW_URL=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" --paginate | jq -r '.[].body' | grep -Po 'https://(?!www\.)[a-zA-Z0-9.-]+\.tugboatqa.com' | tail -n 1 || true)
+              if [[ ! -z "$PREVIEW_URL" ]]; then
+                echo "Preview URL found: $PREVIEW_URL"
+                break
+              fi
+              echo "Tugboat status is success but no preview URL comment yet, still waiting..."
+            else
+              echo "Tugboat status: $TUGBOAT_STATE, waiting..."
+            fi
+
             sleep $INTERVAL
             ELAPSED=$((ELAPSED + INTERVAL))
           done
 
           if [[ -z "$PREVIEW_URL" ]]; then
-            echo "Tugboat preview URL did not appear in time."
+            echo "Tugboat preview did not become available within the timeout."
             exit 1
           fi
 


### PR DESCRIPTION
## Summary

- `wait-for-tugboat` in `.github/workflows/playwright.yml` was gating `playwright-tests` behind a fixed 20-minute poll of PR comments for a Tugboat preview URL. Two separate bugs made this fail persistently on PR #1770 (6 consecutive failures): the comment lookup was missing `--paginate`, so it silently only ever checked the first 30 PR comments (invisible on any PR whose conversation grew past that), and the job always waited out the full 20 minutes even when Tugboat's build actually crashed within the first couple of minutes.
- Reworked the wait loop to poll the `Tugboat` commit status first: it fails immediately on a real `failure`/`error` status, and only falls back to the (now paginated) PR-comment scrape for the live preview URL once status reports `success`. Overall budget raised to 40 minutes to match observed real build times (~34 min), since the commit status's `target_url` only points at the Tugboat dashboard rather than the actual preview host, so the comment is still needed to get the real URL.
- The commit status was also observed flapping `success -> pending -> success` mid-rebuild, so an early `success` isn't treated as final by itself — if the preview URL comment isn't there yet, the loop just keeps polling within the same budget instead of failing outright.

## Test plan

- [x] YAML validated (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] Embedded bash script syntax-checked (`bash -n`)
- [ ] Open this PR and confirm the `wait-for-tugboat` job passes and `playwright-tests` actually runs (rather than being skipped)
- [ ] Confirm the fail-fast path by observing behavior on a PR where Tugboat's build errors

## Pre-merge checklist:

- [ ] I have checked for and if required, created update hooks. — N/A, CI workflow only, no PHP/Drupal code changed.
- [ ] I have run an accessibility check, and resolved any issues. — N/A, no UI/markup changed.
- [ ] I have recompiled SCSS if required. — N/A, no styles changed.
- [x] I have updated or created CI/CD tests, if required. — this PR is itself the CI/CD fix.
- [x] I have updated from `main` and resolved any merge conflicts. — branched fresh off latest `main`.
- [ ] I have verified that all expected checks pass. — pending this PR's own CI run.
- [x] I have run the pr-expert-review skill and resolved all relevant issues. — surfaced a status-flapping false-failure bug and a missing error guard in the first draft; both fixed before commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)