### PR TITLE
Add accessible keyboard/screen-reader alternative to the Map Points widget (#1913)

### DIFF
--- a/modules/mukurtu_core/config/schema/mukurtu_core.schema.yml
+++ b/modules/mukurtu_core/config/schema/mukurtu_core.schema.yml
@@ -276,6 +276,17 @@ field.widget.settings.geofield_mukurtu:
 #      type: boolean
 #      label: 'Escape output'
 
+field.widget.settings.geofield_mukurtu_latlon:
+  type: mapping
+  label: 'Mukurtu Map Points (latitude/longitude) widget settings'
+  mapping:
+    instructions:
+      type: label
+      label: 'Instructions'
+    show_descriptions:
+      type: boolean
+      label: 'Show a description field for each point'
+
 field.widget.settings.mukurtu_leaflet_formatter:
   type: mapping
   label: 'Mukurtu Leaflet widget settings'

--- a/modules/mukurtu_core/css/mukurtu-leaflet-widget.css
+++ b/modules/mukurtu_core/css/mukurtu-leaflet-widget.css
@@ -58,3 +58,17 @@
   left: auto !important;
   right: 0.5em;
 }
+
+/**
+ * Geoman's only built-in focus affordance is a background-color change,
+ * which isn't visible enough for WCAG 2.4.7/2.4.11. Add a visible outline
+ * for the toolbar buttons, popup close button, and markers.
+ */
+.leaflet-buttons-control-button:focus-visible,
+.leaflet-pm-action:focus-visible,
+.leaflet-popup-close-button:focus-visible,
+.leaflet-marker-icon:focus-visible,
+.leaflet-container:focus-visible {
+  outline: var(--focus-color) solid 2px;
+  outline-offset: 2px;
+}

--- a/modules/mukurtu_core/js/mukurtu-leaflet-widget.js
+++ b/modules/mukurtu_core/js/mukurtu-leaflet-widget.js
@@ -32,6 +32,28 @@
   };
 
   /**
+   * Copies Geoman toolbar buttons' existing (but non-focusable-element)
+   * "title" text onto the actual focusable button as an aria-label, since
+   * Geoman puts the title on a wrapping div rather than the focusable
+   * a[role="button"] inside it. Re-run whenever Geoman rebuilds/toggles
+   * the toolbar, since it re-renders buttons on mode changes.
+   */
+  Drupal.mukurtuLabelGeomanToolbar = function (map) {
+    const $container = $(map.getContainer());
+    $container.find('.button-container[title]').each(function () {
+      const $button = $(this).find('a.leaflet-buttons-control-button, a.leaflet-pm-action').first();
+      if ($button.length && !$button.attr('aria-label')) {
+        $button.attr('aria-label', $(this).attr('title'));
+      }
+    });
+    $container.find('a.leaflet-pm-action[title]').each(function () {
+      if (!$(this).attr('aria-label')) {
+        $(this).attr('aria-label', $(this).attr('title'));
+      }
+    });
+  };
+
+  /**
    * Set the leaflet map object.
    */
   Drupal.Leaflet_Widget.prototype.set_leaflet_widget_map = function (map) {
@@ -61,6 +83,35 @@
       }
       map.pm.addControls(this.widgetsettings.toolbarSettings);
 
+      /* Mukurtu accessibility additions begin: */
+
+      // Geoman ships Escape-to-exit and Enter-to-finish keyboard support,
+      // but both default to off. setGlobalOptions() deep-merges, so this
+      // survives the later pathOptions-setting call elsewhere.
+      map.pm.setGlobalOptions({ exitModeOnEscape: true, finishOnEnter: true });
+
+      const containerId = $(map.getContainer()).attr('id');
+      const instructionsId = containerId + '-keyboard-instructions';
+      map.getContainer().setAttribute('aria-label', Drupal.t('Interactive location map'));
+      if ($('#' + instructionsId).length) {
+        map.getContainer().setAttribute('aria-describedby', instructionsId);
+      }
+
+      Drupal.mukurtuLabelGeomanToolbar(map);
+      map.on('pm:globaldrawmodetoggled pm:globaleditmodetoggled pm:globaldragmodetoggled pm:globalremovalmodetoggled pm:globalcutmodetoggled pm:globalrotatemodetoggled', function () {
+        Drupal.mukurtuLabelGeomanToolbar(map);
+      });
+
+      // Move the location-description input's onblur handler to a
+      // delegated listener (CSP-friendlier than an inline attribute, and
+      // avoids re-attaching it for every marker).
+      $(map.getContainer()).on('focusout', '.mukurtu-leaflet-description-field', function () {
+        const popupId = $(this).attr('id').replace('location-popup-', '');
+        Drupal.mukurtuSetLocationDescription(containerId, popupId);
+      });
+
+      /* Mukurtu accessibility additions end. */
+
       map.on('pm:create', function (event) {
         let layer = event.layer;
         if (event.shape === 'Circle') {
@@ -73,6 +124,7 @@
         this.update_text();
         // Listen to changes on the new layer
         this.add_layer_listeners(layer);
+        Drupal.announce(Drupal.t('Shape added to the map.'));
       }, this);
 
       // Start updating the Leaflet Map.
@@ -104,7 +156,15 @@
         }
         // Populate the location description text box from the GeoJSON feature property.
         const locationDescription = event.popup._source.feature.properties['location_description'] ?? '';
-        $('#location-popup-' + event.popup._source._leaflet_id).val(locationDescription);
+        const $input = $('#location-popup-' + event.popup._source._leaflet_id);
+        $input.val(locationDescription);
+        // Move focus into the popup for keyboard users - Leaflet opens it
+        // without moving focus off the marker.
+        $input.trigger('focus');
+        // Translate Leaflet's hardcoded English close-button label.
+        $(event.popup._container).find('.leaflet-popup-close-button')
+          .attr('aria-label', Drupal.t('Close popup'))
+          .attr('title', Drupal.t('Close popup'));
       }, this);
 
       // update_leaflet_widget_map() just ran above, but if this map starts
@@ -281,11 +341,28 @@
     }
 
     // Mukurtu Location Description.
-    const containerId = $(layer._map._container).attr('id');
     const popupId = "location-popup-" + layer._leaflet_id;
-    layer.bindPopup('<label for="' + popupId + '">' + Drupal.t('Map point description') + '</label><input class="mukurtu-leaflet-description-field" type="text" size="60" maxlength="255" id="' + popupId + '" onblur="Drupal.mukurtuSetLocationDescription(\'' + containerId + '\',' + layer._leaflet_id + ')"></input>');
+
+    // Give the marker icon a meaningful accessible name instead of
+    // Leaflet's hardcoded, untranslated alt="Marker".
+    const updateMarkerLabel = function () {
+      const description = (layer.feature && layer.feature.properties) ? layer.feature.properties['location_description'] : '';
+      if (layer._icon) {
+        layer._icon.setAttribute('alt', description || Drupal.t('Map point'));
+        layer._icon.setAttribute('aria-label', description || Drupal.t('Map point'));
+      }
+    };
+    updateMarkerLabel();
+
+    layer.bindPopup('<label for="' + popupId + '">' + Drupal.t('Map point description') + '</label><input class="mukurtu-leaflet-description-field" type="text" size="60" maxlength="255" id="' + popupId + '"></input>');
     layer.on('popupclose', function (event) {
       this.update_text();
+      updateMarkerLabel();
+      // Return focus to the marker so keyboard users aren't dropped
+      // somewhere unexpected when the popup closes.
+      if (layer._icon) {
+        $(layer._icon).trigger('focus');
+      }
     }, this);
 
     // Disable fill for open polylines, same rationale as the display-side
@@ -327,6 +404,7 @@
     layer.on('pm:remove', function (event) {
       this.drawnItems.removeLayer(event.layer);
       this.update_text();
+      Drupal.announce(Drupal.t('Shape removed from the map.'));
     }, this);
 
     /* Copied from leaflet.widget.js end. */

--- a/modules/mukurtu_core/mukurtu_core.libraries.yml
+++ b/modules/mukurtu_core/mukurtu_core.libraries.yml
@@ -8,6 +8,7 @@ mukurtu-leaflet-widget:
   dependencies:
     - core/jquery
     - core/once
+    - core/drupal.announce
     - leaflet/leaflet-widget
 
 tagify-override:

--- a/modules/mukurtu_core/src/Plugin/Field/FieldWidget/GeofieldMukurtuLatLonWidget.php
+++ b/modules/mukurtu_core/src/Plugin/Field/FieldWidget/GeofieldMukurtuLatLonWidget.php
@@ -1,0 +1,1053 @@
+<?php
+
+namespace Drupal\mukurtu_core\Plugin\Field\FieldWidget;
+
+use Drupal\Component\Utility\Html;
+use Drupal\Component\Utility\NestedArray;
+use Drupal\Core\Ajax\AjaxResponse;
+use Drupal\Core\Ajax\AnnounceCommand;
+use Drupal\Core\Ajax\InvokeCommand;
+use Drupal\Core\Ajax\ReplaceCommand;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Render\Element;
+use Drupal\geofield\Element\GeofieldLatLon;
+use Drupal\geofield\Plugin\Field\FieldWidget\GeofieldBaseWidget;
+
+/**
+ * Plugin implementation of the 'geofield_mukurtu_latlon' widget.
+ *
+ * @FieldWidget(
+ *   id = "geofield_mukurtu_latlon",
+ *   label = @Translation("Mukurtu Map Points (accessible list editor)"),
+ *   description = @Translation("Accessible, keyboard-only alternative to the map widget. Supports points, lines, and simple polygons."),
+ *   field_types = {
+ *     "geofield"
+ *   }
+ * )
+ */
+class GeofieldMukurtuLatLonWidget extends GeofieldBaseWidget {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultSettings() {
+    return [
+      'instructions' => '',
+      'show_descriptions' => TRUE,
+    ] + parent::defaultSettings();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsForm(array $form, FormStateInterface $form_state) {
+    $elements = parent::settingsForm($form, $form_state);
+
+    $elements['instructions'] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('Instructions'),
+      '#description' => $this->t('Optional text shown above the shape list, replacing the field description. Leave blank to use the field description.'),
+      '#default_value' => $this->getSetting('instructions'),
+      '#rows' => 2,
+    ];
+    $elements['show_descriptions'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Show a description field for each shape'),
+      '#default_value' => $this->getSetting('show_descriptions'),
+    ];
+
+    return $elements;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsSummary() {
+    $summary = [];
+    $summary[] = $this->getSetting('show_descriptions')
+      ? $this->t('Shows a description field for each shape')
+      : $this->t('No per-shape description field');
+    return $summary;
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * field_coverage stores raw GeoJSON FeatureCollections, not WKT (see
+   * GeofieldMukurtuWidget::geofieldBackendValue()). massageFormValues()
+   * below builds the final value directly and never calls this method; it
+   * is overridden only so no inherited/future code path can silently
+   * WKT-normalize the stored value.
+   */
+  protected function geofieldBackendValue($value) {
+    return $value;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state) {
+    $field_parents = $element['#field_parents'] ?? [];
+    $field_name = $this->fieldDefinition->getName();
+
+    $element = parent::formElement($items, $delta, $element, $form, $form_state);
+    $original = $element['value'];
+
+    $parsed = $this->parseStoredValue($items[$delta]->value ?? NULL);
+
+    $field_state = static::getWidgetState($field_parents, $field_name, $form_state);
+    if (!isset($field_state['mukurtu_shapes'])) {
+      if ($parsed['shapes']) {
+        $field_state['mukurtu_shapes'] = array_map(function (array $shape): array {
+          return ['type' => $shape['type'], 'vertex_count' => count($shape['vertices'])];
+        }, $parsed['shapes']);
+      }
+      else {
+        // Nothing stored yet: start with one empty Point, matching the
+        // original widget's "always show at least one row" behavior.
+        $field_state['mukurtu_shapes'] = [['type' => 'Point', 'vertex_count' => 1]];
+      }
+      static::setWidgetState($field_parents, $field_name, $form_state, $field_state);
+    }
+    $shapes_state = $field_state['mukurtu_shapes'];
+
+    $wrapper_id = Html::getUniqueId('mukurtu-geofield-shapes-' . $field_name);
+
+    $value_element = [
+      '#type' => 'fieldset',
+      '#title' => $original['#title'] ?? $this->fieldDefinition->getLabel(),
+      '#description' => $this->getSetting('instructions') ?: ($original['#description'] ?? NULL),
+      '#required' => $original['#required'] ?? FALSE,
+      '#attributes' => ['class' => ['mukurtu-geofield-latlon']],
+      '#attached' => $original['#attached'] ?? [],
+      '#tree' => TRUE,
+      '#field_parents' => $field_parents,
+      '#mukurtu_field_name' => $field_name,
+    ];
+
+    // Legacy value this widget can't parse (e.g. WKT): show read-only,
+    // change nothing on save.
+    if ($parsed['passthrough'] !== NULL) {
+      $value_element['passthrough_warning'] = [
+        '#type' => 'markup',
+        '#markup' => '<p class="mukurtu-geofield-warning">' . $this->t("This location's data isn't in a format this widget can edit. It's shown below unchanged and won't be modified when you save.") . '</p>',
+      ];
+      $value_element['raw_passthrough'] = [
+        '#type' => 'value',
+        '#value' => $parsed['passthrough'],
+      ];
+      $value_element['raw_display'] = [
+        '#type' => 'textarea',
+        '#title' => $this->t('Stored location data'),
+        '#value' => $parsed['passthrough'],
+        '#attributes' => ['readonly' => 'readonly'],
+        '#rows' => 4,
+      ];
+      return ['value' => $value_element];
+    }
+
+    $value_element['preserved_features'] = [
+      '#type' => 'value',
+      '#value' => $parsed['other'],
+    ];
+
+    if ($parsed['other']) {
+      $value_element['preserved_notice'] = [
+        '#type' => 'markup',
+        '#markup' => '<p class="mukurtu-geofield-warning" role="status">' . $this->formatPlural(
+          count($parsed['other']),
+          "This location also includes 1 shape (a multi-part or complex shape) drawn on the map, which can't be edited here and will be kept unchanged when you save. Use the map widget to edit it.",
+          "This location also includes @count shapes (multi-part or complex shapes) drawn on the map, which can't be edited here and will be kept unchanged when you save. Use the map widget to edit them."
+        ) . '</p>',
+      ];
+    }
+
+    $show_descriptions = $this->getSetting('show_descriptions');
+    $geocoder_available = \Drupal::hasService('geocoder');
+
+    $value_element['shapes'] = [
+      '#type' => 'container',
+      '#prefix' => '<div id="' . $wrapper_id . '">',
+      '#suffix' => '</div>',
+      '#mukurtu_wrapper_id' => $wrapper_id,
+    ];
+
+    foreach ($shapes_state as $n => $shape_info) {
+      $shape_type = $shape_info['type'] ?? 'Point';
+      $vertex_count = max(1, $shape_info['vertex_count'] ?? 1);
+      $shape_row = $parsed['shapes'][$n] ?? NULL;
+      $shape_id = $wrapper_id . '-shape-' . $n;
+      $is_point = $shape_type === 'Point';
+
+      $value_element['shapes'][$n] = [
+        '#type' => 'fieldset',
+        '#title' => $is_point
+          ? $this->t('Point @n', ['@n' => $n + 1])
+          : ($shape_type === 'LineString'
+            ? $this->t('Shape @n: Line', ['@n' => $n + 1])
+            : $this->t('Shape @n: Polygon', ['@n' => $n + 1])),
+        '#attributes' => [
+          'id' => $shape_id,
+          'tabindex' => '-1',
+          'class' => ['mukurtu-geofield-shape'],
+        ],
+      ];
+      $value_element['shapes'][$n]['shape_type'] = ['#type' => 'value', '#value' => $shape_type];
+      $value_element['shapes'][$n]['source_feature'] = [
+        '#type' => 'value',
+        '#value' => $shape_row['feature'] ?? ['type' => 'Feature', 'properties' => []],
+      ];
+      $value_element['shapes'][$n]['source_index'] = [
+        '#type' => 'value',
+        '#value' => $shape_row['index'] ?? NULL,
+      ];
+
+      if ($is_point) {
+        $vertex = $shape_row['vertices'][0] ?? NULL;
+        $geocoded = $field_state['mukurtu_geocoded'][$n][0] ?? NULL;
+        $value_element['shapes'][$n] += $this->buildVertexFields(
+          $shape_id, $n, 0, $vertex, $geocoded, $geocoder_available, $field_name, $field_parents,
+          $this->t('Coordinates for point @n', ['@n' => $n + 1]),
+          $this->t('Point @n', ['@n' => $n + 1]),
+        );
+        if ($show_descriptions) {
+          $value_element['shapes'][$n]['location_description'] = [
+            '#type' => 'textfield',
+            '#title' => $this->t('Description for point @n', ['@n' => $n + 1]),
+            '#maxlength' => 255,
+            '#default_value' => $shape_row['description'] ?? '',
+          ];
+        }
+      }
+      else {
+        if ($show_descriptions) {
+          $value_element['shapes'][$n]['location_description'] = [
+            '#type' => 'textfield',
+            '#title' => $this->t('Description for shape @n', ['@n' => $n + 1]),
+            '#maxlength' => 255,
+            '#default_value' => $shape_row['description'] ?? '',
+          ];
+        }
+
+        $vertices_wrapper_id = $shape_id . '-vertices';
+        $value_element['shapes'][$n]['vertices'] = [
+          '#type' => 'container',
+          '#mukurtu_wrapper_id' => $vertices_wrapper_id,
+          '#prefix' => '<div id="' . $vertices_wrapper_id . '">',
+          '#suffix' => '</div>',
+        ];
+
+        for ($v = 0; $v < $vertex_count; $v++) {
+          $vertex = $shape_row['vertices'][$v] ?? NULL;
+          $geocoded = $field_state['mukurtu_geocoded'][$n][$v] ?? NULL;
+          $vertex_id = $shape_id . '-vertex-' . $v;
+
+          $value_element['shapes'][$n]['vertices'][$v] = [
+            '#type' => 'container',
+            '#attributes' => ['id' => $vertex_id, 'tabindex' => '-1', 'class' => ['mukurtu-geofield-vertex']],
+          ] + $this->buildVertexFields(
+            $vertex_id, $n, $v, $vertex, $geocoded, $geocoder_available, $field_name, $field_parents,
+            $this->t('Coordinates for vertex @v of shape @n', ['@v' => $v + 1, '@n' => $n + 1]),
+            $this->t('Shape @n, vertex @v', ['@n' => $n + 1, '@v' => $v + 1]),
+          );
+
+          if ($v > 0) {
+            $value_element['shapes'][$n]['vertices'][$v]['move_up'] = [
+              '#type' => 'submit',
+              '#value' => $this->t('Move vertex up'),
+              '#name' => str_replace('-', '_', $vertex_id) . '_move_up',
+              '#limit_validation_errors' => [],
+              '#submit' => [[static::class, 'moveVertexUpSubmit']],
+              '#ajax' => ['callback' => [static::class, 'shapesAjax']],
+              '#mukurtu_shape_delta' => $n,
+              '#mukurtu_vertex_delta' => $v,
+            ];
+          }
+          if ($v < $vertex_count - 1) {
+            $value_element['shapes'][$n]['vertices'][$v]['move_down'] = [
+              '#type' => 'submit',
+              '#value' => $this->t('Move vertex down'),
+              '#name' => str_replace('-', '_', $vertex_id) . '_move_down',
+              '#limit_validation_errors' => [],
+              '#submit' => [[static::class, 'moveVertexDownSubmit']],
+              '#ajax' => ['callback' => [static::class, 'shapesAjax']],
+              '#mukurtu_shape_delta' => $n,
+              '#mukurtu_vertex_delta' => $v,
+            ];
+          }
+          if ($vertex_count > 1) {
+            $value_element['shapes'][$n]['vertices'][$v]['remove_vertex'] = [
+              '#type' => 'submit',
+              '#value' => $this->t('Remove vertex @v', ['@v' => $v + 1]),
+              '#name' => str_replace('-', '_', $vertex_id) . '_remove',
+              '#limit_validation_errors' => [],
+              '#submit' => [[static::class, 'removeVertexSubmit']],
+              '#ajax' => ['callback' => [static::class, 'shapesAjax']],
+              '#attributes' => [
+                'aria-label' => $this->t('Remove vertex @v from shape @n', ['@v' => $v + 1, '@n' => $n + 1]),
+              ],
+              '#mukurtu_shape_delta' => $n,
+              '#mukurtu_vertex_delta' => $v,
+            ];
+          }
+        }
+
+        $value_element['shapes'][$n]['vertices']['add_vertex'] = [
+          '#type' => 'submit',
+          '#value' => $this->t('Add vertex'),
+          '#name' => str_replace('-', '_', $shape_id) . '_add_vertex',
+          '#limit_validation_errors' => [],
+          '#submit' => [[static::class, 'addVertexSubmit']],
+          '#ajax' => ['callback' => [static::class, 'shapesAjax']],
+          '#mukurtu_shape_delta' => $n,
+        ];
+      }
+
+      if (count($shapes_state) > 1) {
+        $value_element['shapes'][$n]['remove_shape'] = [
+          '#type' => 'submit',
+          '#value' => $this->t('Remove shape @n', ['@n' => $n + 1]),
+          '#name' => str_replace('-', '_', $shape_id) . '_remove_shape',
+          '#limit_validation_errors' => [],
+          '#submit' => [[static::class, 'removeShapeSubmit']],
+          '#ajax' => ['callback' => [static::class, 'shapesAjax']],
+          '#attributes' => ['aria-label' => $this->t('Remove shape @n', ['@n' => $n + 1])],
+          '#mukurtu_shape_delta' => $n,
+        ];
+      }
+    }
+
+    $value_element['add_point'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Add a point'),
+      '#name' => str_replace('-', '_', $wrapper_id) . '_add_point',
+      '#limit_validation_errors' => [],
+      '#submit' => [[static::class, 'addPointShapeSubmit']],
+      '#ajax' => ['callback' => [static::class, 'shapesAjax']],
+    ];
+    $value_element['add_line'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Add a line'),
+      '#name' => str_replace('-', '_', $wrapper_id) . '_add_line',
+      '#limit_validation_errors' => [],
+      '#submit' => [[static::class, 'addLineShapeSubmit']],
+      '#ajax' => ['callback' => [static::class, 'shapesAjax']],
+    ];
+    $value_element['add_polygon'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Add a polygon'),
+      '#name' => str_replace('-', '_', $wrapper_id) . '_add_polygon',
+      '#limit_validation_errors' => [],
+      '#submit' => [[static::class, 'addPolygonShapeSubmit']],
+      '#ajax' => ['callback' => [static::class, 'shapesAjax']],
+    ];
+
+    if ($geocoder_available) {
+      $value_element['geocoder_attribution'] = [
+        '#type' => 'markup',
+        '#markup' => '<p class="mukurtu-geofield-attribution">' . $this->t('Location search powered by OpenStreetMap Nominatim.') . '</p>',
+      ];
+    }
+
+    $value_element['#element_validate'][] = [static::class, 'validateWidget'];
+
+    return ['value' => $value_element];
+  }
+
+  /**
+   * Builds the place-search + coordinates fields shared by a Point shape
+   * and each vertex of a Line/Polygon shape.
+   */
+  protected function buildVertexFields(
+    string $id,
+    int $shape_delta,
+    int $vertex_delta,
+    ?array $vertex,
+    ?array $geocoded,
+    bool $show_search,
+    string $field_name,
+    array $field_parents,
+    $coordinates_title,
+    $error_label,
+  ): array {
+    $fields = [];
+
+    if ($show_search) {
+      $fields['place_search'] = [
+        '#type' => 'textfield',
+        '#title' => $this->t('Search for a place'),
+        '#size' => 40,
+        '#attributes' => ['class' => ['mukurtu-geofield-place-search']],
+      ];
+      $fields['search'] = [
+        '#type' => 'submit',
+        '#value' => $this->t('Search'),
+        '#name' => str_replace('-', '_', $id) . '_search',
+        '#limit_validation_errors' => [],
+        '#submit' => [[static::class, 'searchPlaceSubmit']],
+        '#ajax' => ['callback' => [static::class, 'shapesAjax']],
+        '#mukurtu_shape_delta' => $shape_delta,
+        '#mukurtu_vertex_delta' => $vertex_delta,
+        '#mukurtu_field_name' => $field_name,
+        '#mukurtu_field_parents' => $field_parents,
+      ];
+    }
+
+    $fields['coordinates'] = [
+      '#type' => 'geofield_latlon',
+      '#title' => $coordinates_title,
+      '#title_display' => 'invisible',
+      '#error_label' => $error_label,
+      '#id' => $id . '-coordinates',
+      '#default_value' => [
+        'lat' => $geocoded['lat'] ?? ($vertex['lat'] ?? ''),
+        'lon' => $geocoded['lon'] ?? ($vertex['lon'] ?? ''),
+      ],
+      '#process' => [
+        [GeofieldLatLon::class, 'latlonProcess'],
+        [static::class, 'processCoordinateInputs'],
+      ],
+    ];
+
+    return $fields;
+  }
+
+  /**
+   * Adds input-mode/format hints to the geofield_latlon element's fields.
+   */
+  public static function processCoordinateInputs(array $element, FormStateInterface $form_state, array &$complete_form) {
+    $examples = ['lat' => '46.7298', 'lon' => '-117.1817'];
+    foreach ($examples as $component => $example) {
+      if (isset($element[$component])) {
+        $element[$component]['#attributes']['inputmode'] = 'decimal';
+        $element[$component]['#attributes']['autocomplete'] = 'off';
+        $element[$component]['#attributes']['id'] = ($element['#id'] ?? 'mukurtu-geofield-latlon') . '-' . $component;
+        $element[$component]['#description'] = t('Decimal degrees, e.g. @example.', ['@example' => $example]);
+      }
+    }
+    return $element;
+  }
+
+  /**
+   * Element validate callback for the widget's outer fieldset.
+   */
+  public static function validateWidget(array &$element, FormStateInterface $form_state, array &$complete_form) {
+    if (!isset($element['shapes'])) {
+      return;
+    }
+    foreach (Element::children($element['shapes']) as $n) {
+      if (!is_numeric($n)) {
+        continue;
+      }
+      $shape = &$element['shapes'][$n];
+      $shape_type = $shape['shape_type']['#value'] ?? 'Point';
+
+      if ($shape_type === 'Point') {
+        if (!isset($shape['coordinates'])) {
+          continue;
+        }
+        $lat = trim((string) ($shape['coordinates']['lat']['#value'] ?? ''));
+        $lon = trim((string) ($shape['coordinates']['lon']['#value'] ?? ''));
+        if (($lat === '') xor ($lon === '')) {
+          $form_state->setError($shape['coordinates'], t('Point @n: enter both a latitude and a longitude.', ['@n' => $n + 1]));
+        }
+        continue;
+      }
+
+      if (!isset($shape['vertices'])) {
+        continue;
+      }
+      foreach (Element::children($shape['vertices']) as $v) {
+        if (!is_numeric($v)) {
+          continue;
+        }
+        $vertex = &$shape['vertices'][$v];
+        if (!isset($vertex['coordinates'])) {
+          continue;
+        }
+        $lat = trim((string) ($vertex['coordinates']['lat']['#value'] ?? ''));
+        $lon = trim((string) ($vertex['coordinates']['lon']['#value'] ?? ''));
+        if (($lat === '') xor ($lon === '')) {
+          $form_state->setError($vertex['coordinates'], t('Shape @n, vertex @v: enter both a latitude and a longitude.', ['@n' => $n + 1, '@v' => $v + 1]));
+        }
+      }
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function massageFormValues(array $values, array $form, FormStateInterface $form_state) {
+    foreach ($values as $delta => $value) {
+      $submitted = is_array($value['value'] ?? NULL) ? $value['value'] : [];
+
+      if (!empty($submitted['raw_passthrough'])) {
+        $values[$delta]['value'] = $submitted['raw_passthrough'];
+        continue;
+      }
+
+      $features = [];
+      foreach (($submitted['preserved_features'] ?? []) as $index => $feature) {
+        if (is_array($feature)) {
+          $features[(int) $index] = $feature;
+        }
+      }
+      $next_index = $features ? max(array_keys($features)) + 1 : 0;
+
+      foreach (($submitted['shapes'] ?? []) as $key => $shape_row) {
+        if (!is_numeric($key) || !is_array($shape_row)) {
+          continue;
+        }
+        $shape_type = $shape_row['shape_type'] ?? 'Point';
+
+        if ($shape_type === 'Point') {
+          $lat = trim((string) ($shape_row['coordinates']['lat'] ?? ''));
+          $lon = trim((string) ($shape_row['coordinates']['lon'] ?? ''));
+          if ($lat === '' || $lon === '' || !is_numeric($lat) || !is_numeric($lon)) {
+            // Empty row: nothing to save (deleted or never filled in).
+            continue;
+          }
+          $coordinates = [(float) $lon, (float) $lat];
+        }
+        else {
+          $vertices = [];
+          foreach (($shape_row['vertices'] ?? []) as $vkey => $vertex_row) {
+            if (!is_numeric($vkey) || !is_array($vertex_row)) {
+              continue;
+            }
+            $vlat = trim((string) ($vertex_row['coordinates']['lat'] ?? ''));
+            $vlon = trim((string) ($vertex_row['coordinates']['lon'] ?? ''));
+            if ($vlat === '' || $vlon === '' || !is_numeric($vlat) || !is_numeric($vlon)) {
+              continue;
+            }
+            $vertices[] = [(float) $vlon, (float) $vlat];
+          }
+
+          // Under-populated shapes are dropped silently rather than
+          // blocked with a validation error, mirroring how an empty Point
+          // row is already silently skipped above.
+          $min_vertices = $shape_type === 'Polygon' ? 3 : 2;
+          if (count($vertices) < $min_vertices) {
+            continue;
+          }
+
+          if ($shape_type === 'Polygon') {
+            // Explicitly close the ring - this must happen here regardless
+            // of geoPHP's own leniency, since the JSON is read directly by
+            // MukurtuLeafletFormatter and the map widget's JS.
+            $vertices[] = $vertices[0];
+            $coordinates = [$vertices];
+          }
+          else {
+            $coordinates = $vertices;
+          }
+        }
+
+        $feature = is_array($shape_row['source_feature'] ?? NULL) ? $shape_row['source_feature'] : ['type' => 'Feature', 'properties' => []];
+        $feature['type'] = 'Feature';
+        $feature['geometry'] = [
+          'type' => $shape_type,
+          'coordinates' => $coordinates,
+        ];
+        $properties = is_array($feature['properties'] ?? NULL) ? $feature['properties'] : [];
+        $description = trim((string) ($shape_row['location_description'] ?? ''));
+        if ($description !== '') {
+          $properties['location_description'] = $description;
+        }
+        else {
+          unset($properties['location_description']);
+        }
+        // json_encode([]) produces "[]", not the "{}" a GeoJSON properties
+        // object requires; cast an empty array so it encodes as an object.
+        $feature['properties'] = $properties ?: new \stdClass();
+
+        $index = isset($shape_row['source_index']) && $shape_row['source_index'] !== NULL
+          ? (int) $shape_row['source_index']
+          : $next_index++;
+        $features[$index] = $feature;
+      }
+
+      ksort($features);
+      // Emit '' (not an empty FeatureCollection) when nothing remains, so
+      // FieldItemList::filterEmptyItems() drops the delta cleanly instead
+      // of tripping the GeoType validation constraint.
+      $values[$delta]['value'] = $features
+        ? json_encode(['type' => 'FeatureCollection', 'features' => array_values($features)])
+        : '';
+    }
+
+    return $values;
+  }
+
+  /**
+   * Parses a stored geofield value into editable shapes (Point, LineString,
+   * or single-ring Polygon), preserved unsupported features, and/or an
+   * unparseable passthrough value.
+   */
+  protected function parseStoredValue($value): array {
+    $result = ['shapes' => [], 'other' => [], 'passthrough' => NULL];
+    if ($value === NULL || $value === '') {
+      return $result;
+    }
+
+    $decoded = json_decode($value, TRUE);
+    if (json_last_error() !== JSON_ERROR_NONE || !is_array($decoded)) {
+      $result['passthrough'] = $value;
+      return $result;
+    }
+
+    if (($decoded['type'] ?? NULL) === 'FeatureCollection' && is_array($decoded['features'] ?? NULL)) {
+      $features = $decoded['features'];
+    }
+    elseif (($decoded['type'] ?? NULL) === 'Feature') {
+      $features = [$decoded];
+    }
+    elseif (isset($decoded['type'], $decoded['coordinates'])) {
+      $features = [['type' => 'Feature', 'properties' => [], 'geometry' => $decoded]];
+    }
+    else {
+      $result['passthrough'] = $value;
+      return $result;
+    }
+
+    foreach ($features as $index => $feature) {
+      if (!is_array($feature)) {
+        $result['other'][$index] = $feature;
+        continue;
+      }
+      $shape = $this->extractEditableShape($feature['geometry'] ?? NULL);
+      if ($shape !== NULL) {
+        $properties = is_array($feature['properties'] ?? NULL) ? $feature['properties'] : [];
+        $result['shapes'][] = [
+          'index' => $index,
+          'type' => $shape['type'],
+          'vertices' => $shape['vertices'],
+          'description' => (string) ($properties['location_description'] ?? ''),
+          'feature' => $feature,
+        ];
+      }
+      else {
+        $result['other'][$index] = $feature;
+      }
+    }
+
+    return $result;
+  }
+
+  /**
+   * Extracts editable vertices from a geometry if it's a Point, LineString,
+   * or single-ring Polygon (no holes); NULL otherwise (multi-part
+   * geometries, polygons with holes, or malformed data - these are
+   * preserved untouched rather than edited here).
+   */
+  protected function extractEditableShape($geometry): ?array {
+    if (!is_array($geometry) || !isset($geometry['type'], $geometry['coordinates']) || !is_array($geometry['coordinates'])) {
+      return NULL;
+    }
+    $type = $geometry['type'];
+    $coordinates = $geometry['coordinates'];
+
+    if ($type === 'Point') {
+      if (count($coordinates) >= 2 && is_numeric($coordinates[0]) && is_numeric($coordinates[1])) {
+        return ['type' => 'Point', 'vertices' => [$this->vertexFromCoordinatePair($coordinates)]];
+      }
+      return NULL;
+    }
+
+    if ($type === 'LineString') {
+      $vertices = $this->verticesFromCoordinateList($coordinates);
+      return $vertices ? ['type' => 'LineString', 'vertices' => $vertices] : NULL;
+    }
+
+    if ($type === 'Polygon' && count($coordinates) === 1 && is_array($coordinates[0])) {
+      $ring = $coordinates[0];
+      // Drop the duplicated closing point before exposing it for editing;
+      // it's re-added on save.
+      if (count($ring) > 1 && $ring[0] == $ring[count($ring) - 1]) {
+        array_pop($ring);
+      }
+      $vertices = $this->verticesFromCoordinateList($ring);
+      return $vertices ? ['type' => 'Polygon', 'vertices' => $vertices] : NULL;
+    }
+
+    return NULL;
+  }
+
+  /**
+   * Converts a single [lon, lat] pair into a vertex array.
+   */
+  protected function vertexFromCoordinatePair(array $pair): array {
+    return ['lon' => (string) $pair[0], 'lat' => (string) $pair[1]];
+  }
+
+  /**
+   * Converts a list of [lon, lat] pairs into vertices, or NULL if any pair
+   * is malformed.
+   */
+  protected function verticesFromCoordinateList($list): ?array {
+    if (!is_array($list) || !$list) {
+      return NULL;
+    }
+    $vertices = [];
+    foreach ($list as $pair) {
+      if (!is_array($pair) || count($pair) < 2 || !is_numeric($pair[0]) || !is_numeric($pair[1])) {
+        return NULL;
+      }
+      $vertices[] = $this->vertexFromCoordinatePair($pair);
+    }
+    return $vertices;
+  }
+
+  /**
+   * Shared logic for the "Add a point/line/polygon" submit handlers.
+   */
+  protected static function addShape(array $form, FormStateInterface $form_state, string $type, int $initial_vertex_count): void {
+    $button = $form_state->getTriggeringElement();
+    // #array_parents: [..., 'value', 'add_point'|'add_line'|'add_polygon'] -
+    // these buttons are direct siblings of 'value' (and of 'shapes'), not
+    // nested inside 'shapes', so 'value' is simply one level up.
+    $value_element = NestedArray::getValue($form, array_slice($button['#array_parents'], 0, -1));
+    $field_name = $value_element['#mukurtu_field_name'];
+    $field_parents = $value_element['#field_parents'];
+
+    $field_state = static::getWidgetState($field_parents, $field_name, $form_state);
+    $field_state['mukurtu_shapes'][] = ['type' => $type, 'vertex_count' => $initial_vertex_count];
+    static::setWidgetState($field_parents, $field_name, $form_state, $field_state);
+
+    $form_state->setRebuild();
+  }
+
+  /**
+   * Submit handler for the "Add a point" button.
+   */
+  public static function addPointShapeSubmit(array $form, FormStateInterface $form_state) {
+    static::addShape($form, $form_state, 'Point', 1);
+  }
+
+  /**
+   * Submit handler for the "Add a line" button.
+   */
+  public static function addLineShapeSubmit(array $form, FormStateInterface $form_state) {
+    static::addShape($form, $form_state, 'LineString', 2);
+  }
+
+  /**
+   * Submit handler for the "Add a polygon" button.
+   */
+  public static function addPolygonShapeSubmit(array $form, FormStateInterface $form_state) {
+    static::addShape($form, $form_state, 'Polygon', 3);
+  }
+
+  /**
+   * Submit handler for a "Remove shape" button.
+   */
+  public static function removeShapeSubmit(array $form, FormStateInterface $form_state) {
+    $button = $form_state->getTriggeringElement();
+    $delta = (int) ($button['#mukurtu_shape_delta'] ?? 0);
+    $array_parents = $button['#array_parents'];
+    $shapes_index = array_search('shapes', $array_parents, TRUE);
+    $shapes_element = NestedArray::getValue($form, array_slice($array_parents, 0, $shapes_index + 1));
+    $value_element = NestedArray::getValue($form, array_slice($array_parents, 0, $shapes_index));
+    $field_name = $value_element['#mukurtu_field_name'];
+    $field_parents = $value_element['#field_parents'];
+
+    $user_input = $form_state->getUserInput();
+    $shapes_input_parents = $shapes_element['#parents'] ?? NULL;
+    if ($shapes_input_parents) {
+      $shapes_input = NestedArray::getValue($user_input, $shapes_input_parents, $exists);
+      if ($exists && is_array($shapes_input)) {
+        unset($shapes_input[$delta]);
+        NestedArray::setValue($user_input, $shapes_input_parents, array_values($shapes_input));
+        $form_state->setUserInput($user_input);
+      }
+    }
+
+    $field_state = static::getWidgetState($field_parents, $field_name, $form_state);
+    if (isset($field_state['mukurtu_shapes'][$delta])) {
+      array_splice($field_state['mukurtu_shapes'], $delta, 1);
+    }
+    unset($field_state['mukurtu_geocoded'][$delta], $field_state['mukurtu_geocode_result'][$delta]);
+    static::setWidgetState($field_parents, $field_name, $form_state, $field_state);
+
+    $form_state->setRebuild();
+  }
+
+  /**
+   * Submit handler for the "Add vertex" button.
+   */
+  public static function addVertexSubmit(array $form, FormStateInterface $form_state) {
+    $button = $form_state->getTriggeringElement();
+    $delta = (int) ($button['#mukurtu_shape_delta'] ?? 0);
+    $array_parents = $button['#array_parents'];
+    $shapes_index = array_search('shapes', $array_parents, TRUE);
+    $value_element = NestedArray::getValue($form, array_slice($array_parents, 0, $shapes_index));
+    $field_name = $value_element['#mukurtu_field_name'];
+    $field_parents = $value_element['#field_parents'];
+
+    $field_state = static::getWidgetState($field_parents, $field_name, $form_state);
+    if (isset($field_state['mukurtu_shapes'][$delta])) {
+      $field_state['mukurtu_shapes'][$delta]['vertex_count'] = ($field_state['mukurtu_shapes'][$delta]['vertex_count'] ?? 1) + 1;
+    }
+    static::setWidgetState($field_parents, $field_name, $form_state, $field_state);
+
+    $form_state->setRebuild();
+  }
+
+  /**
+   * Submit handler for a "Remove vertex" button.
+   */
+  public static function removeVertexSubmit(array $form, FormStateInterface $form_state) {
+    $button = $form_state->getTriggeringElement();
+    $shape_delta = (int) ($button['#mukurtu_shape_delta'] ?? 0);
+    $vertex_delta = (int) ($button['#mukurtu_vertex_delta'] ?? 0);
+    $array_parents = $button['#array_parents'];
+    $shapes_index = array_search('shapes', $array_parents, TRUE);
+    $value_element = NestedArray::getValue($form, array_slice($array_parents, 0, $shapes_index));
+    $field_name = $value_element['#mukurtu_field_name'];
+    $field_parents = $value_element['#field_parents'];
+
+    $vertices_render_parents = array_merge(array_slice($array_parents, 0, $shapes_index + 1), [$shape_delta, 'vertices']);
+    $vertices_element = NestedArray::getValue($form, $vertices_render_parents);
+
+    $user_input = $form_state->getUserInput();
+    $vertices_input_parents = $vertices_element['#parents'] ?? NULL;
+    if ($vertices_input_parents) {
+      $vertices_input = NestedArray::getValue($user_input, $vertices_input_parents, $exists);
+      if ($exists && is_array($vertices_input)) {
+        unset($vertices_input[$vertex_delta]);
+        NestedArray::setValue($user_input, $vertices_input_parents, array_values($vertices_input));
+        $form_state->setUserInput($user_input);
+      }
+    }
+
+    $field_state = static::getWidgetState($field_parents, $field_name, $form_state);
+    if (isset($field_state['mukurtu_shapes'][$shape_delta])) {
+      $field_state['mukurtu_shapes'][$shape_delta]['vertex_count'] = max(0, ($field_state['mukurtu_shapes'][$shape_delta]['vertex_count'] ?? 1) - 1);
+    }
+    unset($field_state['mukurtu_geocoded'][$shape_delta][$vertex_delta]);
+    static::setWidgetState($field_parents, $field_name, $form_state, $field_state);
+
+    $form_state->setRebuild();
+  }
+
+  /**
+   * Shared logic for the "Move vertex up/down" submit handlers - swaps two
+   * adjacent vertices' submitted input, since drag-and-drop reordering
+   * isn't keyboard/screen-reader operable.
+   */
+  protected static function swapVertices(array $form, FormStateInterface $form_state, int $offset): void {
+    $button = $form_state->getTriggeringElement();
+    $vertex_delta = (int) ($button['#mukurtu_vertex_delta'] ?? 0);
+    $other_delta = $vertex_delta + $offset;
+    $shape_delta = (int) ($button['#mukurtu_shape_delta'] ?? 0);
+    $array_parents = $button['#array_parents'];
+    $shapes_index = array_search('shapes', $array_parents, TRUE);
+
+    $vertices_render_parents = array_merge(array_slice($array_parents, 0, $shapes_index + 1), [$shape_delta, 'vertices']);
+    $vertices_element = NestedArray::getValue($form, $vertices_render_parents);
+
+    $user_input = $form_state->getUserInput();
+    $vertices_input_parents = $vertices_element['#parents'] ?? NULL;
+    if ($vertices_input_parents) {
+      $vertices_input = NestedArray::getValue($user_input, $vertices_input_parents, $exists);
+      if ($exists && is_array($vertices_input) && isset($vertices_input[$vertex_delta], $vertices_input[$other_delta])) {
+        $tmp = $vertices_input[$vertex_delta];
+        $vertices_input[$vertex_delta] = $vertices_input[$other_delta];
+        $vertices_input[$other_delta] = $tmp;
+        NestedArray::setValue($user_input, $vertices_input_parents, $vertices_input);
+        $form_state->setUserInput($user_input);
+      }
+    }
+
+    $form_state->setRebuild();
+  }
+
+  /**
+   * Submit handler for a "Move vertex up" button.
+   */
+  public static function moveVertexUpSubmit(array $form, FormStateInterface $form_state) {
+    static::swapVertices($form, $form_state, -1);
+  }
+
+  /**
+   * Submit handler for a "Move vertex down" button.
+   */
+  public static function moveVertexDownSubmit(array $form, FormStateInterface $form_state) {
+    static::swapVertices($form, $form_state, 1);
+  }
+
+  /**
+   * Submit handler for a vertex's "Search" button.
+   *
+   * Runs the geocoding lookup server-side so the search works with or
+   * without JavaScript. The found coordinates are written directly into
+   * $form_state's user input (not just #default_value) because on a
+   * rebuild, FormBuilder::doBuildForm() prefers existing submitted input
+   * (here, the still-empty lat/lon the user hadn't filled in) over
+   * #default_value - #default_value alone would not actually populate
+   * these fields in the browser. shapesAjax() only re-renders the
+   * already-updated state and adds a screen reader announcement.
+   */
+  public static function searchPlaceSubmit(array $form, FormStateInterface $form_state) {
+    $button = $form_state->getTriggeringElement();
+    $shape_delta = (int) ($button['#mukurtu_shape_delta'] ?? 0);
+    $vertex_delta = (int) ($button['#mukurtu_vertex_delta'] ?? 0);
+    $row_parents = array_slice($button['#parents'], 0, -1);
+    $query = trim((string) $form_state->getValue(array_merge($row_parents, ['place_search'])));
+
+    $field_name = $button['#mukurtu_field_name'] ?? NULL;
+    $field_parents = $button['#mukurtu_field_parents'] ?? [];
+
+    if ($query !== '' && $field_name !== NULL) {
+      $field_state = static::getWidgetState($field_parents, $field_name, $form_state);
+      $found = static::geocodeQuery($query);
+
+      if ($found) {
+        $field_state['mukurtu_geocoded'][$shape_delta][$vertex_delta] = $found;
+
+        $user_input = $form_state->getUserInput();
+        $coordinates_parents = array_merge($row_parents, ['coordinates']);
+        NestedArray::setValue($user_input, array_merge($coordinates_parents, ['lat']), $found['lat']);
+        NestedArray::setValue($user_input, array_merge($coordinates_parents, ['lon']), $found['lon']);
+        $form_state->setUserInput($user_input);
+
+        $message = t('Found @query at @lat, @lon. Adjust the coordinates below if needed.', [
+          '@query' => $query,
+          '@lat' => $found['lat'],
+          '@lon' => $found['lon'],
+        ]);
+        \Drupal::messenger()->addStatus($message);
+      }
+      else {
+        $message = t('No matching place found. Try a different search or enter coordinates directly.');
+        \Drupal::messenger()->addWarning($message);
+      }
+      $field_state['mukurtu_geocode_result'][$shape_delta][$vertex_delta] = (string) $message;
+      static::setWidgetState($field_parents, $field_name, $form_state, $field_state);
+    }
+
+    $form_state->setRebuild();
+  }
+
+  /**
+   * Looks up a free-text place name via the site's configured Nominatim
+   * geocoder provider.
+   *
+   * @return array{lat: string, lon: string}|null
+   */
+  protected static function geocodeQuery(string $query): ?array {
+    try {
+      $provider = \Drupal::entityTypeManager()->getStorage('geocoder_provider')->load('nominatim');
+      if (!$provider) {
+        return NULL;
+      }
+      $collection = \Drupal::service('geocoder')->geocode($query, [$provider]);
+      if (!$collection || $collection->isEmpty()) {
+        return NULL;
+      }
+      $coordinates = $collection->first()->getCoordinates();
+      if (!$coordinates) {
+        return NULL;
+      }
+      return [
+        'lat' => (string) round($coordinates->getLatitude(), 6),
+        'lon' => (string) round($coordinates->getLongitude(), 6),
+      ];
+    }
+    catch (\Throwable $e) {
+      \Drupal::logger('mukurtu_core')->warning('Place search failed for query "@query": @message', [
+        '@query' => $query,
+        '@message' => $e->getMessage(),
+      ]);
+      return NULL;
+    }
+  }
+
+  /**
+   * Shared AJAX callback for every shape/vertex button (add/remove shape,
+   * add/remove/move vertex, search) - always replaces the whole shapes
+   * wrapper, which is simple, always correct, and cheap at the scale this
+   * widget is used at.
+   */
+  public static function shapesAjax(array $form, FormStateInterface $form_state) {
+    $button = $form_state->getTriggeringElement();
+    $array_parents = $button['#array_parents'];
+    $last = end($array_parents);
+
+    $response = new AjaxResponse();
+
+    if (in_array($last, ['add_point', 'add_line', 'add_polygon'], TRUE)) {
+      // These buttons are siblings of 'shapes' (both children of 'value'),
+      // not nested inside it.
+      $shapes_parents = array_merge(array_slice($array_parents, 0, -1), ['shapes']);
+    }
+    else {
+      $shapes_index = array_search('shapes', $array_parents, TRUE);
+      if ($shapes_index === FALSE) {
+        return $response;
+      }
+      $shapes_parents = array_slice($array_parents, 0, $shapes_index + 1);
+    }
+
+    $shapes_element = NestedArray::getValue($form, $shapes_parents);
+    $wrapper_id = $shapes_element['#mukurtu_wrapper_id'] ?? NULL;
+
+    if ($wrapper_id) {
+      $response->addCommand(new ReplaceCommand('#' . $wrapper_id, $shapes_element));
+    }
+
+    $shape_count = count(Element::children($shapes_element));
+
+    switch ($last) {
+      case 'add_point':
+      case 'add_line':
+      case 'add_polygon':
+        $response->addCommand(new AnnounceCommand((string) t('Shape added.')));
+        if ($wrapper_id) {
+          $response->addCommand(new InvokeCommand('#' . $wrapper_id . '-shape-' . ($shape_count - 1), 'trigger', ['focus']));
+        }
+        break;
+
+      case 'remove_shape':
+        $response->addCommand(new AnnounceCommand((string) t('Shape removed. @count shapes remain.', ['@count' => $shape_count])));
+        if ($wrapper_id && $shape_count > 0) {
+          $response->addCommand(new InvokeCommand('#' . $wrapper_id . '-shape-0', 'trigger', ['focus']));
+        }
+        break;
+
+      case 'add_vertex':
+        $response->addCommand(new AnnounceCommand((string) t('Vertex added.')));
+        break;
+
+      case 'remove_vertex':
+        $response->addCommand(new AnnounceCommand((string) t('Vertex removed.')));
+        break;
+
+      case 'move_up':
+        $response->addCommand(new AnnounceCommand((string) t('Vertex moved up.')));
+        break;
+
+      case 'move_down':
+        $response->addCommand(new AnnounceCommand((string) t('Vertex moved down.')));
+        break;
+
+      case 'search':
+        $field_name = $button['#mukurtu_field_name'] ?? NULL;
+        $field_parents = $button['#mukurtu_field_parents'] ?? [];
+        $shape_delta = (int) ($button['#mukurtu_shape_delta'] ?? 0);
+        $vertex_delta = (int) ($button['#mukurtu_vertex_delta'] ?? 0);
+        if ($field_name !== NULL) {
+          $field_state = static::getWidgetState($field_parents, $field_name, $form_state);
+          $outcome = $field_state['mukurtu_geocode_result'][$shape_delta][$vertex_delta] ?? NULL;
+          if ($outcome) {
+            $response->addCommand(new AnnounceCommand($outcome));
+          }
+        }
+        break;
+    }
+
+    return $response;
+  }
+
+}

--- a/modules/mukurtu_core/src/Plugin/Field/FieldWidget/GeofieldMukurtuWidget.php
+++ b/modules/mukurtu_core/src/Plugin/Field/FieldWidget/GeofieldMukurtuWidget.php
@@ -92,6 +92,21 @@ class GeofieldMukurtuWidget extends LeafletDefaultWidget {
     // LeafletDefaultWidget smashes our default value. We want to keep
     // our GeoJSON untouched.
     $element['value']['#default_value'] = $items[$delta]->value ?: NULL;
+
+    // Visually-hidden instructions for keyboard/screen reader users,
+    // referenced by the map container's aria-describedby (set in
+    // mukurtu-leaflet-widget.js) - placing a new point still requires a
+    // pointing device, so this points to the accessible alternative.
+    if (!empty($element['map']['#map_id'])) {
+      $element['keyboard_instructions'] = [
+        '#type' => 'markup',
+        '#markup' => '<p id="' . $element['map']['#map_id'] . '-keyboard-instructions" class="visually-hidden">'
+          . $this->t('Use the arrow keys to pan the map and the plus and minus keys to zoom. Tab reaches the toolbar buttons. While drawing, press Escape to cancel or Enter to finish a shape. Existing points are reachable by Tab; press Enter to open a point and edit its description. Placing a new point requires a pointing device - use the "Mukurtu Map Points (latitude/longitude)" widget for a keyboard-only alternative.')
+          . '</p>',
+        '#weight' => -1,
+      ];
+    }
+
     return $element;
   }
 

--- a/modules/mukurtu_core/tests/src/Kernel/GeofieldMukurtuLatLonWidgetTest.php
+++ b/modules/mukurtu_core/tests/src/Kernel/GeofieldMukurtuLatLonWidgetTest.php
@@ -1,0 +1,353 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\mukurtu_core\Kernel;
+
+use Drupal\Core\Field\BaseFieldDefinition;
+use Drupal\Core\Form\FormState;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\mukurtu_core\Plugin\Field\FieldWidget\GeofieldMukurtuLatLonWidget;
+
+/**
+ * Tests GeofieldMukurtuLatLonWidget's GeoJSON FeatureCollection round trip.
+ *
+ * field_coverage stores a raw GeoJSON FeatureCollection (not WKT), where
+ * each Feature may carry a properties.location_description read by
+ * MukurtuLeafletFormatter. These tests guard the parsing/save logic that
+ * has to reproduce that exact shape while never touching geometry this
+ * widget doesn't expose for editing (multi-part geometries, polygons with
+ * holes, legacy WKT).
+ *
+ * @see \Drupal\mukurtu_core\Plugin\Field\FieldWidget\GeofieldMukurtuLatLonWidget
+ * @group mukurtu_core
+ */
+class GeofieldMukurtuLatLonWidgetTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'text',
+    'filter',
+    'node',
+    'geofield',
+    'mukurtu_core',
+  ];
+
+  /**
+   * The widget under test.
+   */
+  protected GeofieldMukurtuLatLonWidget $widget;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $fieldDefinition = BaseFieldDefinition::create('geofield')
+      ->setName('field_coverage')
+      ->setLabel('Map Points');
+
+    $this->widget = \Drupal::service('plugin.manager.field.widget')->createInstance('geofield_mukurtu_latlon', [
+      'field_definition' => $fieldDefinition,
+      'settings' => [],
+      'third_party_settings' => [],
+    ]);
+  }
+
+  /**
+   * Runs massageFormValues() against a fake submitted "value" sub-tree and
+   * returns the resulting stored string.
+   */
+  protected function massage(array $submittedValue): string {
+    $values = [0 => ['value' => $submittedValue]];
+    $result = $this->widget->massageFormValues($values, [], new FormState());
+    return $result[0]['value'];
+  }
+
+  /**
+   * Invokes the protected parseStoredValue() method directly.
+   */
+  protected function parseStored(?string $value): array {
+    $method = new \ReflectionMethod($this->widget, 'parseStoredValue');
+    $method->setAccessible(TRUE);
+    return $method->invoke($this->widget, $value);
+  }
+
+  /**
+   * Builds a submitted Point shape row.
+   */
+  protected function pointShape(string $lat, string $lon, string $description = '', array $sourceFeature = ['type' => 'Feature', 'properties' => []], $sourceIndex = NULL): array {
+    return [
+      'shape_type' => 'Point',
+      'coordinates' => ['lat' => $lat, 'lon' => $lon],
+      'location_description' => $description,
+      'source_feature' => $sourceFeature,
+      'source_index' => $sourceIndex,
+    ];
+  }
+
+  /**
+   * Builds a submitted Line/Polygon shape row from a list of [lat, lon]
+   * pairs.
+   */
+  protected function lineOrPolygonShape(string $type, array $latLonPairs, string $description = '', array $sourceFeature = ['type' => 'Feature', 'properties' => []], $sourceIndex = NULL): array {
+    $vertices = [];
+    foreach ($latLonPairs as $i => $pair) {
+      [$lat, $lon] = $pair;
+      $vertices[$i] = ['coordinates' => ['lat' => $lat, 'lon' => $lon]];
+    }
+    return [
+      'shape_type' => $type,
+      'vertices' => $vertices,
+      'location_description' => $description,
+      'source_feature' => $sourceFeature,
+      'source_index' => $sourceIndex,
+    ];
+  }
+
+  public function testSinglePointWithDescription(): void {
+    $decoded = json_decode($this->massage([
+      'preserved_features' => [],
+      'shapes' => [0 => $this->pointShape('46.7298', '-117.1817', 'Pullman, WA')],
+    ]), TRUE);
+
+    $this->assertSame('FeatureCollection', $decoded['type']);
+    $this->assertCount(1, $decoded['features']);
+    $this->assertSame('Point', $decoded['features'][0]['geometry']['type']);
+    // GeoJSON coordinate order is [lon, lat].
+    $this->assertSame([-117.1817, 46.7298], $decoded['features'][0]['geometry']['coordinates']);
+    $this->assertSame('Pullman, WA', $decoded['features'][0]['properties']['location_description']);
+  }
+
+  public function testSinglePointWithoutDescriptionEncodesEmptyPropertiesObject(): void {
+    $json = $this->massage([
+      'preserved_features' => [],
+      'shapes' => [0 => $this->pointShape('46.7298', '-117.1817')],
+    ]);
+
+    // json_encode([]) would produce "[]", which is not a valid GeoJSON
+    // properties object and diverges from what the map widget writes.
+    $this->assertStringContainsString('"properties":{}', $json);
+    $this->assertStringNotContainsString('"properties":[]', $json);
+  }
+
+  public function testMultiplePoints(): void {
+    $decoded = json_decode($this->massage([
+      'preserved_features' => [],
+      'shapes' => [
+        0 => $this->pointShape('1', '2', 'A'),
+        1 => $this->pointShape('3', '4', 'B'),
+      ],
+    ]), TRUE);
+
+    $this->assertCount(2, $decoded['features']);
+    $this->assertSame('A', $decoded['features'][0]['properties']['location_description']);
+    $this->assertSame('B', $decoded['features'][1]['properties']['location_description']);
+  }
+
+  public function testLineStringRoundTrip(): void {
+    $decoded = json_decode($this->massage([
+      'preserved_features' => [],
+      'shapes' => [0 => $this->lineOrPolygonShape('LineString', [
+        ['46.0', '-117.0'],
+        ['46.1', '-117.1'],
+        ['46.2', '-117.2'],
+      ], 'A trail')],
+    ]), TRUE);
+
+    $this->assertCount(1, $decoded['features']);
+    $feature = $decoded['features'][0];
+    $this->assertSame('LineString', $feature['geometry']['type']);
+    // assertEquals, not assertSame: json_encode() drops the ".0" from
+    // whole-number floats, so -117.0 round-trips through JSON as the
+    // integer -117 - numerically identical, but a different PHP type.
+    $this->assertEquals([
+      [-117.0, 46.0],
+      [-117.1, 46.1],
+      [-117.2, 46.2],
+    ], $feature['geometry']['coordinates']);
+    $this->assertSame('A trail', $feature['properties']['location_description']);
+  }
+
+  public function testLineStringWithOnlyOneValidVertexIsDropped(): void {
+    $value = $this->massage([
+      'preserved_features' => [],
+      'shapes' => [0 => $this->lineOrPolygonShape('LineString', [
+        ['46.0', '-117.0'],
+        ['', ''],
+      ])],
+    ]);
+    $this->assertSame('', $value);
+  }
+
+  public function testPolygonRoundTripClosesTheRing(): void {
+    $decoded = json_decode($this->massage([
+      'preserved_features' => [],
+      'shapes' => [0 => $this->lineOrPolygonShape('Polygon', [
+        ['0', '0'],
+        ['0', '1'],
+        ['1', '1'],
+      ], 'A field')],
+    ]), TRUE);
+
+    $this->assertCount(1, $decoded['features']);
+    $feature = $decoded['features'][0];
+    $this->assertSame('Polygon', $feature['geometry']['type']);
+    $ring = $feature['geometry']['coordinates'][0];
+    $this->assertCount(4, $ring);
+    $this->assertSame($ring[0], $ring[3]);
+    $this->assertEquals([0.0, 0.0], $ring[0]);
+    $this->assertEquals([1.0, 0.0], $ring[1]);
+    $this->assertEquals([1.0, 1.0], $ring[2]);
+    $this->assertSame('A field', $feature['properties']['location_description']);
+  }
+
+  public function testPolygonWithOnlyTwoValidVerticesIsDropped(): void {
+    $value = $this->massage([
+      'preserved_features' => [],
+      'shapes' => [0 => $this->lineOrPolygonShape('Polygon', [
+        ['0', '0'],
+        ['0', '1'],
+        ['', ''],
+      ])],
+    ]);
+    $this->assertSame('', $value);
+  }
+
+  public function testNonPointFeaturesArePreservedByteIdenticalOnSave(): void {
+    $polygonWithHole = [
+      'type' => 'Feature',
+      'properties' => ['foo' => 'bar'],
+      'geometry' => [
+        'type' => 'Polygon',
+        'coordinates' => [
+          [[0, 0], [4, 0], [4, 4], [0, 4], [0, 0]],
+          [[1, 1], [2, 1], [2, 2], [1, 2], [1, 1]],
+        ],
+      ],
+    ];
+
+    $decoded = json_decode($this->massage([
+      'preserved_features' => [0 => $polygonWithHole],
+      'shapes' => [1 => $this->pointShape('10', '20', '', ['type' => 'Feature', 'properties' => []], 1)],
+    ]), TRUE);
+
+    $this->assertCount(2, $decoded['features']);
+    $this->assertSame($polygonWithHole, $decoded['features'][0]);
+    $this->assertSame('Point', $decoded['features'][1]['geometry']['type']);
+  }
+
+  public function testMixedFeatureCollectionRoundTripsEachShapeIndependently(): void {
+    $stored = json_encode([
+      'type' => 'FeatureCollection',
+      'features' => [
+        ['type' => 'Feature', 'properties' => ['location_description' => 'Camp'], 'geometry' => ['type' => 'Point', 'coordinates' => [-117.0, 46.0]]],
+        ['type' => 'Feature', 'properties' => ['location_description' => 'Trail'], 'geometry' => ['type' => 'LineString', 'coordinates' => [[-117.0, 46.0], [-117.1, 46.1]]]],
+        ['type' => 'Feature', 'properties' => ['location_description' => 'Field'], 'geometry' => ['type' => 'Polygon', 'coordinates' => [[[0, 0], [0, 1], [1, 1], [0, 0]]]]],
+      ],
+    ]);
+
+    $parsed = $this->parseStored($stored);
+    $this->assertCount(3, $parsed['shapes']);
+    $this->assertSame([], $parsed['other']);
+    $this->assertNull($parsed['passthrough']);
+    $this->assertSame('Point', $parsed['shapes'][0]['type']);
+    $this->assertSame('LineString', $parsed['shapes'][1]['type']);
+    $this->assertSame('Polygon', $parsed['shapes'][2]['type']);
+    $this->assertCount(2, $parsed['shapes'][1]['vertices']);
+    // The closing point is stripped for editing.
+    $this->assertCount(3, $parsed['shapes'][2]['vertices']);
+
+    // Edit only the point; the line and polygon should round-trip
+    // untouched via their preserved source_feature/source_index.
+    $submitted = [
+      'preserved_features' => [],
+      'shapes' => [
+        0 => $this->pointShape('47.0', '-118.0', 'Camp', $parsed['shapes'][0]['feature'], $parsed['shapes'][0]['index']),
+        1 => $this->lineOrPolygonShape('LineString', [['46.0', '-117.0'], ['46.1', '-117.1']], 'Trail', $parsed['shapes'][1]['feature'], $parsed['shapes'][1]['index']),
+        2 => $this->lineOrPolygonShape('Polygon', [['0', '0'], ['1', '0'], ['1', '1']], 'Field', $parsed['shapes'][2]['feature'], $parsed['shapes'][2]['index']),
+      ],
+    ];
+    $decoded = json_decode($this->massage($submitted), TRUE);
+    $this->assertCount(3, $decoded['features']);
+    $this->assertEquals([-118.0, 47.0], $decoded['features'][0]['geometry']['coordinates']);
+    $this->assertSame('LineString', $decoded['features'][1]['geometry']['type']);
+    $this->assertSame('Polygon', $decoded['features'][2]['geometry']['type']);
+  }
+
+  public function testUnrelatedPropertiesSurviveEditingAPoint(): void {
+    $decoded = json_decode($this->massage([
+      'preserved_features' => [],
+      'shapes' => [0 => $this->pointShape('5', '6', '', ['type' => 'Feature', 'properties' => ['foo' => 'bar']], 0)],
+    ]), TRUE);
+
+    $this->assertSame('bar', $decoded['features'][0]['properties']['foo']);
+  }
+
+  public function testLegacyWktValueIsPassedThroughUnchanged(): void {
+    $this->assertSame('POINT(1 2)', $this->massage(['raw_passthrough' => 'POINT(1 2)']));
+  }
+
+  public function testEmptyEverythingProducesEmptyStringNotEmptyCollection(): void {
+    $this->assertSame('', $this->massage(['preserved_features' => [], 'shapes' => []]));
+  }
+
+  public function testGeneratedValueIsLoadableByGeoPhp(): void {
+    $json = $this->massage([
+      'preserved_features' => [],
+      'shapes' => [0 => $this->pointShape('46.7298', '-117.1817')],
+    ]);
+    $geom = \Drupal::service('geofield.geophp')->load($json);
+    $this->assertInstanceOf(\Geometry::class, $geom);
+
+    $polygonJson = $this->massage([
+      'preserved_features' => [],
+      'shapes' => [0 => $this->lineOrPolygonShape('Polygon', [['0', '0'], ['0', '1'], ['1', '1']])],
+    ]);
+    $polygonGeom = \Drupal::service('geofield.geophp')->load($polygonJson);
+    $this->assertInstanceOf(\Geometry::class, $polygonGeom);
+  }
+
+  public function testParseStoredValueSplitsSimpleShapesFromOther(): void {
+    $value = json_encode([
+      'type' => 'FeatureCollection',
+      'features' => [
+        // Polygon with a hole: not simple, preserved untouched.
+        ['type' => 'Feature', 'properties' => [], 'geometry' => ['type' => 'Polygon', 'coordinates' => [
+          [[0, 0], [4, 0], [4, 4], [0, 4], [0, 0]],
+          [[1, 1], [2, 1], [2, 2], [1, 2], [1, 1]],
+        ]]],
+        ['type' => 'Feature', 'properties' => ['location_description' => 'Home'], 'geometry' => ['type' => 'Point', 'coordinates' => [-117.18, 46.73]]],
+        // MultiPoint: not simple, preserved untouched.
+        ['type' => 'Feature', 'properties' => [], 'geometry' => ['type' => 'MultiPoint', 'coordinates' => [[0, 0], [1, 1]]]],
+      ],
+    ]);
+    $parsed = $this->parseStored($value);
+    $this->assertCount(1, $parsed['shapes']);
+    $this->assertCount(2, $parsed['other']);
+    $this->assertNull($parsed['passthrough']);
+    $this->assertSame('Home', $parsed['shapes'][0]['description']);
+  }
+
+  public function testParseStoredValueDetectsPassthroughForWkt(): void {
+    $parsed = $this->parseStored('POINT(1 2)');
+    $this->assertSame('POINT(1 2)', $parsed['passthrough']);
+    $this->assertSame([], $parsed['shapes']);
+  }
+
+  public function testParseStoredValueHandlesEmptyAndNull(): void {
+    foreach ([NULL, ''] as $value) {
+      $parsed = $this->parseStored($value);
+      $this->assertSame([], $parsed['shapes']);
+      $this->assertSame([], $parsed['other']);
+      $this->assertNull($parsed['passthrough']);
+    }
+  }
+
+}

--- a/modules/mukurtu_core/tests/src/Kernel/GeofieldMukurtuLatLonWidgetTest.php
+++ b/modules/mukurtu_core/tests/src/Kernel/GeofieldMukurtuLatLonWidgetTest.php
@@ -35,6 +35,7 @@ class GeofieldMukurtuLatLonWidgetTest extends KernelTestBase {
     'filter',
     'node',
     'geofield',
+    'leaflet',
     'mukurtu_core',
   ];
 

--- a/modules/mukurtu_local_contexts/mukurtu_local_contexts.install
+++ b/modules/mukurtu_local_contexts/mukurtu_local_contexts.install
@@ -772,7 +772,8 @@ function mukurtu_local_contexts_update_10005() {
   /** @var \Drupal\mukurtu_local_contexts\LocalContextsSupportedProjectManager $project_manager */
   $project_manager = \Drupal::service('mukurtu_local_contexts.supported_project_manager');
 
-  $site_api_key = reset($project_manager->getSiteApiKeys()) ?: NULL;
+  $site_api_keys = $project_manager->getSiteApiKeys();
+  $site_api_key = reset($site_api_keys) ?: NULL;
   if (!empty($site_api_key)) {
     $db->update('mukurtu_local_contexts_supported_projects')
       ->fields(['api_key' => $site_api_key])
@@ -799,7 +800,8 @@ function mukurtu_local_contexts_update_10005() {
     if (!$group) {
       continue;
     }
-    $group_api_key = reset($project_manager->getGroupApiKeys($group)) ?: NULL;
+    $group_api_keys = $project_manager->getGroupApiKeys($group);
+    $group_api_key = reset($group_api_keys) ?: NULL;
     if (empty($group_api_key)) {
       continue;
     }

--- a/modules/mukurtu_submissions/src/Form/SubmissionSettingsForm.php
+++ b/modules/mukurtu_submissions/src/Form/SubmissionSettingsForm.php
@@ -574,6 +574,7 @@ class SubmissionSettingsForm extends EntityForm {
         $component = $display->getComponent($field_name) ?: ($default_display->getComponent($field_name) ?: []);
         $component['weight'] = (int) $row['weight'];
         $component = $this->formDisplayManager->applySimpleMediaUploadWidget($field_name, $component, $entity_type_id, $bundle);
+        $component = $this->formDisplayManager->applySubmissionWidgetOverride($field_name, $component, $entity_type_id, $bundle);
         $display->setComponent($field_name, $component);
         if (!empty($row['group'])) {
           $assignments[$field_name] = $row['group'];

--- a/modules/mukurtu_submissions/src/SubmissionFormDisplayManager.php
+++ b/modules/mukurtu_submissions/src/SubmissionFormDisplayManager.php
@@ -24,6 +24,27 @@ use Drupal\mukurtu_submissions\Form\PublicSubmissionForm;
 class SubmissionFormDisplayManager {
 
   /**
+   * Field-type-keyed widget overrides for the public submission form.
+   *
+   * The public form's audience includes keyboard-only and screen reader
+   * visitors, for whom the Leaflet/Geoman map widget (the editorial
+   * default for geofield-type fields) has no accessible equivalent - see
+   * https://github.com/MukurtuCMS/Mukurtu-CMS/issues/1913. Keyed by field
+   * type so it applies to field_coverage (or any other geofield) on every
+   * bundle, regardless of what the bundle's own "default" form display
+   * uses.
+   */
+  const SUBMISSION_WIDGET_OVERRIDES = [
+    'geofield' => [
+      'type' => 'geofield_mukurtu_latlon',
+      'settings' => [
+        'instructions' => '',
+        'show_descriptions' => TRUE,
+      ],
+    ],
+  ];
+
+  /**
    * Administrative/scaffolding content types that ship with the profile
    * for general site-building rather than as community-authored content -
    * visitor submission doesn't make sense for these, so createDefaultForms()
@@ -205,6 +226,7 @@ class SubmissionFormDisplayManager {
       }
       $component = $display->getComponent($field_name) ?: ($default_display->getComponent($field_name) ?: []);
       $component = $this->applySimpleMediaUploadWidget($field_name, $component, $entity_type_id, $bundle);
+      $component = $this->applySubmissionWidgetOverride($field_name, $component, $entity_type_id, $bundle);
       $component = $this->applyParagraphSubmissionMode($field_name, $component, $definition, $visited);
       $display->setComponent($field_name, $component);
     }
@@ -421,6 +443,23 @@ class SubmissionFormDisplayManager {
 
     $component['type'] = 'mukurtu_simple_media_upload';
     $component['settings'] = ['allowed_bundles' => $allowed_bundles];
+    return $component;
+  }
+
+  /**
+   * Applies SUBMISSION_WIDGET_OVERRIDES to a form display component, if the
+   * field's type has an override and the component exists. Leaves the
+   * component alone (does not create one) for a field that isn't yet
+   * included on the display.
+   */
+  public function applySubmissionWidgetOverride(string $field_name, array $component, string $entity_type_id, string $bundle): array {
+    if (!$component) {
+      return $component;
+    }
+    $field_type = $this->entityFieldManager->getFieldDefinitions($entity_type_id, $bundle)[$field_name]?->getType();
+    if ($field_type !== NULL && isset(self::SUBMISSION_WIDGET_OVERRIDES[$field_type])) {
+      return self::SUBMISSION_WIDGET_OVERRIDES[$field_type] + $component;
+    }
     return $component;
   }
 

--- a/modules/mukurtu_submissions/tests/src/Unit/SubmissionWidgetOverrideTest.php
+++ b/modules/mukurtu_submissions/tests/src/Unit/SubmissionWidgetOverrideTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\mukurtu_submissions\Unit;
+
+use Drupal\Core\Entity\EntityDisplayRepositoryInterface;
+use Drupal\Core\Entity\EntityFieldManagerInterface;
+use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Field\FieldDefinitionInterface;
+use Drupal\Tests\UnitTestCase;
+use Drupal\mukurtu_submissions\SubmissionFormDisplayManager;
+
+/**
+ * Tests that the public submission form always gets an accessible widget
+ * for geofield-type fields, regardless of what the bundle's own "default"
+ * form display uses.
+ *
+ * @see \Drupal\mukurtu_submissions\SubmissionFormDisplayManager::applySubmissionWidgetOverride()
+ * @group mukurtu_submissions
+ */
+class SubmissionWidgetOverrideTest extends UnitTestCase {
+
+  /**
+   * Builds a SubmissionFormDisplayManager with mocked dependencies and
+   * invokes applySubmissionWidgetOverride() on it.
+   */
+  protected function applyOverride(array $component, string $fieldType): array {
+    $fieldDefinition = $this->createMock(FieldDefinitionInterface::class);
+    $fieldDefinition->method('getType')->willReturn($fieldType);
+
+    $entityFieldManager = $this->createMock(EntityFieldManagerInterface::class);
+    $entityFieldManager->method('getFieldDefinitions')->willReturn(['field_coverage' => $fieldDefinition]);
+
+    $manager = new SubmissionFormDisplayManager(
+      $this->createMock(EntityDisplayRepositoryInterface::class),
+      $entityFieldManager,
+      $this->createMock(EntityTypeManagerInterface::class),
+      $this->createMock(EntityTypeBundleInfoInterface::class),
+    );
+
+    return $manager->applySubmissionWidgetOverride('field_coverage', $component, 'node', 'digital_heritage');
+  }
+
+  /**
+   * A geofield component (whatever widget the bundle's own display uses)
+   * gets switched to the accessible widget, keeping its weight/region.
+   */
+  public function testGeofieldWidgetIsOverriddenOnTheSubmissionForm(): void {
+    $component = $this->applyOverride([
+      'type' => 'geofield_mukurtu',
+      'weight' => 31,
+      'region' => 'content',
+      'settings' => ['map' => ['leaflet_map' => 'OSM Mapnik']],
+    ], 'geofield');
+
+    $this->assertSame('geofield_mukurtu_latlon', $component['type']);
+    $this->assertSame(31, $component['weight']);
+    $this->assertSame('content', $component['region']);
+  }
+
+  /**
+   * Fields of any other type are left completely alone.
+   */
+  public function testNonGeofieldWidgetsAreLeftAlone(): void {
+    $original = [
+      'type' => 'string_textfield',
+      'weight' => 1,
+      'region' => 'content',
+      'settings' => [],
+    ];
+
+    $this->assertSame($original, $this->applyOverride($original, 'string'));
+  }
+
+  /**
+   * A field with no existing component (e.g. not yet included) is left
+   * alone rather than getting a component created for it.
+   */
+  public function testFieldWithNoExistingComponentIsLeftAlone(): void {
+    $this->assertSame([], $this->applyOverride([], 'geofield'));
+  }
+
+}


### PR DESCRIPTION
## Summary
- Adds a new field widget (`geofield_mukurtu_latlon`) for the `field_coverage` ("Map Points") field: an accessible, keyboard-and-screen-reader-operable lat/lon list editor supporting points, lines, and simple polygons, as an alternative to the Leaflet-Geoman map widget - closes #1913.
- The widget reproduces the exact GeoJSON `FeatureCollection` shape the map widget and `MukurtuLeafletFormatter` already expect, and safely preserves any geometry it doesn't support editing (polygons with holes, multi-part geometries, legacy WKT) untouched.
- Includes an optional Nominatim-backed place search per point/vertex.
- Coexists with the existing map widget - site builders choose per bundle via Manage Form Display. `SubmissionSettingsForm` now always prefers the accessible widget for geofield-type fields on the public submission form, since that audience has no accessible equivalent to the map.
- Also hardens the existing map widget itself: enables Leaflet-Geoman's built-in Escape/Enter keyboard support (shipped but off by default), gives toolbar buttons real accessible names, adds visible focus indicators, and improves popup/marker labeling and focus management.

Stacked on #1890 (targets `272-visitor-submission-workflow`, not `main`) since this widget is primarily motivated by that branch's public submission form.

Should make sure these are all merged in first:

- https://github.com/MukurtuCMS/Mukurtu-CMS/pull/1941
- https://github.com/MukurtuCMS/Mukurtu-CMS/pull/1934

## Pre-merge checklist:

- [x] I have checked for and if required, created update hooks. (None needed - this branch has never merged to main, so no upgrade path exists yet to guard.)
- [ ] I have run an accessibility check, and resolved any issues.
- [x] I have recompiled SCSS if required. (No theme-level SCSS touched - only plain module CSS.)
- [x] I have updated or created CI/CD tests, if required. (16 new kernel tests + 3 unit tests, all passing.)
- [ ] I have updated from `main` and resolved any merge conflicts.
- [x] I have verified that all expected checks pass. (Kernel/unit tests pass locally; verified live in a DDEV environment including a real add-line/add-vertex/remove-shape round trip.)
- [ ] I have run the pr-expert-review skill and resolved all relevant issues.

## Test plan
- [x] Kernel tests: GeoJSON round-trip for points/lines/polygons, ring auto-closure, non-editable geometry preserved byte-identical, legacy WKT passthrough (`GeofieldMukurtuLatLonWidgetTest`)
- [x] Unit test: public submission form always gets the accessible widget for geofield fields (`SubmissionWidgetOverrideTest`)
- [x] Verified live in DDEV: widget renders correctly on both the public submission form and an admin node form, add/remove/move-vertex AJAX flow confirmed against a real built form
- [ ] Manual keyboard-only and screen reader pass (pending - opening as draft until this is done)
- [ ] Accessibility check and PR review skill (pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)