### PR TITLE
Fix Playwright CI falsely treating a sleeping Tugboat preview as ready

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -72,18 +72,30 @@ jobs:
           fi
 
           # The comment can appear before the preview site has finished
-          # booting, so poll the URL itself until it responds successfully.
-          READY_MAX_WAIT=300
+          # booting. A bare status-code check isn't enough here: Tugboat
+          # serves its own "Preview is resuming" holding page (while a
+          # suspended/idle preview container wakes back up) with a 200,
+          # so that alone looks "ready" while Drupal underneath is still
+          # down. Poll /user/login instead and only accept a response that
+          # is actually the rendered Drupal login form.
+          READY_MAX_WAIT=600
           READY_INTERVAL=15
           READY_ELAPSED=0
           while [ $READY_ELAPSED -lt $READY_MAX_WAIT ]; do
-            STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$PREVIEW_URL" || true)
-            if [[ "$STATUS" =~ ^(2|3)[0-9][0-9]$ ]]; then
+            RESULT=$(curl -s -L -o /tmp/tugboat-preview-check.html -w "%{http_code} %{url_effective}" "$PREVIEW_URL/user/login" || true)
+            STATUS="${RESULT%% *}"
+            EFFECTIVE_URL="${RESULT#* }"
+
+            if [[ "$STATUS" == "200" ]] \
+              && [[ "$EFFECTIVE_URL" != *"/core/install.php"* ]] \
+              && ! grep -q "Preview is resuming" /tmp/tugboat-preview-check.html \
+              && grep -qi ">Username<" /tmp/tugboat-preview-check.html; then
               echo "Preview is ready: $PREVIEW_URL"
               echo "preview_url=$PREVIEW_URL" >> "$GITHUB_OUTPUT"
               exit 0
             fi
-            echo "Waiting for Tugboat preview to respond (last status: $STATUS)..."
+
+            echo "Waiting for Tugboat preview to serve the real Drupal site (status: $STATUS, url: $EFFECTIVE_URL)..."
             sleep $READY_INTERVAL
             READY_ELAPSED=$((READY_ELAPSED + READY_INTERVAL))
           done

--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -116,6 +116,13 @@ services:
           # Run any pending update hooks introduced by this branch and clear
           # caches so templates and config changes take effect immediately.
           sudo -E -u www-data ./vendor/bin/drush updb -y
+          # Disable Honeypot's time-based submission check on this preview
+          # only. Its 5-second default rejects Playwright's near-instant
+          # form fills as spam, which would otherwise fail every automated
+          # login. Production sites keep the real default (see
+          # mukurtu_bot_protection.install / mukurtu_core.install) - this
+          # override only ever applies to Tugboat's test/preview database.
+          sudo -E -u www-data ./vendor/bin/drush config:set honeypot.settings time_limit 0 -y
           sudo -E -u www-data ./vendor/bin/drush cr
       update:
         # Ensure settings.php is always present with the correct database
@@ -145,6 +152,9 @@ services:
           cd ~/mukurtu
           if sudo -E -u www-data ./vendor/bin/drush core:status 2>/dev/null; then
             sudo -E -u www-data ./vendor/bin/drush updb -y
+            # See the matching override in the build phase above for why
+            # this is disabled only on this preview, not in production.
+            sudo -E -u www-data ./vendor/bin/drush config:set honeypot.settings time_limit 0 -y
             sudo -E -u www-data ./vendor/bin/drush cr
           else
             echo "Drupal not yet installed; updb/cr will run after site-install in the build phase."

--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -116,13 +116,17 @@ services:
           # Run any pending update hooks introduced by this branch and clear
           # caches so templates and config changes take effect immediately.
           sudo -E -u www-data ./vendor/bin/drush updb -y
-          # Disable Honeypot's time-based submission check on this preview
-          # only. Its 5-second default rejects Playwright's near-instant
-          # form fills as spam, which would otherwise fail every automated
-          # login. Production sites keep the real default (see
-          # mukurtu_bot_protection.install / mukurtu_core.install) - this
-          # override only ever applies to Tugboat's test/preview database.
+          # Disable Honeypot's time-based submission check and the login
+          # form's CAPTCHA challenge on this preview only. Honeypot's
+          # 5-second default rejects Playwright's near-instant form fills
+          # as spam, and the ALTCHA widget (auto="off") requires an
+          # explicit checkbox click before the browser will submit the
+          # form at all - both would otherwise block every automated
+          # login. Production sites keep the real defaults (see
+          # mukurtu_bot_protection.install / mukurtu_core.install) - these
+          # overrides only ever apply to Tugboat's test/preview database.
           sudo -E -u www-data ./vendor/bin/drush config:set honeypot.settings time_limit 0 -y
+          sudo -E -u www-data ./vendor/bin/drush config:set captcha.captcha_point.user_login_form status 0 -y
           sudo -E -u www-data ./vendor/bin/drush cr
       update:
         # Ensure settings.php is always present with the correct database
@@ -152,9 +156,10 @@ services:
           cd ~/mukurtu
           if sudo -E -u www-data ./vendor/bin/drush core:status 2>/dev/null; then
             sudo -E -u www-data ./vendor/bin/drush updb -y
-            # See the matching override in the build phase above for why
-            # this is disabled only on this preview, not in production.
+            # See the matching overrides in the build phase above for why
+            # these are disabled only on this preview, not in production.
             sudo -E -u www-data ./vendor/bin/drush config:set honeypot.settings time_limit 0 -y
+            sudo -E -u www-data ./vendor/bin/drush config:set captcha.captcha_point.user_login_form status 0 -y
             sudo -E -u www-data ./vendor/bin/drush cr
           else
             echo "Drupal not yet installed; updb/cr will run after site-install in the build phase."

--- a/tests/playwright/src/components/login.ts
+++ b/tests/playwright/src/components/login.ts
@@ -20,7 +20,14 @@ export class Login {
     const loginButton = this.page.getByRole('button', { name: 'Log in' });
     await usernameField.fill(username);
     await passwordField.fill(password);
-    await loginButton.click();
+    // Wait for the post-login redirect to complete before returning:
+    // clicking the button alone doesn't wait for the resulting navigation,
+    // so callers could otherwise navigate away and cancel the login
+    // request before the session cookie is ever set.
+    await Promise.all([
+      this.page.waitForURL((url) => !url.pathname.startsWith('/user/login')),
+      loginButton.click(),
+    ]);
   }
 
   public async logout(): Promise<void> {


### PR DESCRIPTION
## Summary

Three separate, compounding bugs were making this pipeline fail on effectively every build:

1. **`wait-for-tugboat`'s readiness probe only checked the HTTP status code.** Tugboat's own "Preview is resuming" holding page (served while a suspended/idle preview wakes back up) also returns `200`, so the probe reported "ready" against a preview that wasn't serving the Drupal site yet. Fixed by polling `/user/login` and only accepting a response that's genuinely the rendered login form (`200`, not redirected to `/core/install.php`, no "Preview is resuming" marker, `Username` label present).
2. **Honeypot's `time_limit` (5s default) rejects fast form submissions as spam.** PR #1832 (merged into `main`) enabled Honeypot on `user_login_form`; Playwright's near-instant fill+submit (~1.4s, confirmed via a local trace reproduction against this PR's own preview) got silently rejected every run.
3. **The ALTCHA CAPTCHA widget on the login form ships `auto="off"`**, which requires an explicit click on its own checkbox before the browser will submit the form at all. `Login.login()` never touches the widget, so the click on "Log in" produced *zero* network requests in every trace captured, no matter how long the wait - confirmed this was the real, deterministic blocker once (2) was ruled out.

Fixes:
- `.github/workflows/playwright.yml`: harden the readiness probe (see #1 above), bump the wait budget 300s → 600s.
- `.tugboat/config.yml`: disable Honeypot's time check and the login form's CaptchaPoint, **on the Tugboat preview database only**, in both the build and update phases. Production's real defaults (`mukurtu_bot_protection.install` / `mukurtu_core.install`) are untouched.
- `tests/playwright/src/components/login.ts`: make `Login.login()` wait for the post-login redirect before returning, instead of clicking and immediately moving on - removes a latent race where a caller's next action could navigate away and cancel the login request before its session cookie was ever set.

## Test plan

- [x] YAML validated for both workflow files
- [x] Readiness-check logic dry-run against captured resuming-page/real-login-page/install-wizard-page HTML samples
- [x] Reproduced the original failure locally against this PR's own live preview via Playwright trace + page-snapshot inspection (confirmed 403 due to failed login)
- [x] Root-caused the Honeypot and CAPTCHA blockers via direct inspection of `vendor/drupal/honeypot` source and the rendered `<altcha-widget>` markup
- [x] **This PR's own CI run is green end-to-end**: `wait-for-tugboat` (2m16s) → `playwright-tests` (1m15s), all 7 default-content tests passing against the live preview

## Pre-merge checklist:

- [x] I have checked for and if required, created update hooks. (N/A - CI/Tugboat config and test helper only, no Drupal application code)
- [x] I have run an accessibility check, and resolved any issues. (N/A - no user-facing UI change)
- [x] I have recompiled SCSS if required. (N/A - no SCSS change)
- [x] I have updated or created CI/CD tests, if required. (this PR *is* the CI/CD fix)
- [x] I have updated from `main` and resolved any merge conflicts.
- [x] I have verified that all expected checks pass.
- [x] I have run the pr-expert-review skill and resolved all relevant issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)