### PR TITLE
Fix grammar typo in UID 1 admin warning message

### DIFF
--- a/modules/mukurtu_core/mukurtu_core.module
+++ b/modules/mukurtu_core/mukurtu_core.module
@@ -266,7 +266,7 @@ function mukurtu_core_preprocess_page(array &$variables) {
       $dismiss_link = Link::fromTextAndUrl(Markup::create('<span aria-hidden="true">&times;</span>'), $dismiss_url)->toString();
       $manager_link = Link::fromTextAndUrl(t('Mukurtu Manager'), Url::fromUri('https://docs.mukurtu.org/users/user-role-types/'))->toString();
       $message = new FormattableMarkup('<div class="mukurtu-super-admin-warning"><div class="mukurtu-super-admin-warning__text">@text</div>@dismiss</div>', [
-        '@text' => t('You are logged in as an Administrator (UID 1), which gives you the ability to take actions that can break the site and corrupt your data. We strongly recommended using a @manager_link account instead for most site management.', [
+        '@text' => t('You are logged in as an Administrator (UID 1), which gives you the ability to take actions that can break the site and corrupt your data. We strongly recommend using a @manager_link account instead for most site management.', [
           '@manager_link' => $manager_link,
         ]),
         '@dismiss' => $dismiss_link,


### PR DESCRIPTION
## Summary
- Fixes "We strongly recommended" to "We strongly recommend" in the UID 1 super admin warning banner, since this is ongoing advice rather than a past action.

## Test plan
- [x] Visually confirmed the corrected string in modules/mukurtu_core/mukurtu_core.module
- [ ] Load the site as UID 1 to confirm the corrected message renders

## Pre-merge checklist:

- [x] I have checked for and if required, created update hooks. (N/A - text-only change)
- [x] I have run an accessibility check, and resolved any issues. (N/A - grammar fix, no structural/markup change)
- [x] I have recompiled SCSS if required. (N/A - no SCSS change)
- [x] I have updated or created CI/CD tests, if required. (N/A - no logic change)
- [x] I have updated from `main` and resolved any merge conflicts.
- [ ] I have verified that all expected checks pass.
- [ ] I have run the pr-expert-review skill and resolved all relevant issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)