### PR TITLE
Fix: guard mukurtu_local_contexts_update_10004() against pre-existing columns

### DIFF
--- a/modules/mukurtu_local_contexts/mukurtu_local_contexts.install
+++ b/modules/mukurtu_local_contexts/mukurtu_local_contexts.install
@@ -602,26 +602,30 @@ function mukurtu_local_contexts_update_10003() {
 function mukurtu_local_contexts_update_10004() {
   $schema = \Drupal::database()->schema();
 
-  $schema->addField(
-    'mukurtu_local_contexts_notices',
-    'locale',
-    [
-      'type' => 'varchar',
-      'length' => 64,
-      'not null' => FALSE,
-      'description' => 'Language code',
-    ]
-  );
-  $schema->addField(
-    'mukurtu_local_contexts_notices',
-    'language',
-    [
-      'type' => 'varchar',
-      'length' => 128,
-      'not null' => FALSE,
-      'description' => 'Language',
-    ]
-  );
+  if (!$schema->fieldExists('mukurtu_local_contexts_notices', 'locale')) {
+    $schema->addField(
+      'mukurtu_local_contexts_notices',
+      'locale',
+      [
+        'type' => 'varchar',
+        'length' => 64,
+        'not null' => FALSE,
+        'description' => 'Language code',
+      ]
+    );
+  }
+  if (!$schema->fieldExists('mukurtu_local_contexts_notices', 'language')) {
+    $schema->addField(
+      'mukurtu_local_contexts_notices',
+      'language',
+      [
+        'type' => 'varchar',
+        'length' => 128,
+        'not null' => FALSE,
+        'description' => 'Language',
+      ]
+    );
+  }
 }
 
 /**

--- a/modules/mukurtu_local_contexts/tests/src/Kernel/Update10004Test.php
+++ b/modules/mukurtu_local_contexts/tests/src/Kernel/Update10004Test.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\mukurtu_local_contexts\Kernel;
+
+/**
+ * Tests mukurtu_local_contexts_update_10004().
+ *
+ * @group mukurtu_local_contexts
+ */
+class Update10004Test extends LocalContextsTestBase {
+
+  /**
+   * Tests the update hook is safe to run when the columns already exist.
+   *
+   * This hook was renumbered during a merge (it originally ran as
+   * update_10001 on some environments before three unrelated hooks were
+   * inserted ahead of it), so it must tolerate being invoked against a
+   * schema that already has the locale/language columns, exactly as
+   * installSchema() produces here from the module's current hook_schema().
+   */
+  public function testUpdateHookSkipsExistingColumns(): void {
+    require_once __DIR__ . '/../../../mukurtu_local_contexts.install';
+
+    mukurtu_local_contexts_update_10004();
+
+    $schema = $this->container->get('database')->schema();
+    $this->assertTrue($schema->fieldExists('mukurtu_local_contexts_notices', 'locale'));
+    $this->assertTrue($schema->fieldExists('mukurtu_local_contexts_notices', 'language'));
+  }
+
+}

--- a/modules/mukurtu_local_contexts/tests/src/Kernel/Update10004Test.php
+++ b/modules/mukurtu_local_contexts/tests/src/Kernel/Update10004Test.php
@@ -30,4 +30,20 @@ class Update10004Test extends LocalContextsTestBase {
     $this->assertTrue($schema->fieldExists('mukurtu_local_contexts_notices', 'language'));
   }
 
+  /**
+   * Tests the update hook still adds the columns when they're missing.
+   */
+  public function testUpdateHookAddsMissingColumns(): void {
+    require_once __DIR__ . '/../../../mukurtu_local_contexts.install';
+
+    $schema = $this->container->get('database')->schema();
+    $schema->dropField('mukurtu_local_contexts_notices', 'locale');
+    $schema->dropField('mukurtu_local_contexts_notices', 'language');
+
+    mukurtu_local_contexts_update_10004();
+
+    $this->assertTrue($schema->fieldExists('mukurtu_local_contexts_notices', 'locale'));
+    $this->assertTrue($schema->fieldExists('mukurtu_local_contexts_notices', 'language'));
+  }
+
 }


### PR DESCRIPTION
## Summary

- `mukurtu_local_contexts_update_10004()` unconditionally added the `locale`/`language` columns to `mukurtu_local_contexts_notices`, with no `fieldExists()` guard, unlike its sibling hooks (`update_10001`, `update_10003`, `update_40001`).
- This logic was originally `update_10001()` (added on `269-lc-translations-audio`). PR #1872 inserted three new, unrelated hooks ahead of it, renumbering it to `update_10004()` and carrying the missing guard along with it.
- Any environment that ran `drush updb` while this logic was still numbered `10001` (before PR #1872 landed) already has the columns. After pulling code with the new numbering, Drupal reruns everything up to `10004`, which fatals with `Cannot add field 'mukurtu_local_contexts_notices.locale': field already exists.`
- Fix: add the same `fieldExists()` guard pattern already used elsewhere in this file.

## Test plan

- [x] Added `Update10004Test` (Kernel test) covering both branches: columns already present (guard skips, matches the reported bug) and columns missing (guard still adds them with the correct type/length).
- [x] Verified manually in an isolated DDEV sandbox: reverting the guard reproduces the exact reported `SchemaObjectExistsException`; with the guard, both test cases pass.
- [ ] CI run on this PR (not yet observed — will confirm once checks run).

## Pre-merge checklist:

- [x] I have checked for and if required, created update hooks. (No new hook needed — this only adds an idempotency guard to an existing one; the hook number and schema-version bump are unchanged.)
- [x] I have run an accessibility check, and resolved any issues. (N/A — no user-facing UI or text changed.)
- [x] I have recompiled SCSS if required. (N/A — no SCSS changed.)
- [x] I have updated or created CI/CD tests, if required.
- [x] I have updated from `main` and resolved any merge conflicts. (Branched directly from `origin/main` tip.)
- [ ] I have verified that all expected checks pass. (Verified locally; will confirm once GitHub Actions runs on this PR.)
- [x] I have run the pr-expert-review skill and resolved all relevant issues.