### PR TITLE
Fix stale referenced content cache and add place-records redirect

### DIFF
--- a/modules/mukurtu_core/mukurtu_core.module
+++ b/modules/mukurtu_core/mukurtu_core.module
@@ -25,6 +25,7 @@ use Drupal\user\UserInterface;
 use Drupal\Core\Url;
 use Drupal\Core\Link;
 use Drupal\Core\Cache\Cache;
+use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Render\Markup;
 use Drupal\Component\Render\FormattableMarkup;
 
@@ -646,6 +647,17 @@ function mukurtu_core_entity_type_alter(array &$entity_types) {
 function mukurtu_core_node_view(array &$build, EntityInterface $entity, EntityViewDisplayInterface $display, $view_mode) {
   if ($display->getComponent('field_title')) {
     $build['field_title'] = $entity->title->view();
+  }
+
+  // field_all_related_content is computed by querying all nodes system-wide
+  // for references back to this entity (see AllRelatedContentItemList). That
+  // result can change when any node elsewhere is saved, so tag the render
+  // array to invalidate on any node list change rather than relying on this
+  // entity's own cache tags, which only fire when this entity itself is saved.
+  if ($display->getComponent('field_all_related_content')) {
+    $cache = CacheableMetadata::createFromRenderArray($build);
+    $cache->addCacheTags(['node_list']);
+    $cache->applyTo($build);
   }
 }
 

--- a/modules/mukurtu_taxonomy/src/Controller/TaxonomyRecordViewController.php
+++ b/modules/mukurtu_taxonomy/src/Controller/TaxonomyRecordViewController.php
@@ -152,28 +152,34 @@ class TaxonomyRecordViewController extends ControllerBase implements ContainerIn
   /**
    * Display the taxonomy term page.
    *
-   * If the term maps to exactly one accessible person record, redirects to
-   * that record instead of rendering the taxonomy term page.
+   * If the term maps to exactly one accessible person or place record,
+   * redirects to that record instead of rendering the taxonomy term page.
    *
    * @param \Drupal\taxonomy\TermInterface $taxonomy_term
    *   The taxonomy term.
    *
    * @return array|\Drupal\Core\Routing\TrustedRedirectResponse
-   *   A redirect to the person record, or the full taxonomy term render array.
+   *   A redirect to the record, or the full taxonomy term render array.
    */
   public function build(TermInterface $taxonomy_term): array|TrustedRedirectResponse {
-    $person = $this->getSinglePersonRecord($taxonomy_term);
-    if ($person) {
-      $url = $person->toUrl()->toString();
+    $record = $this->getSingleRecord($taxonomy_term, 'person', 'field_other_names', 'person_records_enabled_vocabularies')
+      ?? $this->getSingleRecord($taxonomy_term, 'place', 'field_other_place_names', 'place_records_enabled_vocabularies');
+    if ($record) {
+      $url = $record->toUrl()->toString();
       $this->getLogger('mukurtu_taxonomy')->notice(
-        'Taxonomy term %label (tid %tid) redirected to person record nid %nid.',
-        ['%label' => $taxonomy_term->label(), '%tid' => $taxonomy_term->id(), '%nid' => $person->id()]
+        'Taxonomy term %label (tid %tid) redirected to %type record nid %nid.',
+        [
+          '%label' => $taxonomy_term->label(),
+          '%tid' => $taxonomy_term->id(),
+          '%type' => $record->bundle(),
+          '%nid' => $record->id(),
+        ]
       );
       $response = new TrustedRedirectResponse($url);
       $cache = new CacheableMetadata();
       $cache->addCacheContexts(['user.node_grants:view']);
       $cache->addCacheableDependency($taxonomy_term);
-      $cache->addCacheableDependency($person);
+      $cache->addCacheableDependency($record);
       $response->addCacheableDependency($cache);
       return $response;
     }
@@ -254,20 +260,25 @@ class TaxonomyRecordViewController extends ControllerBase implements ContainerIn
       ],
     ];
 
-    // When this term's vocabulary is person-records-enabled, this page could
-    // become a redirect if a person node is later created and linked via
-    // field_other_names. Tag the render so that creating or editing any person
-    // node invalidates this cache and re-runs the redirect check.
-    // Trade-off: node_list:person fires on every person node save, so bulk
-    // imports will invalidate all person-vocabulary term pages at once. This
-    // is acceptable for correctness; a term-scoped tag would require a custom
-    // cache tag strategy.
+    // When this term's vocabulary is person- or place-records-enabled, this
+    // page could become a redirect if a matching node is later created and
+    // linked via field_other_names / field_other_place_names. Tag the render
+    // so that creating or editing any person/place node invalidates this
+    // cache and re-runs the redirect check.
+    // Trade-off: node_list:person / node_list:place fire on every save of
+    // that bundle, so bulk imports will invalidate all term pages for that
+    // vocabulary at once. This is acceptable for correctness; a term-scoped
+    // tag would require a custom cache tag strategy.
     $person_vocabularies = $this->mukurtuTaxonomySettings->get('person_records_enabled_vocabularies') ?? [];
+    $place_vocabularies = $this->mukurtuTaxonomySettings->get('place_records_enabled_vocabularies') ?? [];
+    $cache = CacheableMetadata::createFromRenderArray($build);
     if (in_array($taxonomy_term->bundle(), $person_vocabularies)) {
-      $cache = CacheableMetadata::createFromRenderArray($build);
       $cache->addCacheTags(['node_list:person']);
-      $cache->applyTo($build);
     }
+    if (in_array($taxonomy_term->bundle(), $place_vocabularies)) {
+      $cache->addCacheTags(['node_list:place']);
+    }
+    $cache->applyTo($build);
 
     return $build;
   }
@@ -307,27 +318,37 @@ class TaxonomyRecordViewController extends ControllerBase implements ContainerIn
   }
 
   /**
-   * Returns the single accessible person record for a term, or NULL.
+   * Returns the single accessible record of the given bundle for a term.
    *
-   * Only redirects when exactly one published, accessible person record has
-   * this term in field_other_names and the term's vocabulary is enabled for
-   * person records. Multiple matches return NULL so the taxonomy page is shown
-   * instead.
+   * Only redirects when exactly one published, accessible record of the given
+   * bundle has this term in the given field and the term's vocabulary is
+   * enabled per the given settings key. Multiple matches return NULL so the
+   * taxonomy page is shown instead.
    *
    * Key edge cases worth covering in tests: vocabulary not enabled (NULL),
    * zero matches (NULL), two or more matches (NULL), draft node excluded by
    * status=1, inaccessible node excluded by accessCheck(TRUE).
+   *
+   * @param \Drupal\taxonomy\TermInterface $taxonomy_term
+   *   The taxonomy term.
+   * @param string $bundle
+   *   The node bundle to search, e.g. 'person' or 'place'.
+   * @param string $field
+   *   The "other names" field on that bundle, e.g. 'field_other_names'.
+   * @param string $vocabularySetting
+   *   The mukurtu_taxonomy.settings key listing enabled vocabularies for
+   *   this bundle.
    */
-  protected function getSinglePersonRecord(TermInterface $taxonomy_term): ?NodeInterface {
-    $person_vocabularies = $this->mukurtuTaxonomySettings->get('person_records_enabled_vocabularies') ?? [];
-    if (!in_array($taxonomy_term->bundle(), $person_vocabularies)) {
+  protected function getSingleRecord(TermInterface $taxonomy_term, string $bundle, string $field, string $vocabularySetting): ?NodeInterface {
+    $vocabularies = $this->mukurtuTaxonomySettings->get($vocabularySetting) ?? [];
+    if (!in_array($taxonomy_term->bundle(), $vocabularies)) {
       return NULL;
     }
 
     $storage = $this->entityTypeManager()->getStorage('node');
     $results = $storage->getQuery()
-      ->condition('type', 'person')
-      ->condition('field_other_names', $taxonomy_term->id())
+      ->condition('type', $bundle)
+      ->condition($field, $taxonomy_term->id())
       ->condition('status', 1)
       ->accessCheck(TRUE)
       ->execute();
@@ -349,19 +370,28 @@ class TaxonomyRecordViewController extends ControllerBase implements ContainerIn
     // here.
     $person_vocabularies = $this->mukurtuTaxonomySettings->get('person_records_enabled_vocabularies') ?? [];
     $place_vocabularies = $this->mukurtuTaxonomySettings->get('place_records_enabled_vocabularies') ?? [];
-    $enabled_vocabularies = array_merge($person_vocabularies, $place_vocabularies);
-    // If the term vocabulary is not enabled for taxonomy records, return
-    // an empty array.
-    if (!in_array($taxonomy_term->bundle(), $enabled_vocabularies)) {
-      return [];
-    }
 
     $storage = $this->entityTypeManager()->getStorage('node');
-    $query = $storage->getQuery();
-    $query->condition('field_other_names', $taxonomy_term->id());
-    $query->condition('status', 1, '=');
-    $query->accessCheck();
-    $results = $query->execute();
+    $results = [];
+
+    if (in_array($taxonomy_term->bundle(), $person_vocabularies)) {
+      $results += $storage->getQuery()
+        ->condition('type', 'person')
+        ->condition('field_other_names', $taxonomy_term->id())
+        ->condition('status', 1, '=')
+        ->accessCheck()
+        ->execute();
+    }
+
+    if (in_array($taxonomy_term->bundle(), $place_vocabularies)) {
+      $results += $storage->getQuery()
+        ->condition('type', 'place')
+        ->condition('field_other_place_names', $taxonomy_term->id())
+        ->condition('status', 1, '=')
+        ->accessCheck()
+        ->execute();
+    }
+
     return empty($results) ? [] : $storage->loadMultiple($results);
   }
 

--- a/modules/mukurtu_taxonomy/tests/src/Unit/TaxonomyRecordViewControllerTest.php
+++ b/modules/mukurtu_taxonomy/tests/src/Unit/TaxonomyRecordViewControllerTest.php
@@ -4,7 +4,12 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\mukurtu_taxonomy\Unit;
 
+use Drupal\Core\Config\Config;
+use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Entity\Query\QueryInterface;
 use Drupal\mukurtu_taxonomy\Controller\TaxonomyRecordViewController;
+use Drupal\node\NodeInterface;
 use Drupal\taxonomy\TermInterface;
 use Drupal\Tests\UnitTestCase;
 
@@ -31,6 +36,69 @@ class TaxonomyRecordViewControllerTest extends UnitTestCase {
     $method = new \ReflectionMethod($controller, 'getSingularVocabularyLabel');
     $method->setAccessible(TRUE);
     return $method->invoke($controller, $vocab);
+  }
+
+  /**
+   * Builds a controller wired up for testing getSingleRecord().
+   *
+   * Stubs the mukurtuTaxonomySettings config and an entityTypeManager wired
+   * to the given node query results.
+   *
+   * @param array $settings
+   *   Map of mukurtu_taxonomy.settings keys to values, e.g.
+   *   ['person_records_enabled_vocabularies' => ['people']].
+   * @param array $queryResultsByType
+   *   Map of node bundle => array of matching node IDs returned by the
+   *   entity query for that bundle.
+   * @param \Drupal\node\NodeInterface[] $nodesById
+   *   Map of node ID => node mock, used by storage::load().
+   */
+  protected function getControllerForRecordLookup(array $settings, array $queryResultsByType, array $nodesById = []): TaxonomyRecordViewController {
+    $controller = $this->getMockBuilder(TaxonomyRecordViewController::class)
+      ->disableOriginalConstructor()
+      ->onlyMethods(['entityTypeManager'])
+      ->getMock();
+
+    $config = $this->createMock(Config::class);
+    $config->method('get')->willReturnCallback(fn(string $key) => $settings[$key] ?? NULL);
+
+    $configProperty = new \ReflectionProperty($controller, 'mukurtuTaxonomySettings');
+    $configProperty->setAccessible(TRUE);
+    $configProperty->setValue($controller, $config);
+
+    $storage = $this->createMock(EntityStorageInterface::class);
+    $storage->method('load')->willReturnCallback(fn($id) => $nodesById[$id] ?? NULL);
+    $storage->method('getQuery')->willReturnCallback(function () use (&$queryResultsByType) {
+      $type = NULL;
+      $query = $this->createMock(QueryInterface::class);
+      $query->method('condition')->willReturnCallback(function ($field, $value = NULL) use ($query, &$type) {
+        if ($field === 'type') {
+          $type = $value;
+        }
+        return $query;
+      });
+      $query->method('accessCheck')->willReturnSelf();
+      $query->method('execute')->willReturnCallback(function () use (&$type, &$queryResultsByType) {
+        return $queryResultsByType[$type] ?? [];
+      });
+      return $query;
+    });
+
+    $entityTypeManager = $this->createMock(EntityTypeManagerInterface::class);
+    $entityTypeManager->method('getStorage')->with('node')->willReturn($storage);
+
+    $controller->method('entityTypeManager')->willReturn($entityTypeManager);
+
+    return $controller;
+  }
+
+  /**
+   * Calls the protected getSingleRecord() via reflection.
+   */
+  protected function callGetSingleRecord(TaxonomyRecordViewController $controller, TermInterface $term, string $bundle, string $field, string $vocabularySetting): ?NodeInterface {
+    $method = new \ReflectionMethod($controller, 'getSingleRecord');
+    $method->setAccessible(TRUE);
+    return $method->invoke($controller, $term, $bundle, $field, $vocabularySetting);
   }
 
   /**
@@ -112,6 +180,113 @@ class TaxonomyRecordViewControllerTest extends UnitTestCase {
 
     $controller = $this->getController();
     $this->assertSame('Keyword: Traditional Dance', $controller->title($term));
+  }
+
+  /**
+   * @covers ::getSingleRecord
+   */
+  public function testGetSingleRecordReturnsNullWhenVocabularyNotEnabled(): void {
+    $term = $this->createMock(TermInterface::class);
+    $term->method('bundle')->willReturn('location');
+
+    $controller = $this->getControllerForRecordLookup(
+      ['place_records_enabled_vocabularies' => ['other_vocab']],
+      []
+    );
+
+    $this->assertNull($this->callGetSingleRecord($controller, $term, 'place', 'field_other_place_names', 'place_records_enabled_vocabularies'));
+  }
+
+  /**
+   * @covers ::getSingleRecord
+   */
+  public function testGetSingleRecordReturnsNullWhenNoMatches(): void {
+    $term = $this->createMock(TermInterface::class);
+    $term->method('bundle')->willReturn('location');
+    $term->method('id')->willReturn(42);
+
+    $controller = $this->getControllerForRecordLookup(
+      ['place_records_enabled_vocabularies' => ['location']],
+      ['place' => []]
+    );
+
+    $this->assertNull($this->callGetSingleRecord($controller, $term, 'place', 'field_other_place_names', 'place_records_enabled_vocabularies'));
+  }
+
+  /**
+   * @covers ::getSingleRecord
+   */
+  public function testGetSingleRecordReturnsNullWhenMultipleMatches(): void {
+    $term = $this->createMock(TermInterface::class);
+    $term->method('bundle')->willReturn('location');
+    $term->method('id')->willReturn(42);
+
+    $controller = $this->getControllerForRecordLookup(
+      ['place_records_enabled_vocabularies' => ['location']],
+      ['place' => [1, 2]]
+    );
+
+    $this->assertNull($this->callGetSingleRecord($controller, $term, 'place', 'field_other_place_names', 'place_records_enabled_vocabularies'));
+  }
+
+  /**
+   * @covers ::getSingleRecord
+   */
+  public function testGetSingleRecordReturnsThePlaceNodeOnSingleAccessibleMatch(): void {
+    $term = $this->createMock(TermInterface::class);
+    $term->method('bundle')->willReturn('location');
+    $term->method('id')->willReturn(42);
+
+    $place = $this->createMock(NodeInterface::class);
+    $place->method('access')->with('view')->willReturn(TRUE);
+
+    $controller = $this->getControllerForRecordLookup(
+      ['place_records_enabled_vocabularies' => ['location']],
+      ['place' => [7]],
+      [7 => $place]
+    );
+
+    $this->assertSame($place, $this->callGetSingleRecord($controller, $term, 'place', 'field_other_place_names', 'place_records_enabled_vocabularies'));
+  }
+
+  /**
+   * @covers ::getSingleRecord
+   */
+  public function testGetSingleRecordReturnsNullWhenSingleMatchIsInaccessible(): void {
+    $term = $this->createMock(TermInterface::class);
+    $term->method('bundle')->willReturn('location');
+    $term->method('id')->willReturn(42);
+
+    $place = $this->createMock(NodeInterface::class);
+    $place->method('access')->with('view')->willReturn(FALSE);
+
+    $controller = $this->getControllerForRecordLookup(
+      ['place_records_enabled_vocabularies' => ['location']],
+      ['place' => [7]],
+      [7 => $place]
+    );
+
+    $this->assertNull($this->callGetSingleRecord($controller, $term, 'place', 'field_other_place_names', 'place_records_enabled_vocabularies'));
+  }
+
+  /**
+   * @covers ::getSingleRecord
+   */
+  public function testGetSingleRecordStillWorksForPersonBundle(): void {
+    $term = $this->createMock(TermInterface::class);
+    $term->method('bundle')->willReturn('people');
+    $term->method('id')->willReturn(11);
+
+    $person = $this->createMock(NodeInterface::class);
+    $person->method('access')->with('view')->willReturn(TRUE);
+
+    $controller = $this->getControllerForRecordLookup(
+      ['person_records_enabled_vocabularies' => ['people']],
+      ['person' => [3]],
+      [3 => $person]
+    );
+
+    $this->assertSame($person, $this->callGetSingleRecord($controller, $term, 'person', 'field_other_names', 'person_records_enabled_vocabularies'));
   }
 
 }


### PR DESCRIPTION
- [ ] New content added to existing "other names/place names" should now connect without a cache clear.
- [ ] Place record connect names should now redirect to place records, the same way that person records already did.

## Summary
- Fixes #1805
- `field_all_related_content` is computed by a live cross-node query (see `AllRelatedContentItemList`), but nothing tagged the render array to invalidate when new content elsewhere changed that result. Person/place records (and every other bundle sharing this field) only refreshed on their own save or a full cache clear. Added a `node_list` cache tag in `mukurtu_core_node_view()` whenever the field is displayed.
- The taxonomy term-page redirect (`/admin/config/mukurtu/person-records` -> matching person record) had no place-records equivalent. Generalized `TaxonomyRecordViewController::getSinglePersonRecord()` into a bundle-parameterized `getSingleRecord()` and now check place records too, with a matching `node_list:place` cache tag.
- Fixed `getTaxonomyTermRecords()`, which was silently dropping all place content from the term-page "records" tab because it only ever queried `field_other_names` (person) even though it already gated on place-enabled vocabularies.
- Added unit test coverage for `getSingleRecord()` (vocabulary not enabled, zero/multiple/single match, access-denied, for both person and place bundles).

## Test plan
- [x] `phpunit` on `modules/mukurtu_taxonomy/tests/src/Unit` (18/18 passing)
- [x] `phpcs --standard=Drupal,DrupalPractice` on changed files (no new violations)
- [ ] Manual verification in DDEV: new content referencing a person/place's "other names" term shows up in Referenced Content without a cache clear or re-save
- [ ] Manual verification in DDEV: a place-enabled vocabulary term page with exactly one matching place record redirects to it, and place records now appear in the taxonomy term "records" tab

## Pre-merge checklist:

- [x] I have checked for and if required, created update hooks. (none required, no schema/config changes)
- [ ] I have run an accessibility check, and resolved any issues.
- [x] I have recompiled SCSS if required. (no SCSS touched)
- [x] I have updated or created CI/CD tests, if required.
- [x] I have updated from `main` and resolved any merge conflicts.
- [x] I have verified that all expected checks pass.
- [ ] I have run the pr-expert-review skill and resolved all relevant issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)