### PR TITLE
Fix duplicate installSchema() breaking LabelIdCollisionTest/RemoveProjectNoticesTest

### DIFF
--- a/modules/mukurtu_local_contexts/tests/src/Kernel/LabelIdCollisionTest.php
+++ b/modules/mukurtu_local_contexts/tests/src/Kernel/LabelIdCollisionTest.php
@@ -33,7 +33,6 @@ class LabelIdCollisionTest extends LocalContextsTestBase {
   protected function setUp(): void {
     parent::setUp();
     $this->manager = $this->container->get('mukurtu_local_contexts.supported_project_manager');
-    $this->installSchema('mukurtu_local_contexts', ['mukurtu_local_contexts_label_translations']);
   }
 
   /**

--- a/modules/mukurtu_local_contexts/tests/src/Kernel/RemoveProjectNoticesTest.php
+++ b/modules/mukurtu_local_contexts/tests/src/Kernel/RemoveProjectNoticesTest.php
@@ -30,7 +30,6 @@ class RemoveProjectNoticesTest extends LocalContextsTestBase {
   protected function setUp(): void {
     parent::setUp();
     $this->manager = $this->container->get('mukurtu_local_contexts.supported_project_manager');
-    $this->installSchema('mukurtu_local_contexts', ['mukurtu_local_contexts_notice_translations']);
   }
 
   protected function seedNotice(string $projectId, string $type, string $name = 'Notice'): void {


### PR DESCRIPTION
## Summary
- `LocalContextsTestBase::setUp()` (added in #1881) already installs `mukurtu_local_contexts_label_translations` and `mukurtu_local_contexts_notice_translations`.
- `LabelIdCollisionTest` and `RemoveProjectNoticesTest` (also added in #1881) each call `installSchema()` again for the same table in their own `setUp()`, which throws `Drupal\Core\Database\SchemaObjectExistsException: Table '...' already exists.`
- Removes the redundant `installSchema()` calls from both test files; the tables are already available via the base class.

Found while investigating the crash reported on PR #1886 (unrelated stale-branch issue, being fixed separately) — ran the full `mukurtu_local_contexts` kernel test suite and found these two test classes failing on `main` itself.

## Test plan
- [x] `vendor/bin/phpunit -c web/core .../LabelIdCollisionTest.php .../RemoveProjectNoticesTest.php` — 4/4 pass (previously 4/4 errored with `SchemaObjectExistsException`).
- [x] Full `mukurtu_local_contexts` kernel suite otherwise unaffected.

## Pre-merge checklist:

- [ ] I have checked for and if required, created update hooks.
- [ ] I have run an accessibility check, and resolved any issues.
- [ ] I have recompiled SCSS if required.
- [x] I have updated or created CI/CD tests, if required.
- [x] I have updated from `main` and resolved any merge conflicts.
- [ ] I have verified that all expected checks pass.
- [ ] I have run the pr-expert-review skill and resolved all relevant issues.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>