### PR TITLE
Fix: backfill api_key column for sites where update_10001() was silently skipped

### DIFF
--- a/modules/mukurtu_local_contexts/mukurtu_local_contexts.install
+++ b/modules/mukurtu_local_contexts/mukurtu_local_contexts.install
@@ -629,6 +629,81 @@ function mukurtu_local_contexts_update_10004() {
 }
 
 /**
+ * Add the api_key column for sites where update_10001() was silently skipped.
+ *
+ * Before update_10001() was rewritten by #1872 to add this column, that same
+ * hook number belonged to the (now update_10004()) locale/language columns
+ * migration. Any site that already ran updates under that older numbering
+ * has its stored schema version at 10001, so Drupal's update system treats
+ * the current, unrelated update_10001() as already applied and never runs
+ * it, leaving the api_key column missing entirely.
+ *
+ * Such a site did still run update_10002() and update_10003() (both greater
+ * than 10001), so by the time this hook runs, update_10001()'s own backfill
+ * sources are gone: update_10002() already moved the site-wide key from the
+ * single 'site_api_key' config value into the 'site_api_keys' list and
+ * migrated each group's field_local_contexts_api_key to unlimited
+ * cardinality, so the old single-column data update_10001() reads from no
+ * longer exists. Simply re-invoking update_10001() would therefore add the
+ * column but backfill nothing. Instead, backfill from the current storage
+ * locations via the existing supported project manager helpers.
+ */
+function mukurtu_local_contexts_update_10005() {
+  $db = \Drupal::database();
+  $schema = $db->schema();
+
+  if (!$schema->fieldExists('mukurtu_local_contexts_supported_projects', 'api_key')) {
+    $schema->addField('mukurtu_local_contexts_supported_projects', 'api_key', [
+      'type' => 'varchar',
+      'length' => 255,
+      'not null' => FALSE,
+      'description' => 'The Local Contexts Hub API key that added/owns this project, if any.',
+    ]);
+  }
+
+  /** @var \Drupal\mukurtu_local_contexts\LocalContextsSupportedProjectManager $project_manager */
+  $project_manager = \Drupal::service('mukurtu_local_contexts.supported_project_manager');
+
+  $site_api_key = reset($project_manager->getSiteApiKeys()) ?: NULL;
+  if (!empty($site_api_key)) {
+    $db->update('mukurtu_local_contexts_supported_projects')
+      ->fields(['api_key' => $site_api_key])
+      ->condition('type', 'site')
+      ->condition('group_id', 0)
+      ->isNull('api_key')
+      ->execute();
+  }
+
+  $groups = $db->select('mukurtu_local_contexts_supported_projects', 'sp')
+    ->fields('sp', ['type', 'group_id'])
+    ->condition('sp.type', 'site', '<>')
+    ->isNull('sp.api_key')
+    ->distinct()
+    ->execute()
+    ->fetchAll();
+
+  $entity_type_manager = \Drupal::entityTypeManager();
+  foreach ($groups as $row) {
+    if (!$entity_type_manager->hasDefinition($row->type)) {
+      continue;
+    }
+    $group = $entity_type_manager->getStorage($row->type)->load($row->group_id);
+    if (!$group) {
+      continue;
+    }
+    $group_api_key = reset($project_manager->getGroupApiKeys($group)) ?: NULL;
+    if (empty($group_api_key)) {
+      continue;
+    }
+    $db->update('mukurtu_local_contexts_supported_projects')
+      ->fields(['api_key' => $group_api_key])
+      ->condition('type', $row->type)
+      ->condition('group_id', $row->group_id)
+      ->execute();
+  }
+}
+
+/**
  * Add project_id to Local Contexts label translations.
  *
  * Label ids are not unique across projects (unlike notices, which have

--- a/modules/mukurtu_local_contexts/tests/src/Kernel/Update10005Test.php
+++ b/modules/mukurtu_local_contexts/tests/src/Kernel/Update10005Test.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\mukurtu_local_contexts\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\mukurtu_protocol\Entity\Community;
+use Drupal\og\Og;
+use Drupal\user\Entity\User;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Tests mukurtu_local_contexts_update_10005().
+ */
+#[Group('mukurtu_local_contexts')]
+class Update10005Test extends KernelTestBase {
+
+  /**
+   * Test Community.
+   *
+   * @var \Drupal\mukurtu_protocol\Entity\CommunityInterface
+   */
+  protected $community;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'field',
+    'node',
+    'media',
+    'taxonomy',
+    'content_moderation',
+    'workflows',
+    'options',
+    'path_alias',
+    'system',
+    'text',
+    'user',
+    'og',
+    'mukurtu_protocol',
+    'mukurtu_local_contexts',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->installConfig(['og', 'mukurtu_local_contexts']);
+    $this->installEntitySchema('og_membership');
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('taxonomy_term');
+    $this->installEntitySchema('workflow');
+    $this->installEntitySchema('community');
+    $this->installEntitySchema('protocol');
+    $this->installSchema('system', ['sequences']);
+    $this->installSchema('mukurtu_local_contexts', [
+      'mukurtu_local_contexts_supported_projects',
+      'mukurtu_local_contexts_projects',
+      'mukurtu_local_contexts_labels',
+      'mukurtu_local_contexts_notices',
+      'mukurtu_local_contexts_notice_translations',
+      'mukurtu_local_contexts_api_key_labels',
+    ]);
+
+    Og::addGroup('community', 'community');
+
+    $owner = User::create(['name' => $this->randomString()]);
+    $owner->save();
+    $this->community = Community::create([
+      'name' => $this->randomString(),
+      'status' => TRUE,
+      'uid' => $owner->id(),
+    ]);
+    $this->community->save();
+  }
+
+  /**
+   * Seed a project directly in the DB so it can be referenced by ID.
+   */
+  protected function seedProject(string $id, string $title = 'Project'): void {
+    $this->container->get('database')->merge('mukurtu_local_contexts_projects')
+      ->key('id', $id)
+      ->fields([
+        'provider_id' => $id,
+        'title' => $title,
+        'privacy' => 'public',
+        'updated' => 1,
+      ])
+      ->execute();
+  }
+
+  /**
+   * Tests the hook backfills from the current storage locations.
+   *
+   * Simulates a site whose schema version was stuck at 10001 under the old
+   * hook numbering: update_10002() already migrated the site-wide key into
+   * the 'site_api_keys' list and the group key into the group entity's own
+   * field storage, before update_10001() (renamed here to update_10005())
+   * ever got a chance to run and add the api_key column.
+   */
+  public function testUpdateHookBackfillsFromCurrentStorage(): void {
+    require_once __DIR__ . '/../../../mukurtu_local_contexts.install';
+
+    $db = $this->container->get('database');
+    $schema = $db->schema();
+    $schema->dropField('mukurtu_local_contexts_supported_projects', 'api_key');
+
+    $this->seedProject('site-project', 'Site Project');
+    $db->insert('mukurtu_local_contexts_supported_projects')
+      ->fields(['project_id' => 'site-project', 'type' => 'site', 'group_id' => 0])
+      ->execute();
+    \Drupal::configFactory()->getEditable('mukurtu_local_contexts.settings')
+      ->set('site_api_keys', ['site-key-one'])
+      ->save();
+
+    $this->seedProject('group-project', 'Group Project');
+    $db->insert('mukurtu_local_contexts_supported_projects')
+      ->fields(['project_id' => 'group-project', 'type' => 'community', 'group_id' => $this->community->id()])
+      ->execute();
+    $this->community->set('field_local_contexts_api_key', ['group-key-one']);
+    $this->community->save();
+
+    mukurtu_local_contexts_update_10005();
+
+    $this->assertTrue($schema->fieldExists('mukurtu_local_contexts_supported_projects', 'api_key'));
+
+    $site_api_key = $db->select('mukurtu_local_contexts_supported_projects', 'sp')
+      ->fields('sp', ['api_key'])
+      ->condition('type', 'site')
+      ->condition('group_id', 0)
+      ->execute()
+      ->fetchField();
+    $this->assertEquals('site-key-one', $site_api_key);
+
+    $group_api_key = $db->select('mukurtu_local_contexts_supported_projects', 'sp')
+      ->fields('sp', ['api_key'])
+      ->condition('type', 'community')
+      ->condition('group_id', $this->community->id())
+      ->execute()
+      ->fetchField();
+    $this->assertEquals('group-key-one', $group_api_key);
+  }
+
+}


### PR DESCRIPTION
## Summary

- Another tester hit `SQLSTATE[42S22]: Column not found: 1054 Unknown column 'sp.api_key'` when trying to create content, from `LocalContextsSupportedProjectManager::getSiteSupportedProjects()`.
- Root cause is the mirror image of #1914: before PR #1872 renumbered this module's update hooks, `update_10001()` was a different, unrelated hook (the locale/language columns migration, now `update_10004()`). Any site that already ran updates under that old numbering has its stored schema version at exactly `10001`. Drupal's update system only runs hooks with a number *greater* than the stored version, so on those sites the current, unrelated `update_10001()` (which adds the `api_key` column) is treated as already applied and is **silently skipped forever** — leaving the column missing entirely.
- Those same sites *did* run `update_10002()` (renumbering put it at `10002`, which is greater than the stuck `10001`), which already migrated `update_10001()`'s backfill sources: the site-wide key moved from the single `site_api_key` config value into the `site_api_keys` list, and each group's key moved from a single column into unlimited-cardinality field storage. So simply re-invoking `update_10001()` today would add the column but backfill nothing, since the data it reads from is already gone.
- Fix: add `update_10005()`, which adds the column if missing, then backfills any still-`NULL` rows from the *current* storage locations, reusing the existing `LocalContextsSupportedProjectManager::getSiteApiKeys()` / `getGroupApiKeys()` helpers rather than duplicating raw config/entity access.

## Test plan

- [x] Added `Update10005Test` (Kernel test), seeding a site-scoped and a group-scoped (community) supported project with the column dropped, and asserting both get backfilled correctly from `site_api_keys` config and the group's `field_local_contexts_api_key` field respectively.
- [x] Verified manually in an isolated scratch DDEV worktree: the test fails with `Call to undefined function ...update_10005()` against the pre-fix code, and passes (37+ assertions, no failures) with the fix.
- [ ] CI run on this PR (not yet observed — will confirm once checks run).

## Pre-merge checklist:

- [x] I have checked for and if required, created update hooks. (This PR's entire purpose is a new update hook, `update_10005()`.)
- [x] I have run an accessibility check, and resolved any issues. (N/A — no user-facing UI or text changed.)
- [x] I have recompiled SCSS if required. (N/A — no SCSS changed.)
- [x] I have updated or created CI/CD tests, if required.
- [x] I have updated from `main` and resolved any merge conflicts. (Branched directly from `origin/main` tip, which already includes #1914.)
- [ ] I have verified that all expected checks pass. (Verified locally; will confirm once GitHub Actions runs on this PR.)
- [x] I have run the pr-expert-review skill and resolved all relevant issues.