### PR TITLE
Match admin (UID 1) warning banner styling to real warning messages

### DIFF
--- a/modules/mukurtu_core/css/mukurtu-super-admin-warning.css
+++ b/modules/mukurtu_core/css/mukurtu-super-admin-warning.css
@@ -92,7 +92,16 @@
 /* mukurtu_v4's global `a` rule sets color and text-decoration-color together
  * via the `text-decoration` shorthand, and its extlink icon SVGs are colored
  * with an explicit fill/stroke rather than currentColor - none of that
- * follows from overriding `color` alone, so each is overridden explicitly. */
+ * follows from overriding `color` alone, so each is overridden explicitly.
+ *
+ * This hardcoded white is only safe against Gin's warning background
+ * (--gin-bg-warning, always a dark tone in both light and dark Gin mode) and
+ * would fail contrast against mukurtu_v4's own light warning background if
+ * that were ever the *only* one in play. That fallback-only case isn't
+ * reachable today: this banner only renders for UID 1, and gin_toolbar
+ * loads Gin's color variables globally on every page - front end included -
+ * for any user with toolbar access, so the Gin branch above is always the
+ * one that applies here. */
 .mukurtu-super-admin-warning__text a,
 .mukurtu-super-admin-warning__text a:hover,
 .mukurtu-super-admin-warning__text a:active {

--- a/modules/mukurtu_core/css/mukurtu-super-admin-warning.css
+++ b/modules/mukurtu_core/css/mukurtu-super-admin-warning.css
@@ -4,10 +4,21 @@
 
 /*
  * The BCSans font-face is normally declared by the mukurtu_v4 theme's own
- * stylesheet, which isn't loaded on admin themes (e.g. Gin). Redeclare just
- * the bold face here (the only weight this banner uses) so the font matches
- * the front end regardless of the active theme.
+ * stylesheet, which isn't loaded on admin themes (e.g. Gin). Redeclare the
+ * weights this banner uses (regular text, bold dismiss control) so the font
+ * matches the front end regardless of the active theme. Without a matching
+ * @font-face, the browser has no "BCSans" glyph data for that weight at all
+ * on admin pages and silently falls back to whichever weight IS declared
+ * here, so this isn't just cosmetic - omitting a weight means it can't
+ * actually render.
  */
+@font-face {
+  font-family: BCSans;
+  font-weight: 400;
+  src: url('../../../themes/mukurtu_v4/fonts/BCSans-Regular.woff2') format('woff2'),
+    url('../../../themes/mukurtu_v4/fonts/BCSans-Regular.woff') format('woff');
+}
+
 @font-face {
   font-family: BCSans;
   font-weight: 700;
@@ -18,21 +29,92 @@
 .mukurtu-super-admin-warning-wrapper {
   /* Fallback values (matching themes/mukurtu_v4/components/00-base) keep the
    * banner styled on admin themes like Gin, which don't define these custom
-   * properties. */
+   * properties. This is a warning (not error) message, so it uses the same
+   * warning color tokens as core's real messages--warning boxes: Gin's
+   * --gin-color-warning-light/--gin-bg-warning on admin pages, falling back
+   * to mukurtu_v4's --color-warning-dark/--color-warning-light on the front
+   * end. Matches Gin's real messages--warning treatment on both themes: no
+   * colored border, a larger corner radius, and normal (not bold) text. */
   box-sizing: border-box;
   font-family: var(--font-display-face, 'BCSans', 'Noto Sans', verdana, arial, sans-serif);
   padding: var(--v-space-4xxs, 1rem);
   margin-block: var(--v-space-4xxs, 1rem);
-  border-radius: 3px;
+  border-radius: var(--gin-border-l, .75rem);
   line-height: var(--line-height-s, 1.75rem);
-  font-weight: 900;
-  border: 2px solid var(--color-error-dark, #924d48);
-  color: var(--color-error-dark, #924d48);
-  background-color: var(--color-error-light, #f2dedf);
+  font-weight: 400;
+  border: 2px solid transparent;
+  color: var(--gin-color-warning-light, var(--color-warning-dark, #54738c));
+  background-color: var(--gin-bg-warning, var(--color-warning-light, #d8edfa));
 }
 
-.mukurtu-super-admin-warning__text a {
-  color: inherit;
+.gin--dark-mode .mukurtu-super-admin-warning-wrapper {
+  box-shadow: 0 6px 16px var(--gin-border-color-layer);
+}
+
+/* Gin's node edit/add form layout (.page-wrapper__node-edit-form) stretches
+ * the main region full-width and then reins specific elements - including
+ * real messages (.messages-list) - back in with this same constraint. Our
+ * banner isn't rendered through core's status-messages markup so it doesn't
+ * get that rule for free; match it here (see
+ * web/themes/contrib/gin/styles/components/edit_form.scss). */
+.gin--edit-form .page-wrapper__node-edit-form .mukurtu-super-admin-warning-wrapper {
+  width: 100%;
+  max-width: 1280px;
+  margin-inline: auto;
+}
+
+.mukurtu-super-admin-warning__text {
+  position: relative;
+  flex: 1 1 auto;
+  min-width: 0;
+  padding-inline-start: 2.125rem;
+}
+
+.mukurtu-super-admin-warning__text:before {
+  content: '';
+  display: block;
+  position: absolute;
+  inset-inline-start: 0;
+  inset-block-start: 2px;
+  width: 1.5rem;
+  height: 1.5rem;
+  background-color: currentColor;
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cg fill='none' stroke='%23000' stroke-width='2.25' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolygon points='7.86 2 16.14 2 22 7.86 22 16.14 16.14 22 7.86 22 2 16.14 2 7.86 7.86 2'/%3E%3Cline x1='12' y1='8' x2='12' y2='12'/%3E%3Cline x1='12' y1='16' x2='12.01' y2='16'/%3E%3C/g%3E%3C/svg%3E");
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cg fill='none' stroke='%23000' stroke-width='2.25' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolygon points='7.86 2 16.14 2 22 7.86 22 16.14 16.14 22 7.86 22 2 16.14 2 7.86 7.86 2'/%3E%3Cline x1='12' y1='8' x2='12' y2='12'/%3E%3Cline x1='12' y1='16' x2='12.01' y2='16'/%3E%3C/g%3E%3C/svg%3E");
+  -webkit-mask-repeat: no-repeat;
+  mask-repeat: no-repeat;
+  -webkit-mask-position: center;
+  mask-position: center;
+  -webkit-mask-size: contain;
+  mask-size: contain;
+}
+
+/* mukurtu_v4's global `a` rule sets color and text-decoration-color together
+ * via the `text-decoration` shorthand, and its extlink icon SVGs are colored
+ * with an explicit fill/stroke rather than currentColor - none of that
+ * follows from overriding `color` alone, so each is overridden explicitly. */
+.mukurtu-super-admin-warning__text a,
+.mukurtu-super-admin-warning__text a:hover,
+.mukurtu-super-admin-warning__text a:active {
+  color: #fff;
+  text-decoration-color: #fff;
+}
+
+.mukurtu-super-admin-warning-wrapper .mukurtu-super-admin-warning__text a svg.ext,
+.mukurtu-super-admin-warning-wrapper .mukurtu-super-admin-warning__text a svg.mailto,
+.mukurtu-super-admin-warning-wrapper .mukurtu-super-admin-warning__text a svg.tel {
+  fill: #fff;
+}
+
+/* mukurtu_v4's own stroke rule is scoped as
+ * `a:not(.primary-nav__menu-link) svg.ext path`, which out-specifies a plain
+ * `.mukurtu-super-admin-warning__text svg.ext path` selector - match its
+ * shape (element + class chain through `a`) rather than relying on source
+ * order to win the tie. */
+.mukurtu-super-admin-warning-wrapper .mukurtu-super-admin-warning__text a svg.ext path,
+.mukurtu-super-admin-warning-wrapper .mukurtu-super-admin-warning__text a svg.mailto path,
+.mukurtu-super-admin-warning-wrapper .mukurtu-super-admin-warning__text a svg.tel path {
+  stroke: #fff;
 }
 
 .mukurtu-super-admin-warning {
@@ -40,11 +122,6 @@
   align-items: flex-start;
   justify-content: space-between;
   gap: 1rem;
-}
-
-.mukurtu-super-admin-warning__text {
-  flex: 1 1 auto;
-  min-width: 0;
 }
 
 .mukurtu-super-admin-warning__dismiss {


### PR DESCRIPTION
Just updating the admin warning to a warning, not an error message. No review needed, just letting you know.

<img width="1503" height="384" alt="Screenshot 2026-07-27 at 1 28 45 PM" src="https://github.com/user-attachments/assets/44f65e5e-d461-45e6-8dd0-29f249bd7f49" />

<img width="1815" height="324" alt="Screenshot 2026-07-27 at 1 28 52 PM" src="https://github.com/user-attachments/assets/2eaa64b3-dcc0-45be-897e-96495516c0d6" />




## Summary
- Fixes #1896: the UID 1 "super admin warning" banner looked like an error message (red/pink, bold, hard border) on both the mukurtu_v4 front end and the Gin admin theme, instead of matching the site's real warning-type messages.
- Swaps the hardcoded error-color tokens for the same warning-color tokens (with a graceful per-theme fallback chain) that real `messages--warning` boxes already use on each theme, so it now reads as a warning rather than an error.
- Matches Gin's real warning-message treatment: no colored border, larger corner radius, normal (not bold) font weight, a warning-triangle icon, dark-mode shadow, and width constrained to match real messages on node edit/add forms.
- Fixes link/icon color and underline-color mismatches: mukurtu_v4's global link styles and the `extlink` module's external-link icon SVGs don't follow from overriding `color` alone, so those are overridden explicitly (with a documented rationale for why a hardcoded white is safe here).
- CSS-only change (`modules/mukurtu_core/css/mukurtu-super-admin-warning.css`); no markup, schema, or PHP changes.

## Pre-merge checklist:

- [x] I have checked for and if required, created update hooks. (Not required - CSS-only change, no schema/config changes.)
- [x] I have run an accessibility check, and resolved any issues. (One theoretical contrast edge case found and reviewed - documented in a code comment as an accepted, unreachable case rather than changed, per product decision.)
- [x] I have recompiled SCSS if required. (Not required - no SCSS touched, only a plain CSS file.)
- [ ] I have updated or created CI/CD tests, if required. (N/A - pure visual/CSS change.)
- [x] I have updated from `main` and resolved any merge conflicts. (Branch was already even with `main` at push time.)
- [ ] I have verified that all expected checks pass.
- [x] I have run the pr-expert-review skill and resolved all relevant issues.

## Test plan
- [ ] Log in as UID 1 on a site with existing content.
- [ ] View the front end (mukurtu_v4) - banner should show a blue-gray bordered warning box (no icon), matching the front end's real warning messages.
- [ ] View an admin page (Gin) in both light and dark mode - banner should show the gold/olive coloring, no border, rounded corners, and a warning-triangle icon, matching real warning messages elsewhere on the page.
- [ ] View a node add/edit form in Gin - banner width should match the width of real messages on that page.
- [ ] Confirm the "Mukurtu Manager" link and its external-link icon are legible (white) against the banner background.
- [ ] Confirm the dismiss (×) control still works and keyboard focus still looks correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)