### PR TITLE
Recover orphaned PR #1854: legacy Local Contexts project remap tool

### DIFF
--- a/config/install/user.role.mukurtu_manager.yml
+++ b/config/install/user.role.mukurtu_manager.yml
@@ -45,6 +45,7 @@ dependencies:
     - mukurtu_dictionary
     - mukurtu_export
     - mukurtu_import
+    - mukurtu_local_contexts
     - mukurtu_media
     - mukurtu_multipage_items
     - mukurtu_protocol
@@ -70,6 +71,7 @@ permissions:
   - 'access mukurtu export'
   - 'access mukurtu import'
   - 'access visitors'
+  - 'administer local contexts legacy projects'
   - 'administer mukurtu access denied page'
   - 'administer mukurtu_media configuration'
   - 'administer mukurtu media download settings'

--- a/modules/mukurtu_local_contexts/mukurtu_local_contexts.install
+++ b/modules/mukurtu_local_contexts/mukurtu_local_contexts.install
@@ -786,3 +786,10 @@ function mukurtu_local_contexts_update_40002(): void {
     }
   }
 }
+
+/**
+ * Grant the Mukurtu Manager role access to the legacy project remap tool.
+ */
+function mukurtu_local_contexts_update_10006() {
+  user_role_grant_permissions('mukurtu_manager', ['administer local contexts legacy projects']);
+}

--- a/modules/mukurtu_local_contexts/mukurtu_local_contexts.links.menu.yml
+++ b/modules/mukurtu_local_contexts/mukurtu_local_contexts.links.menu.yml
@@ -11,3 +11,10 @@ mukurtu_local_contexts.site_projects_directory:
   parent: mukurtu_dashboard
   menu_name: dashboard-site-settings
   route_name: mukurtu_local_contexts.site_project_directory
+
+mukurtu_local_contexts.remap_legacy_project_site:
+  title: 'Remap Legacy Projects'
+  description: 'Reassign content off legacy (v3-migrated) Local Contexts projects onto real Local Contexts Hub projects, in bulk.'
+  parent: mukurtu_dashboard
+  menu_name: dashboard-site-settings
+  route_name: mukurtu_local_contexts.remap_legacy_project_site

--- a/modules/mukurtu_local_contexts/mukurtu_local_contexts.links.task.yml
+++ b/modules/mukurtu_local_contexts/mukurtu_local_contexts.links.task.yml
@@ -11,6 +11,11 @@ mukurtu_local_contexts.site_project_directory_settings:
   title: 'Project Directory Settings'
   base_route: mukurtu_local_contexts.manage_site_supported_projects
 
+mukurtu_local_contexts.remap_legacy_project_site:
+  route_name: mukurtu_local_contexts.remap_legacy_project_site
+  title: 'Remap Legacy Projects'
+  base_route: mukurtu_local_contexts.manage_site_supported_projects
+
 ##
 # Local tasks for Communities:
 ##
@@ -19,11 +24,21 @@ mukurtu_local_contexts.manage_community_supported_projects:
   title: 'Manage Projects'
   base_route: mukurtu_local_contexts.manage_community_supported_projects
 
+mukurtu_local_contexts.remap_legacy_project_community:
+  route_name: mukurtu_local_contexts.remap_legacy_project_community
+  title: 'Remap Legacy Projects'
+  base_route: mukurtu_local_contexts.manage_community_supported_projects
+
 ##
 # Local tasks for Contexts:
 ##
 mukurtu_local_contexts.manage_protocol_supported_projects:
   route_name: mukurtu_local_contexts.manage_protocol_supported_projects
   title: 'Manage Projects'
+  base_route: mukurtu_local_contexts.manage_protocol_supported_projects
+
+mukurtu_local_contexts.remap_legacy_project_protocol:
+  route_name: mukurtu_local_contexts.remap_legacy_project_protocol
+  title: 'Remap Legacy Projects'
   base_route: mukurtu_local_contexts.manage_protocol_supported_projects
 

--- a/modules/mukurtu_local_contexts/mukurtu_local_contexts.permissions.yml
+++ b/modules/mukurtu_local_contexts/mukurtu_local_contexts.permissions.yml
@@ -1,0 +1,4 @@
+administer local contexts legacy projects:
+  title: 'Administer legacy Local Contexts project remapping'
+  description: 'Reassign content off legacy (v3-migrated) Local Contexts projects onto real Local Contexts Hub projects, in bulk.'
+  restrict access: true

--- a/modules/mukurtu_local_contexts/mukurtu_local_contexts.routing.yml
+++ b/modules/mukurtu_local_contexts/mukurtu_local_contexts.routing.yml
@@ -28,6 +28,14 @@ mukurtu_local_contexts.site_project_directory_settings:
   requirements:
     _permission: 'administer site configuration'
 
+mukurtu_local_contexts.remap_legacy_project_site:
+  path: '/admin/local-contexts/legacy-projects/remap'
+  defaults:
+    _title: 'Reassign legacy Local Contexts project'
+    _form: 'Drupal\mukurtu_local_contexts\Form\RemapLegacyProjectSite'
+  requirements:
+    _permission: 'administer local contexts legacy projects'
+
 ##
 # Community LC projects (front-end):
 ##
@@ -59,6 +67,18 @@ mukurtu_local_contexts.manage_community_supported_projects:
       group:
         type: community_alias
 
+mukurtu_local_contexts.remap_legacy_project_community:
+  path: '/admin/communities/{group}/local-contexts/legacy-projects/remap'
+  defaults:
+    _title: 'Reassign legacy Local Contexts project'
+    _form: 'Drupal\mukurtu_local_contexts\Form\RemapLegacyProjectGroup'
+  requirements:
+    _permission: 'administer local contexts legacy projects'
+  options:
+    parameters:
+      group:
+        type: entity:community
+
 ##
 # Protocol LC projects (front-end):
 ##
@@ -88,4 +108,16 @@ mukurtu_local_contexts.manage_protocol_supported_projects:
     parameters:
       group:
         type: protocol_alias
+
+mukurtu_local_contexts.remap_legacy_project_protocol:
+  path: '/admin/protocols/{group}/local-contexts/legacy-projects/remap'
+  defaults:
+    _title: 'Reassign legacy Local Contexts project'
+    _form: 'Drupal\mukurtu_local_contexts\Form\RemapLegacyProjectGroup'
+  requirements:
+    _permission: 'administer local contexts legacy projects'
+  options:
+    parameters:
+      group:
+        type: entity:protocol
 

--- a/modules/mukurtu_local_contexts/mukurtu_local_contexts.services.yml
+++ b/modules/mukurtu_local_contexts/mukurtu_local_contexts.services.yml
@@ -2,6 +2,8 @@ services:
   mukurtu_local_contexts.supported_project_manager:
     class: Drupal\mukurtu_local_contexts\LocalContextsSupportedProjectManager
     arguments: ['@database', '@config.factory']
+  mukurtu_local_contexts.legacy_project_remap_preview_builder:
+    class: Drupal\mukurtu_local_contexts\LegacyProjectRemapPreviewBuilder
   mukurtu_local_contexts.event_subscriber:
     class: Drupal\mukurtu_local_contexts\EventSubscriber\MukurtuLocalContextsProjectReferenceUpdatedSubscriber
     arguments: ['@messenger']

--- a/modules/mukurtu_local_contexts/src/Batch/LegacyProjectRemapBatch.php
+++ b/modules/mukurtu_local_contexts/src/Batch/LegacyProjectRemapBatch.php
@@ -1,0 +1,173 @@
+<?php
+
+namespace Drupal\mukurtu_local_contexts\Batch;
+
+use Drupal\mukurtu_local_contexts\LocalContextsProject;
+
+/**
+ * Batch operation for reassigning content off a legacy Local Contexts project.
+ */
+class LegacyProjectRemapBatch {
+
+  /**
+   * Number of nodes processed per batch pass.
+   */
+  const BATCH_SIZE = 25;
+
+  /**
+   * Batch operation callback.
+   *
+   * @param string $legacyProjectId
+   *   The legacy project ID being reassigned.
+   * @param string $targetProjectId
+   *   The real Hub project ID to reassign to.
+   * @param array $labelMapping
+   *   Legacy label ID/notice type => target label ID/notice type.
+   * @param array $context
+   *   The batch context.
+   */
+  public static function run(string $legacyProjectId, string $targetProjectId, array $labelMapping, array &$context) {
+    if (!isset($context['sandbox']['nids'])) {
+      $legacy = new LocalContextsProject($legacyProjectId);
+      $referencing = $legacy->getReferencingNodeIds();
+
+      $mappedNids = [];
+      foreach ($labelMapping as $legacyId => $targetLabelId) {
+        $mappedNids = array_merge($mappedNids, $referencing['labels_and_notices'][$legacyId] ?? []);
+      }
+
+      $context['sandbox']['nids'] = array_values(array_unique(array_merge($referencing['project'], $mappedNids)));
+      $context['sandbox']['max'] = count($context['sandbox']['nids']);
+      $context['sandbox']['progress'] = 0;
+      $context['results'] += [
+        'legacy_project_id' => $legacyProjectId,
+        'rewritten' => 0,
+        'errors' => 0,
+        'error_log' => [],
+        'skipped_by_id' => [],
+      ];
+    }
+
+    if ($context['sandbox']['max'] === 0) {
+      $context['finished'] = 1;
+      return;
+    }
+
+    $chunk = array_splice($context['sandbox']['nids'], 0, self::BATCH_SIZE);
+    $storage = \Drupal::entityTypeManager()->getStorage('node');
+
+    foreach ($chunk as $nid) {
+      try {
+        $node = $storage->load($nid);
+        if (!$node) {
+          $context['sandbox']['progress']++;
+          continue;
+        }
+        $changed = FALSE;
+
+        if ($node->hasField('field_local_contexts_projects')) {
+          foreach ($node->get('field_local_contexts_projects') as $item) {
+            if ($item->value === $legacyProjectId) {
+              $item->value = $targetProjectId;
+              $changed = TRUE;
+            }
+          }
+        }
+
+        if ($node->hasField('field_local_contexts_labels_and_notices')) {
+          foreach ($node->get('field_local_contexts_labels_and_notices') as $item) {
+            $parts = explode(':', (string) $item->value, 3);
+            if (count($parts) !== 3) {
+              continue;
+            }
+            [$projectId, $labelOrType, $display] = $parts;
+            if ($projectId !== $legacyProjectId) {
+              continue;
+            }
+            if (isset($labelMapping[$labelOrType])) {
+              $item->value = $targetProjectId . ':' . $labelMapping[$labelOrType] . ':' . $display;
+              $changed = TRUE;
+            }
+            else {
+              $context['results']['skipped_by_id'][$labelOrType] = ($context['results']['skipped_by_id'][$labelOrType] ?? 0) + 1;
+            }
+          }
+        }
+
+        if ($changed) {
+          $node->setNewRevision(TRUE);
+          $node->revision_log = t('Reassigned legacy Local Contexts project @legacy to @target.', [
+            '@legacy' => $legacyProjectId,
+            '@target' => $targetProjectId,
+          ]);
+          $node->save();
+          $context['results']['rewritten']++;
+        }
+      }
+      catch (\Throwable $e) {
+        $context['results']['errors']++;
+        $context['results']['error_log'][] = "Node {$nid}: " . $e->getMessage();
+        \Drupal::logger('mukurtu_local_contexts')->error('Legacy project remap failed for node @nid: @message', [
+          '@nid' => $nid,
+          '@message' => $e->getMessage(),
+        ]);
+      }
+      $context['sandbox']['progress']++;
+    }
+
+    $context['finished'] = $context['sandbox']['progress'] / $context['sandbox']['max'];
+  }
+
+  /**
+   * Batch finished callback.
+   *
+   * @param bool $success
+   *   Whether the batch completed without a fatal error.
+   * @param array $results
+   *   The accumulated results from run().
+   */
+  public static function finished($success, array $results) {
+    $messenger = \Drupal::messenger();
+
+    if (!$success) {
+      $messenger->addError(t('The legacy project reassignment did not complete successfully.'));
+      return;
+    }
+
+    if (!empty($results['rewritten'])) {
+      $messenger->addStatus(\Drupal::translation()->formatPlural(
+        $results['rewritten'],
+        '1 node was updated.',
+        '@count nodes were updated.'
+      ));
+    }
+
+    if (!empty($results['skipped_by_id'])) {
+      $legacy = new LocalContextsProject($results['legacy_project_id']);
+      $names = [];
+      foreach (array_merge($legacy->getLabels('tk'), $legacy->getLabels('bc')) as $id => $label) {
+        $names[$id] = $label['name'];
+      }
+      foreach ($legacy->getNotices() as $notice) {
+        $names[$notice['notice_type']] = $notice['name'];
+      }
+
+      $lines = [];
+      foreach ($results['skipped_by_id'] as $id => $count) {
+        $lines[] = ($names[$id] ?? $id) . " ({$count})";
+      }
+      $messenger->addWarning(t('Some content still references unmapped labels/notices and was left as-is: @list', [
+        '@list' => implode(', ', $lines),
+      ]));
+    }
+
+    if (!empty($results['errors'])) {
+      $messenger->addError(\Drupal::translation()->formatPlural(
+        $results['errors'],
+        '1 node failed to update; see the logs for details.',
+        '@count nodes failed to update; see the logs for details.'
+      ));
+    }
+  }
+
+}

--- a/modules/mukurtu_local_contexts/src/Form/RemapLegacyProjectBase.php
+++ b/modules/mukurtu_local_contexts/src/Form/RemapLegacyProjectBase.php
@@ -1,0 +1,339 @@
+<?php
+
+namespace Drupal\mukurtu_local_contexts\Form;
+
+use Drupal\Core\Batch\BatchBuilder;
+use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\mukurtu_local_contexts\Batch\LegacyProjectRemapBatch;
+use Drupal\mukurtu_local_contexts\LegacyProjectRemapPreviewBuilder;
+use Drupal\mukurtu_local_contexts\LocalContextsProject;
+use Drupal\mukurtu_local_contexts\LocalContextsSupportedProjectManager;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Provides a Local Contexts form for remapping a legacy project.
+ *
+ * A 3-step wizard: select the legacy project and its real-project target,
+ * optionally map individual legacy labels/notices to real ones, preview the
+ * exact content that will change, then confirm and run the batch.
+ */
+abstract class RemapLegacyProjectBase extends FormBase {
+
+  /**
+   * Constructs the form with dependencies.
+   *
+   * @param \Drupal\mukurtu_local_contexts\LocalContextsSupportedProjectManager $supportedProjectManager
+   *   The Local Contexts supported project manager.
+   * @param \Drupal\mukurtu_local_contexts\LegacyProjectRemapPreviewBuilder $previewBuilder
+   *   The legacy project remap preview builder.
+   */
+  public function __construct(
+    protected LocalContextsSupportedProjectManager $supportedProjectManager,
+    protected LegacyProjectRemapPreviewBuilder $previewBuilder,
+  ) {
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container): static {
+    return new static(
+      $container->get('mukurtu_local_contexts.supported_project_manager'),
+      $container->get('mukurtu_local_contexts.legacy_project_remap_preview_builder'),
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $form['#tree'] = TRUE;
+    $step = $form_state->get('step') ?? 'select';
+
+    switch ($step) {
+      case 'map':
+        return $this->buildMapStep($form, $form_state);
+
+      case 'preview':
+        return $this->buildPreviewStep($form, $form_state);
+
+      default:
+        return $this->buildSelectStep($form, $form_state);
+    }
+  }
+
+  /**
+   * Step 1: pick the legacy project to reassign and its real-project target.
+   */
+  protected function buildSelectStep(array $form, FormStateInterface $form_state) {
+    $group = $form_state->get('group');
+
+    $legacyProjects = $group
+      ? $this->supportedProjectManager->getGroupSupportedProjects($group)
+      : $this->supportedProjectManager->getSiteSupportedProjects();
+    $legacyProjects = array_filter(
+      $legacyProjects,
+      fn ($id) => $this->supportedProjectManager->isLegacyProjectId((string) $id),
+      ARRAY_FILTER_USE_KEY
+    );
+
+    $targetProjects = array_filter(
+      $this->supportedProjectManager->getAllProjects(),
+      fn ($id) => !$this->supportedProjectManager->isLegacyProjectId((string) $id),
+      ARRAY_FILTER_USE_KEY
+    );
+
+    $legacyOptions = [];
+    foreach ($legacyProjects as $id => $project) {
+      $legacyOptions[$id] = $project['title'];
+    }
+
+    $targetOptions = [];
+    foreach ($targetProjects as $id => $project) {
+      $targetOptions[$id] = $this->t('@title (@scope)', [
+        '@title' => $project['title'],
+        '@scope' => $this->describeScope($project['type'], (int) $project['group_id']),
+      ]);
+    }
+
+    $form['legacy_project_id'] = [
+      '#type' => 'radios',
+      '#title' => $this->t('Legacy project to reassign'),
+      '#description' => $this->t("Legacy projects come from your v3 migration. 'Default' labels were never customized; 'Sitewide' labels were customized at the site level; a community-specific project appears only if that community customized its own labels in v3."),
+      '#options' => $legacyOptions,
+      '#default_value' => $form_state->get('legacy_project_id'),
+      '#required' => TRUE,
+    ];
+
+    $form['target_project_id'] = [
+      '#type' => 'radios',
+      '#title' => $this->t('Target Local Contexts Hub project'),
+      '#options' => $targetOptions,
+      '#default_value' => $form_state->get('target_project_id'),
+      '#required' => TRUE,
+    ];
+
+    $form['actions'] = ['#type' => 'actions'];
+    $form['actions']['next'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Next: Map Labels'),
+      '#button_type' => 'primary',
+      '#gin_action_item' => TRUE,
+      '#submit' => ['::submitSelect'],
+    ];
+
+    return $form;
+  }
+
+  /**
+   * Describes the scope a supported project belongs to, for display.
+   */
+  protected function describeScope(string $type, int $group_id) {
+    if ($type === 'site') {
+      return $this->t('Site');
+    }
+    $entity = \Drupal::entityTypeManager()->getStorage($type)->load($group_id);
+    return $entity ? $entity->label() : $this->t('@type #@id', ['@type' => $type, '@id' => $group_id]);
+  }
+
+  /**
+   * Submit handler for the "select" step.
+   */
+  public function submitSelect(array &$form, FormStateInterface $form_state) {
+    $form_state->set('legacy_project_id', $form_state->getValue('legacy_project_id'));
+    $form_state->set('target_project_id', $form_state->getValue('target_project_id'));
+    $form_state->set('step', 'map');
+    $form_state->setRebuild();
+  }
+
+  /**
+   * Step 2: optionally map individual legacy labels/notices to real ones.
+   */
+  protected function buildMapStep(array $form, FormStateInterface $form_state) {
+    $legacy = new LocalContextsProject($form_state->get('legacy_project_id'));
+    $target = new LocalContextsProject($form_state->get('target_project_id'));
+
+    $form['heading'] = [
+      '#type' => 'html_tag',
+      '#tag' => 'h2',
+      '#value' => $this->t('Map legacy labels and notices to their real Hub equivalents (optional)'),
+    ];
+
+    $form['mapping'] = [
+      '#type' => 'table',
+      '#header' => [$this->t('Legacy label/notice'), $this->t('Map to')],
+    ];
+
+    $skipOption = ['' => $this->t('— Skip (leave unmapped) —')];
+
+    foreach (['tk', 'bc'] as $kind) {
+      foreach ($legacy->getLabels($kind) as $id => $label) {
+        $this->addMappingRow($form, $form_state, $id, $label['name'], $skipOption + $this->labelOptions($target->getLabels($kind)));
+      }
+    }
+
+    $targetNoticeOptions = [];
+    foreach ($target->getNotices() as $notice) {
+      $targetNoticeOptions[$notice['notice_type']] = $notice['name'];
+    }
+    foreach ($legacy->getNotices() as $notice) {
+      $this->addMappingRow($form, $form_state, $notice['notice_type'], $notice['name'], $skipOption + $targetNoticeOptions);
+    }
+
+    $form['actions'] = ['#type' => 'actions'];
+    $form['actions']['back'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Back'),
+      '#submit' => ['::submitMapBack'],
+      '#limit_validation_errors' => [],
+    ];
+    $form['actions']['preview'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Preview'),
+      '#button_type' => 'primary',
+      '#gin_action_item' => TRUE,
+      '#submit' => ['::submitMap'],
+    ];
+
+    return $form;
+  }
+
+  /**
+   * Adds one row to the label/notice mapping table.
+   */
+  protected function addMappingRow(array &$form, FormStateInterface $form_state, string $id, string $name, array $options): void {
+    $form['mapping'][$id]['name'] = ['#markup' => $name];
+    $form['mapping'][$id]['target'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Map @name to', ['@name' => $name]),
+      '#title_display' => 'invisible',
+      '#options' => $options,
+      '#default_value' => $form_state->get(['label_mapping', $id]) ?? '',
+    ];
+  }
+
+  /**
+   * Flattens a label/notice list (keyed by ID) into an options array.
+   */
+  protected function labelOptions(array $labels): array {
+    $options = [];
+    foreach ($labels as $id => $label) {
+      $options[$id] = $label['name'];
+    }
+    return $options;
+  }
+
+  /**
+   * Submit handler for the "map" step.
+   */
+  public function submitMap(array &$form, FormStateInterface $form_state) {
+    $mapping = [];
+    foreach ($form_state->getValue('mapping', []) as $id => $row) {
+      if ($row['target'] !== '') {
+        $mapping[$id] = $row['target'];
+      }
+    }
+    $form_state->set('label_mapping', $mapping);
+    $form_state->set('step', 'preview');
+    $form_state->setRebuild();
+  }
+
+  /**
+   * Submit handler to go back from the "map" step to "select".
+   */
+  public function submitMapBack(array &$form, FormStateInterface $form_state) {
+    $form_state->set('step', 'select');
+    $form_state->setRebuild();
+  }
+
+  /**
+   * Step 3: preview the affected content, then confirm and run the batch.
+   */
+  protected function buildPreviewStep(array $form, FormStateInterface $form_state) {
+    $legacyId = $form_state->get('legacy_project_id');
+    $targetId = $form_state->get('target_project_id');
+    $mapping = $form_state->get('label_mapping') ?? [];
+
+    $preview = $this->previewBuilder->build($legacyId, $targetId, $mapping);
+
+    $form['heading'] = [
+      '#type' => 'html_tag',
+      '#tag' => 'h2',
+      '#value' => $this->t('Preview: content that will be reassigned'),
+    ];
+
+    $rows = [];
+    foreach ($preview['rows'] as $row) {
+      $rows[] = [
+        $row['id'] === NULL ? $this->t('Whole-project reference') : $row['label'],
+        count($row['nids']),
+        $row['mapped'] ? $this->t('Will be reassigned') : $this->t('Will be skipped — map this label to include it'),
+      ];
+    }
+
+    $form['preview'] = [
+      '#type' => 'table',
+      '#header' => [$this->t('Reference'), $this->t('Nodes affected'), $this->t('Outcome')],
+      '#rows' => $rows,
+      '#empty' => $this->t('No content currently references this legacy project.'),
+    ];
+
+    $form['summary'] = [
+      '#type' => 'html_tag',
+      '#tag' => 'p',
+      '#value' => $this->t('@count distinct nodes will be updated. (Row counts may overlap since a node can be referenced more than one way.)', ['@count' => $preview['total']]),
+    ];
+
+    $form['actions'] = ['#type' => 'actions'];
+    $form['actions']['back'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Back to mapping'),
+      '#submit' => ['::submitPreviewBack'],
+      '#limit_validation_errors' => [],
+    ];
+    $form['actions']['confirm'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Confirm & Run Batch'),
+      '#button_type' => 'primary',
+      '#gin_action_item' => TRUE,
+      '#submit' => ['::submitConfirm'],
+      '#access' => $preview['total'] > 0,
+    ];
+
+    return $form;
+  }
+
+  /**
+   * Submit handler to go back from the "preview" step to "map".
+   */
+  public function submitPreviewBack(array &$form, FormStateInterface $form_state) {
+    $form_state->set('step', 'map');
+    $form_state->setRebuild();
+  }
+
+  /**
+   * Submit handler that dispatches the batch operation.
+   */
+  public function submitConfirm(array &$form, FormStateInterface $form_state) {
+    $legacyId = $form_state->get('legacy_project_id');
+    $targetId = $form_state->get('target_project_id');
+    $mapping = $form_state->get('label_mapping') ?? [];
+
+    $batch = (new BatchBuilder())
+      ->setTitle($this->t('Reassigning legacy Local Contexts project…'))
+      ->setProgressMessage('')
+      ->addOperation([LegacyProjectRemapBatch::class, 'run'], [$legacyId, $targetId, $mapping])
+      ->setFinishCallback([LegacyProjectRemapBatch::class, 'finished']);
+    batch_set($batch->toArray());
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    // Submission is fully handled by the step-specific #submit handlers
+    // above; this exists only to satisfy FormBase's abstract method.
+  }
+
+}

--- a/modules/mukurtu_local_contexts/src/Form/RemapLegacyProjectGroup.php
+++ b/modules/mukurtu_local_contexts/src/Form/RemapLegacyProjectGroup.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Drupal\mukurtu_local_contexts\Form;
+
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Provides a form for remapping a community/protocol legacy Local Contexts
+ * project.
+ */
+class RemapLegacyProjectGroup extends RemapLegacyProjectBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'mukurtu_local_contexts_remap_legacy_project_group';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state, ?ContentEntityInterface $group = NULL) {
+    $form_state->set('group', $group);
+    return parent::buildForm($form, $form_state);
+  }
+
+}

--- a/modules/mukurtu_local_contexts/src/Form/RemapLegacyProjectSite.php
+++ b/modules/mukurtu_local_contexts/src/Form/RemapLegacyProjectSite.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Drupal\mukurtu_local_contexts\Form;
+
+/**
+ * Provides a form for remapping a site-wide legacy Local Contexts project.
+ */
+class RemapLegacyProjectSite extends RemapLegacyProjectBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'mukurtu_local_contexts_remap_legacy_project_site';
+  }
+
+}

--- a/modules/mukurtu_local_contexts/src/LegacyProjectRemapPreviewBuilder.php
+++ b/modules/mukurtu_local_contexts/src/LegacyProjectRemapPreviewBuilder.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Drupal\mukurtu_local_contexts;
+
+/**
+ * Computes the affected-content breakdown for a legacy project remap.
+ */
+class LegacyProjectRemapPreviewBuilder {
+
+  /**
+   * Build the preview breakdown for a proposed legacy project remap.
+   *
+   * @param string $legacyProjectId
+   *   The legacy project ID being reassigned.
+   * @param string $targetProjectId
+   *   The real Hub project ID content will be reassigned to (unused for the
+   *   breakdown itself, kept for a consistent signature with the batch).
+   * @param array $labelMapping
+   *   An array keyed by legacy label ID or notice type, each value the
+   *   real label ID or notice type on the target project to map to.
+   *
+   * @return array
+   *   An array with keys:
+   *   - 'rows': a list of rows, each an array with 'id' (NULL for the
+   *     whole-project row), 'label' (display name), 'nids' (int[]), and
+   *     'mapped' (bool, always TRUE for the whole-project row).
+   *   - 'total': int, the count of distinct nodes that will actually be
+   *     updated - the whole-project row plus any mapped rows. Unmapped rows
+   *     are informational only and excluded from this count. This is a
+   *     deduplicated union, not a sum of row counts, since a single node can
+   *     be referenced more than one way at once.
+   */
+  public function build(string $legacyProjectId, string $targetProjectId, array $labelMapping): array {
+    $legacy = new LocalContextsProject($legacyProjectId);
+    $referencing = $legacy->getReferencingNodeIds();
+
+    $names = [];
+    foreach (array_merge($legacy->getLabels('tk'), $legacy->getLabels('bc')) as $id => $label) {
+      $names[$id] = $label['name'];
+    }
+    foreach ($legacy->getNotices() as $notice) {
+      $names[$notice['notice_type']] = $notice['name'];
+    }
+
+    $rows = [];
+    $updateNids = [];
+
+    if (!empty($referencing['project'])) {
+      $rows[] = [
+        'id' => NULL,
+        'label' => NULL,
+        'nids' => $referencing['project'],
+        'mapped' => TRUE,
+      ];
+      $updateNids = array_merge($updateNids, $referencing['project']);
+    }
+
+    foreach ($referencing['labels_and_notices'] as $id => $nids) {
+      $mapped = isset($labelMapping[$id]);
+      $rows[] = [
+        'id' => $id,
+        'label' => $names[$id] ?? $id,
+        'nids' => $nids,
+        'mapped' => $mapped,
+      ];
+      if ($mapped) {
+        $updateNids = array_merge($updateNids, $nids);
+      }
+    }
+
+    return [
+      'rows' => $rows,
+      'total' => count(array_unique($updateNids)),
+    ];
+  }
+
+}

--- a/modules/mukurtu_local_contexts/src/LocalContextsProject.php
+++ b/modules/mukurtu_local_contexts/src/LocalContextsProject.php
@@ -464,50 +464,76 @@ class LocalContextsProject extends LocalContextsHubBase {
   }
 
   public function inUse() : bool {
-    // @todo Decide if we should lookup ALL fields of our local contexts types
-    // or if we want to keep things hardwired to just our usage.
+    $referencing = $this->getReferencingNodeIds();
 
-    // Check if any content is using the projects in the projects field.
-    $query = \Drupal::entityQuery('node')
-      ->condition('field_local_contexts_projects', $this->id)
-      ->accessCheck(FALSE);
-    $results = $query->execute();
-    if (!empty($results)) {
+    if (!empty($referencing['project'])) {
       return TRUE;
     }
 
-    $labels = array_merge($this->getLabels("tk"), $this->getLabels("bc"));
-    $notices = $this->getNotices();
-
-    if (!empty($labels)) {
-      // Build the project ID: label ID: 'label' keys.
-      $values = array_map(fn($v) => $this->id . ':' . $v['id'] . ':' . 'label', $labels);
-
-      // Check if any content is using those keys.
-      $query = \Drupal::entityQuery('node')
-        ->condition('field_local_contexts_labels_and_notices', $values, 'IN')
-        ->accessCheck(FALSE);
-      $results = $query->execute();
-      if (!empty($results)) {
-        return TRUE;
-      }
-    }
-    else if (!empty($notices)) {
-      // Build the project ID: notice type: 'notice' keys.
-      $notices = array_keys($notices);
-      $values = array_map(fn($v) => strval($v) . ':' . 'notice', $notices);
-
-      // Check if any content is using those keys.
-      $query = \Drupal::entityQuery('node')
-        ->condition('field_local_contexts_labels_and_notices', $values, 'IN')
-        ->accessCheck(FALSE);
-      $results = $query->execute();
-      if (!empty($results)) {
+    foreach ($referencing['labels_and_notices'] as $nids) {
+      if (!empty($nids)) {
         return TRUE;
       }
     }
 
     return FALSE;
+  }
+
+  /**
+   * Get the IDs of nodes referencing this project.
+   *
+   * Checks both the whole-project field (field_local_contexts_projects) and
+   * the individual label/notice field (field_local_contexts_labels_and_notices),
+   * independently - a project can be referenced via either or both, and
+   * unlike a simple "is this project in use" check, this needs per-label/
+   * notice granularity so callers can tell exactly which references exist.
+   *
+   * @return array
+   *   An array with keys:
+   *   - 'project': int[] of node IDs referencing this project via the
+   *     whole-project field.
+   *   - 'labels_and_notices': array keyed by label ID or notice type (the
+   *     same identifier that appears as the middle segment of a
+   *     "project_id:label_id_or_type:display" field value), each value an
+   *     int[] of node IDs referencing that specific label/notice.
+   */
+  public function getReferencingNodeIds(): array {
+    $referencing = [
+      'project' => [],
+      'labels_and_notices' => [],
+    ];
+
+    $query = \Drupal::entityQuery('node')
+      ->condition('field_local_contexts_projects', $this->id)
+      ->accessCheck(FALSE);
+    $referencing['project'] = array_values($query->execute());
+
+    $labels = array_merge($this->getLabels('tk'), $this->getLabels('bc'));
+    foreach ($labels as $labelId => $label) {
+      $value = $this->id . ':' . $labelId . ':label';
+      $query = \Drupal::entityQuery('node')
+        ->condition('field_local_contexts_labels_and_notices', $value)
+        ->accessCheck(FALSE);
+      $results = array_values($query->execute());
+      if (!empty($results)) {
+        $referencing['labels_and_notices'][$labelId] = $results;
+      }
+    }
+
+    $notices = $this->getNotices();
+    foreach ($notices as $notice) {
+      $type = $notice['notice_type'];
+      $value = $this->id . ':' . $type . ':notice';
+      $query = \Drupal::entityQuery('node')
+        ->condition('field_local_contexts_labels_and_notices', $value)
+        ->accessCheck(FALSE);
+      $results = array_values($query->execute());
+      if (!empty($results)) {
+        $referencing['labels_and_notices'][$type] = $results;
+      }
+    }
+
+    return $referencing;
   }
 
 }

--- a/modules/mukurtu_local_contexts/tests/src/Kernel/LegacyProjectReferencingNodeIdsTest.php
+++ b/modules/mukurtu_local_contexts/tests/src/Kernel/LegacyProjectReferencingNodeIdsTest.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Drupal\Tests\mukurtu_local_contexts\Kernel;
+
+use Drupal\mukurtu_local_contexts\LocalContextsProject;
+use Drupal\node\Entity\Node;
+
+/**
+ * Tests LocalContextsProject::getReferencingNodeIds() and inUse().
+ *
+ * @group mukurtu_local_contexts
+ */
+class LegacyProjectReferencingNodeIdsTest extends LocalContextsTestBase {
+
+  /**
+   * Creates and saves a new test node.
+   */
+  protected function createTestNode(): Node {
+    $node = Node::create([
+      'type' => static::TEST_BUNDLE,
+      'title' => $this->randomString(),
+    ]);
+    $node->save();
+    return $node;
+  }
+
+  /**
+   * A project referenced only via the whole-project field.
+   */
+  public function testProjectFieldOnly() {
+    $this->seedSiteProject('proj_a', 'Project A');
+    $node = $this->createTestNode();
+    $node->set('field_local_contexts_projects', ['proj_a']);
+    $node->save();
+
+    $project = new LocalContextsProject('proj_a');
+    $refs = $project->getReferencingNodeIds();
+
+    $this->assertEquals([(int) $node->id()], $refs['project']);
+    $this->assertEquals([], $refs['labels_and_notices']);
+    $this->assertTrue($project->inUse());
+  }
+
+  /**
+   * A project referenced only via an individual label.
+   */
+  public function testLabelOnly() {
+    $this->seedSiteProject('proj_b', 'Project B');
+    $this->seedLabel('label_1', 'proj_b', 'Label One');
+    $node = $this->createTestNode();
+    $node->set('field_local_contexts_labels_and_notices', ['proj_b:label_1:label']);
+    $node->save();
+
+    $project = new LocalContextsProject('proj_b');
+    $refs = $project->getReferencingNodeIds();
+
+    $this->assertEquals([], $refs['project']);
+    $this->assertEquals(['label_1' => [(int) $node->id()]], $refs['labels_and_notices']);
+    $this->assertTrue($project->inUse());
+  }
+
+  /**
+   * A project referenced only via an individual notice.
+   */
+  public function testNoticeOnly() {
+    $this->seedSiteProject('proj_c', 'Project C');
+    $this->seedNotice('notice_type_1', 'proj_c', 'Notice One');
+    $node = $this->createTestNode();
+    $node->set('field_local_contexts_labels_and_notices', ['proj_c:notice_type_1:notice']);
+    $node->save();
+
+    $project = new LocalContextsProject('proj_c');
+    $refs = $project->getReferencingNodeIds();
+
+    $this->assertEquals([], $refs['project']);
+    $this->assertEquals(['notice_type_1' => [(int) $node->id()]], $refs['labels_and_notices']);
+    $this->assertTrue($project->inUse());
+  }
+
+  /**
+   * Regression test for the `else if` bug in the original inUse(): a
+   * project with both a label reference (on one node) and a notice
+   * reference (on another node) must have BOTH detected, not just the
+   * label.
+   */
+  public function testLabelAndNoticeBothDetected() {
+    $this->seedSiteProject('proj_d', 'Project D');
+    $this->seedLabel('label_2', 'proj_d', 'Label Two');
+    $this->seedNotice('notice_type_2', 'proj_d', 'Notice Two');
+
+    $labelNode = $this->createTestNode();
+    $labelNode->set('field_local_contexts_labels_and_notices', ['proj_d:label_2:label']);
+    $labelNode->save();
+
+    $noticeNode = $this->createTestNode();
+    $noticeNode->set('field_local_contexts_labels_and_notices', ['proj_d:notice_type_2:notice']);
+    $noticeNode->save();
+
+    $project = new LocalContextsProject('proj_d');
+    $refs = $project->getReferencingNodeIds();
+
+    $this->assertEquals([
+      'label_2' => [(int) $labelNode->id()],
+      'notice_type_2' => [(int) $noticeNode->id()],
+    ], $refs['labels_and_notices']);
+    $this->assertTrue($project->inUse());
+  }
+
+  /**
+   * A project with no content referencing it at all.
+   */
+  public function testUnused() {
+    $this->seedSiteProject('proj_e', 'Project E');
+    $project = new LocalContextsProject('proj_e');
+    $refs = $project->getReferencingNodeIds();
+
+    $this->assertEquals([], $refs['project']);
+    $this->assertEquals([], $refs['labels_and_notices']);
+    $this->assertFalse($project->inUse());
+  }
+
+}

--- a/modules/mukurtu_local_contexts/tests/src/Kernel/LegacyProjectRemapBatchTest.php
+++ b/modules/mukurtu_local_contexts/tests/src/Kernel/LegacyProjectRemapBatchTest.php
@@ -1,0 +1,229 @@
+<?php
+
+namespace Drupal\Tests\mukurtu_local_contexts\Kernel;
+
+use Drupal\mukurtu_local_contexts\Batch\LegacyProjectRemapBatch;
+use Drupal\node\Entity\Node;
+
+/**
+ * Tests LegacyProjectRemapBatch::run().
+ *
+ * @group mukurtu_local_contexts
+ */
+class LegacyProjectRemapBatchTest extends LocalContextsTestBase {
+
+  /**
+   * Creates and saves a new test node.
+   */
+  protected function createTestNode(): Node {
+    $node = Node::create([
+      'type' => static::TEST_BUNDLE,
+      'title' => $this->randomString(),
+    ]);
+    $node->save();
+    return $node;
+  }
+
+  /**
+   * A fresh batch context, as the form's first call would provide.
+   */
+  protected function newContext(): array {
+    return ['sandbox' => [], 'results' => []];
+  }
+
+  /**
+   * A straight whole-project field swap.
+   */
+  public function testProjectFieldSwap() {
+    $this->seedSiteProject('legacy_1', 'Legacy One');
+    $node = $this->createTestNode();
+    $node->set('field_local_contexts_projects', ['legacy_1']);
+    $node->save();
+
+    $context = $this->newContext();
+    LegacyProjectRemapBatch::run('legacy_1', 'target_1', [], $context);
+
+    $this->assertEquals(1.0, $context['finished']);
+    $this->assertEquals(1, $context['results']['rewritten']);
+
+    $reloaded = Node::load($node->id());
+    $this->assertEquals(['target_1'], array_column($reloaded->get('field_local_contexts_projects')->getValue(), 'value'));
+  }
+
+  /**
+   * A mapped label is rewritten to its target project + target label.
+   */
+  public function testMappedLabelSwap() {
+    $this->seedSiteProject('legacy_2', 'Legacy Two');
+    $this->seedLabel('legacy_label_a', 'legacy_2', 'Legacy Label A');
+    $node = $this->createTestNode();
+    $node->set('field_local_contexts_labels_and_notices', ['legacy_2:legacy_label_a:label']);
+    $node->save();
+
+    $context = $this->newContext();
+    LegacyProjectRemapBatch::run('legacy_2', 'target_2', ['legacy_label_a' => 'real_label_a'], $context);
+
+    $this->assertEquals(1, $context['results']['rewritten']);
+    $reloaded = Node::load($node->id());
+    $this->assertEquals(['target_2:real_label_a:label'], array_column($reloaded->get('field_local_contexts_labels_and_notices')->getValue(), 'value'));
+  }
+
+  /**
+   * A node referenced only via an unmapped label is left untouched and
+   * isn't even queued for processing.
+   */
+  public function testUnmappedLabelLeftUntouched() {
+    $this->seedSiteProject('legacy_3', 'Legacy Three');
+    $this->seedLabel('legacy_label_b', 'legacy_3', 'Legacy Label B');
+    $node = $this->createTestNode();
+    $node->set('field_local_contexts_labels_and_notices', ['legacy_3:legacy_label_b:label']);
+    $node->save();
+
+    $context = $this->newContext();
+    LegacyProjectRemapBatch::run('legacy_3', 'target_3', [], $context);
+
+    $this->assertEquals(0, $context['results']['rewritten']);
+    $this->assertEquals(0, $context['sandbox']['max']);
+
+    $reloaded = Node::load($node->id());
+    $this->assertEquals(['legacy_3:legacy_label_b:label'], array_column($reloaded->get('field_local_contexts_labels_and_notices')->getValue(), 'value'));
+  }
+
+  /**
+   * Notices are rewritten the same way labels are.
+   */
+  public function testMappedNoticeSwap() {
+    $this->seedSiteProject('legacy_4', 'Legacy Four');
+    $this->seedNotice('legacy_notice_a', 'legacy_4', 'Legacy Notice A');
+    $node = $this->createTestNode();
+    $node->set('field_local_contexts_labels_and_notices', ['legacy_4:legacy_notice_a:notice']);
+    $node->save();
+
+    $context = $this->newContext();
+    LegacyProjectRemapBatch::run('legacy_4', 'target_4', ['legacy_notice_a' => 'real_notice_a'], $context);
+
+    $this->assertEquals(1, $context['results']['rewritten']);
+    $reloaded = Node::load($node->id());
+    $this->assertEquals(['target_4:real_notice_a:notice'], array_column($reloaded->get('field_local_contexts_labels_and_notices')->getValue(), 'value'));
+  }
+
+  /**
+   * A node with one mapped and one unmapped value in the same multi-valued
+   * field - only the mapped one changes, and the node is saved once.
+   */
+  public function testMixedMappedAndUnmappedOnSameNode() {
+    $this->seedSiteProject('legacy_5', 'Legacy Five');
+    $this->seedLabel('mapped_label', 'legacy_5', 'Mapped Label');
+    $this->seedLabel('unmapped_label', 'legacy_5', 'Unmapped Label');
+    $node = $this->createTestNode();
+    $node->set('field_local_contexts_labels_and_notices', [
+      'legacy_5:mapped_label:label',
+      'legacy_5:unmapped_label:label',
+    ]);
+    $node->save();
+
+    $context = $this->newContext();
+    LegacyProjectRemapBatch::run('legacy_5', 'target_5', ['mapped_label' => 'real_label'], $context);
+
+    $this->assertEquals(1, $context['results']['rewritten']);
+    $this->assertEquals(1, $context['results']['skipped_by_id']['unmapped_label']);
+
+    $reloaded = Node::load($node->id());
+    $values = array_column($reloaded->get('field_local_contexts_labels_and_notices')->getValue(), 'value');
+    $this->assertContains('target_5:real_label:label', $values);
+    $this->assertContains('legacy_5:unmapped_label:label', $values);
+  }
+
+  /**
+   * Multi-pass chunking: more nodes than one chunk (BATCH_SIZE = 25) are
+   * all processed exactly once, across multiple calls.
+   */
+  public function testMultiPassChunking() {
+    $this->seedSiteProject('legacy_6', 'Legacy Six');
+    $nodes = [];
+    for ($i = 0; $i < 30; $i++) {
+      $node = $this->createTestNode();
+      $node->set('field_local_contexts_projects', ['legacy_6']);
+      $node->save();
+      $nodes[] = $node;
+    }
+
+    $context = $this->newContext();
+    $passes = 0;
+    do {
+      LegacyProjectRemapBatch::run('legacy_6', 'target_6', [], $context);
+      $passes++;
+    } while ($context['finished'] < 1.0 && $passes < 10);
+
+    $this->assertGreaterThan(1, $passes);
+    $this->assertEquals(1.0, $context['finished']);
+    $this->assertEquals(30, $context['results']['rewritten']);
+
+    foreach ($nodes as $node) {
+      $reloaded = Node::load($node->id());
+      $this->assertEquals(['target_6'], array_column($reloaded->get('field_local_contexts_projects')->getValue(), 'value'));
+    }
+  }
+
+  /**
+   * A legacy project can be remapped across multiple passes as more labels
+   * get mapped over time - later passes must still find and rewrite
+   * remaining legacy-referencing values, anchored on the legacy project ID
+   * within the compound value (not on the whole-project field, which was
+   * never set on this node).
+   */
+  public function testIncrementalPartialRemap() {
+    $this->seedSiteProject('legacy_7', 'Legacy Seven');
+    $this->seedLabel('label_x', 'legacy_7', 'Label X');
+    $this->seedLabel('label_y', 'legacy_7', 'Label Y');
+    $node = $this->createTestNode();
+    $node->set('field_local_contexts_labels_and_notices', [
+      'legacy_7:label_x:label',
+      'legacy_7:label_y:label',
+    ]);
+    $node->save();
+
+    // Pass 1: only map label_x.
+    $context = $this->newContext();
+    LegacyProjectRemapBatch::run('legacy_7', 'target_7', ['label_x' => 'real_x'], $context);
+    $this->assertEquals(1, $context['results']['rewritten']);
+
+    $reloaded = Node::load($node->id());
+    $values = array_column($reloaded->get('field_local_contexts_labels_and_notices')->getValue(), 'value');
+    $this->assertContains('target_7:real_x:label', $values);
+    $this->assertContains('legacy_7:label_y:label', $values);
+
+    // Pass 2: now map label_y too.
+    $context = $this->newContext();
+    LegacyProjectRemapBatch::run('legacy_7', 'target_7', ['label_y' => 'real_y'], $context);
+    $this->assertEquals(1, $context['results']['rewritten']);
+
+    $reloaded = Node::load($node->id());
+    $values = array_column($reloaded->get('field_local_contexts_labels_and_notices')->getValue(), 'value');
+    $this->assertContains('target_7:real_x:label', $values);
+    $this->assertContains('target_7:real_y:label', $values);
+  }
+
+  /**
+   * A node ID that fails to load is skipped gracefully, without being
+   * counted as rewritten or aborting the rest of the batch.
+   */
+  public function testMissingNodeIsSkippedGracefully() {
+    $context = [
+      'sandbox' => ['nids' => [999999], 'max' => 1, 'progress' => 0],
+      'results' => [
+        'legacy_project_id' => 'legacy_8',
+        'rewritten' => 0,
+        'errors' => 0,
+        'error_log' => [],
+        'skipped_by_id' => [],
+      ],
+    ];
+    LegacyProjectRemapBatch::run('legacy_8', 'target_8', [], $context);
+
+    $this->assertEquals(0, $context['results']['rewritten']);
+    $this->assertEquals(0, $context['results']['errors']);
+    $this->assertEquals(1.0, $context['finished']);
+  }
+
+}

--- a/modules/mukurtu_local_contexts/tests/src/Kernel/LegacyProjectRemapPreviewBuilderTest.php
+++ b/modules/mukurtu_local_contexts/tests/src/Kernel/LegacyProjectRemapPreviewBuilderTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Drupal\Tests\mukurtu_local_contexts\Kernel;
+
+use Drupal\mukurtu_local_contexts\LegacyProjectRemapPreviewBuilder;
+use Drupal\node\Entity\Node;
+
+/**
+ * Tests LegacyProjectRemapPreviewBuilder::build().
+ *
+ * @group mukurtu_local_contexts
+ */
+class LegacyProjectRemapPreviewBuilderTest extends LocalContextsTestBase {
+
+  /**
+   * Creates and saves a new test node.
+   */
+  protected function createTestNode(): Node {
+    $node = Node::create([
+      'type' => static::TEST_BUNDLE,
+      'title' => $this->randomString(),
+    ]);
+    $node->save();
+    return $node;
+  }
+
+  /**
+   * Rows are correctly classified as mapped vs. unmapped.
+   */
+  public function testMappedAndUnmappedClassification() {
+    $this->seedSiteProject('legacy_p', 'Legacy P');
+    $this->seedLabel('mapped_label', 'legacy_p', 'Mapped Label');
+    $this->seedLabel('unmapped_label', 'legacy_p', 'Unmapped Label');
+
+    $mappedNode = $this->createTestNode();
+    $mappedNode->set('field_local_contexts_labels_and_notices', ['legacy_p:mapped_label:label']);
+    $mappedNode->save();
+
+    $unmappedNode = $this->createTestNode();
+    $unmappedNode->set('field_local_contexts_labels_and_notices', ['legacy_p:unmapped_label:label']);
+    $unmappedNode->save();
+
+    $builder = new LegacyProjectRemapPreviewBuilder();
+    $preview = $builder->build('legacy_p', 'target_p', ['mapped_label' => 'real_label']);
+
+    $rowsById = [];
+    foreach ($preview['rows'] as $row) {
+      $rowsById[$row['id']] = $row;
+    }
+
+    $this->assertTrue($rowsById['mapped_label']['mapped']);
+    $this->assertFalse($rowsById['unmapped_label']['mapped']);
+    $this->assertEquals(1, $preview['total']);
+  }
+
+  /**
+   * A node with both a whole-project reference and a mapped label
+   * reference must count once in the headline total, not twice, even
+   * though it appears in two rows.
+   */
+  public function testHeadlineTotalIsDeduplicated() {
+    $this->seedSiteProject('legacy_q', 'Legacy Q');
+    $this->seedLabel('mapped_label_q', 'legacy_q', 'Mapped Label Q');
+
+    $node = $this->createTestNode();
+    $node->set('field_local_contexts_projects', ['legacy_q']);
+    $node->set('field_local_contexts_labels_and_notices', ['legacy_q:mapped_label_q:label']);
+    $node->save();
+
+    $builder = new LegacyProjectRemapPreviewBuilder();
+    $preview = $builder->build('legacy_q', 'target_q', ['mapped_label_q' => 'real_label_q']);
+
+    $rowCountSum = array_sum(array_map(fn ($row) => count($row['nids']), $preview['rows']));
+    $this->assertEquals(2, $rowCountSum);
+    $this->assertEquals(1, $preview['total']);
+  }
+
+  /**
+   * A project with no referencing content produces an empty preview.
+   */
+  public function testNoReferences() {
+    $this->seedSiteProject('legacy_r', 'Legacy R');
+    $builder = new LegacyProjectRemapPreviewBuilder();
+    $preview = $builder->build('legacy_r', 'target_r', []);
+
+    $this->assertEquals([], $preview['rows']);
+    $this->assertEquals(0, $preview['total']);
+  }
+
+}

--- a/modules/mukurtu_local_contexts/tests/src/Kernel/LocalContextsTestBase.php
+++ b/modules/mukurtu_local_contexts/tests/src/Kernel/LocalContextsTestBase.php
@@ -91,8 +91,10 @@ abstract class LocalContextsTestBase extends EntityKernelTestBase {
    *   The project ID the label belongs to.
    * @param string $name
    *   The label name.
+   * @param string $tkOrBc
+   *   Whether this is a 'TK' or 'BC' label.
    */
-  protected function seedLabel(string $labelId, string $projectId, string $name = 'Label'): void {
+  protected function seedLabel(string $labelId, string $projectId, string $name = 'Label', string $tkOrBc = 'TK'): void {
     $this->container->get('database')->insert('mukurtu_local_contexts_labels')
       ->fields([
         'id' => $labelId,
@@ -100,9 +102,33 @@ abstract class LocalContextsTestBase extends EntityKernelTestBase {
         'name' => $name,
         'type' => 'Attribution',
         'display' => 'label',
-        'tk_or_bc' => 'TK',
+        'tk_or_bc' => $tkOrBc,
         'img_url' => '',
         'community' => '',
+        'default_text' => '',
+        'updated' => 1,
+      ])
+      ->execute();
+  }
+
+  /**
+   * Seed a notice directly in the DB, associated with a project.
+   *
+   * @param string $type
+   *   The notice type.
+   * @param string $projectId
+   *   The project ID the notice belongs to.
+   * @param string $name
+   *   The notice name.
+   */
+  protected function seedNotice(string $type, string $projectId, string $name = 'Notice'): void {
+    $this->container->get('database')->insert('mukurtu_local_contexts_notices')
+      ->fields([
+        'project_id' => $projectId,
+        'type' => $type,
+        'name' => $name,
+        'display' => 'notice',
+        'img_url' => '',
         'default_text' => '',
         'updated' => 1,
       ])


### PR DESCRIPTION
## Summary

PR #1854 shows as **Merged** on GitHub, but its work never actually reached `main`.

**Root cause:** #1854's base branch was `206-legacy-tk-label-readonly` — the head branch of #1853,
which had *already* been squash-merged into `main` on 2026-07-21 before #1854 was opened against it.
When #1854 was merged (squashed as `908629184`) on 2026-07-23, GitHub updated that stale leftover
branch instead of `main`. No follow-up PR ever merged `206-legacy-tk-label-readonly` into `main`, so
all of #1854's work — the legacy Local Contexts project remap tool (`RemapLegacyProjectBase`/`Site`/
`Group`, `LegacyProjectRemapBatch`, `LegacyProjectRemapPreviewBuilder`,
`LocalContextsProject::getReferencingNodeIds()`) — sat unreachable from `main` the whole time.

This PR cherry-picks that squash commit onto current `main` and resolves the resulting conflicts:

- **`mukurtu_local_contexts.install`**: the recovered commit's `update_10001()` collided with an
  unrelated `update_10001()` that landed on `main` afterward (multi-key API support, #1872) — this
  is the same slot-collision pattern documented in this file's own `update_10005()` comment. Renumbered
  the recovered hook to `update_10006` (the next free slot); its body
  (`user_role_grant_permissions('mukurtu_manager', ['administer local contexts legacy projects'])`)
  is unchanged.
- **`mukurtu_local_contexts.services.yml`**: merged the new `legacy_project_remap_preview_builder`
  service alongside `main`'s already-updated `supported_project_manager` service (now takes
  `['@database', '@config.factory']` for multi-key support, not the old `['@database']`).
- **`config/install/user.role.mukurtu_manager.yml`**: merged the new `administer local contexts
  legacy projects` permission into the role's alphabetized permission list, alongside `access
  visitors` (also added by a later, already-landed PR).
- `LocalContextsProject.php` (adds `getReferencingNodeIds()`, fixes a latent `inUse()` bug where
  notices were never checked when a project had any labels) and the test helpers in
  `LocalContextsTestBase.php` auto-merged cleanly with no manual changes needed.

Net diff vs `main`: 17 files, ~1225 lines — exactly #1854's original reviewed content, plus the one
hook renumber.

## Test plan

- [x] Full `mukurtu_local_contexts` kernel test suite (13 test files, 52 tests) passes with zero
  failures/errors, including the 16 tests this recovery adds
  (`LegacyProjectReferencingNodeIdsTest`, `LegacyProjectRemapBatchTest`,
  `LegacyProjectRemapPreviewBuilderTest`) and pre-existing tests covering the interim
  multi-key-API/facets/alias-URL work that landed on `main` after this code was originally written
  (`MultipleApiKeysTest`, `LabelIdCollisionTest`, `LegacyProjectExclusionTest`, etc.) — no
  regressions either direction.
- [x] Verified `update_10006` doesn't collide with any existing hook number in this module.

## Pre-merge checklist:

- [x] I have checked for and if required, created update hooks. (Renumbered `update_10001` →
  `update_10006` to avoid colliding with an unrelated hook that landed on `main` in the interim;
  see Summary.)
- [x] I have run an accessibility check, and resolved any issues. (Not re-run — the UI/forms in this
  recovery are byte-for-byte the same code that already passed an accessibility check under the
  original #1854 review, which fixed a heading-level issue at the time. No UI logic changed here,
  only YAML config merges and one update hook renumber.)
- [x] I have recompiled SCSS if required. (No CSS touched.)
- [x] I have updated or created CI/CD tests, if required. (All of #1854's original tests carried over
  unchanged; see Test plan.)
- [x] I have updated from `main` and resolved any merge conflicts.
- [ ] I have verified that all expected checks pass. (Pending CI on this PR.)
- [x] I have run the pr-expert-review skill and resolved all relevant issues. (Scoped to the manual
  conflict resolutions described above, since the underlying logic was already reviewed under #1854.)

Closes the gap left by #1854 / relates to #1851, #1852, #1853.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
