### PR TITLE
Rename "Public Submissions" to "Submission Forms" (#1924, part 1/4)

### DIFF
--- a/modules/mukurtu_submissions/README.md
+++ b/modules/mukurtu_submissions/README.md
@@ -4,9 +4,9 @@ Lets site visitors submit content for review without community/protocol membersh
 
 The submission form, its access check, and the `mukurtu_submission_settings` config entity are all generic - none of them contain per-content-type code. Digital Heritage is the only bundle configured out of the box.
 
-## Enabling public submissions for another content type
+## Enabling a submission form for another content type
 
-1. Add a `mukurtu_submission_settings` entity at `/admin/config/mukurtu/submissions/add`, selecting the target content type and checking "Enable public submissions for this content type".
+1. Add a `mukurtu_submission_settings` entity at `/admin/config/mukurtu/submissions/add`, selecting the target content type and checking "Enable the submission form for this content type".
 2. Saving it for the first time automatically creates a `submission` form display for that bundle (seeded from every field the bundle has, minus the fields the public form never shows). Use the "Manage fields shown on this form" link on the settings edit page to adjust which fields appear and their widgets, the same way you would for any other form display.
 3. The public form's URL uses a hyphenated bundle segment automatically (e.g. `field_trip_report` becomes `/submit/node/field-trip-report`) - no extra configuration needed.
 

--- a/modules/mukurtu_submissions/mukurtu_submissions.install
+++ b/modules/mukurtu_submissions/mukurtu_submissions.install
@@ -82,11 +82,11 @@ function mukurtu_submissions_install($is_syncing): void {
 }
 
 /**
- * Creates the blocked "Public Submissions" service account.
+ * Creates the blocked "Submission Forms" service account.
  */
 function mukurtu_submissions_create_service_account(): User {
   $account = User::create([
-    'name' => 'Public Submissions',
+    'name' => 'Submission Forms',
     'mail' => 'public-submissions@' . \Drupal::request()->getHost(),
     'status' => 0,
     'pass' => \Drupal::service('password_generator')->generate(32),
@@ -145,5 +145,22 @@ function mukurtu_submissions_update_40001(): void {
     if ($changed) {
       $role->save();
     }
+  }
+}
+
+/**
+ * Renames the service account from "Public Submissions" to "Submission
+ * Forms", matching the module's naming cleanup - only if a site hasn't
+ * already renamed it to something else.
+ */
+function mukurtu_submissions_update_40002(): void {
+  $uid = \Drupal::config('mukurtu_submissions.settings')->get('service_account_uid');
+  if (!$uid) {
+    return;
+  }
+  $account = User::load($uid);
+  if ($account && $account->getAccountName() === 'Public Submissions') {
+    $account->setUsername('Submission Forms');
+    $account->save();
   }
 }

--- a/modules/mukurtu_submissions/mukurtu_submissions.links.menu.yml
+++ b/modules/mukurtu_submissions/mukurtu_submissions.links.menu.yml
@@ -1,7 +1,7 @@
 entity.mukurtu_submission_settings.collection:
   title: 'Submission Forms'
   route_name: entity.mukurtu_submission_settings.collection
-  description: 'Enable and configure public submission forms per content type.'
+  description: 'Enable and configure submission forms per content type.'
   parent: mukurtu_dashboard
   menu_name: dashboard-site-settings
   weight: 1

--- a/modules/mukurtu_submissions/mukurtu_submissions.module
+++ b/modules/mukurtu_submissions/mukurtu_submissions.module
@@ -209,7 +209,7 @@ function mukurtu_submissions_form_node_form_alter(array &$form, FormStateInterfa
 
   $form['mukurtu_submissions'] = [
     '#type' => 'details',
-    '#title' => t('Public submission'),
+    '#title' => t('Submission'),
     '#open' => TRUE,
     '#weight' => -10,
   ];

--- a/modules/mukurtu_submissions/mukurtu_submissions.permissions.yml
+++ b/modules/mukurtu_submissions/mukurtu_submissions.permissions.yml
@@ -1,10 +1,10 @@
 administer mukurtu submissions:
-  title: 'Administer public submission settings'
-  description: 'Enable/disable public submissions per content type and configure allowed fields and media.'
+  title: 'Administer submission forms'
+  description: 'Enable/disable submission forms per content type and configure allowed fields and media.'
   restrict access: true
 
 review mukurtu submissions:
-  title: 'Review public submissions'
+  title: 'Review submissions'
   description: 'View the Pending Submissions queue, receive submission notifications, and contact submitters.'
   restrict access: true
 

--- a/modules/mukurtu_submissions/src/Access/SubmissionAccessCheck.php
+++ b/modules/mukurtu_submissions/src/Access/SubmissionAccessCheck.php
@@ -24,7 +24,7 @@ class SubmissionAccessCheck implements AccessInterface {
     $setting = reset($settings);
 
     if (!$setting || !$setting->status()) {
-      return AccessResult::forbidden('Public submissions are not enabled for this content type.');
+      return AccessResult::forbidden('The submission form is not enabled for this content type.');
     }
 
     // The public form only ever renders whichever fields the target

--- a/modules/mukurtu_submissions/src/Form/SubmissionSettingsForm.php
+++ b/modules/mukurtu_submissions/src/Form/SubmissionSettingsForm.php
@@ -72,7 +72,7 @@ class SubmissionSettingsForm extends EntityForm {
 
     $form['status'] = [
       '#type' => 'checkbox',
-      '#title' => $this->t('Enable public submissions for this content type'),
+      '#title' => $this->t('Enable the submission form for this content type'),
       '#default_value' => $this->entity->status(),
     ];
 
@@ -114,7 +114,7 @@ class SubmissionSettingsForm extends EntityForm {
     $form['intro_text'] = [
       '#type' => 'text_format',
       '#title' => $this->t('Introductory text'),
-      '#description' => $this->t('Optional text shown above the Title field on the public submission form. Use this to explain what belongs here, any restrictions, or how submissions will be reviewed.'),
+      '#description' => $this->t('Optional text shown above the Title field on the submission form. Use this to explain what belongs here, any restrictions, or how submissions will be reviewed.'),
       '#default_value' => $intro_text['value'] ?? '',
       '#format' => $intro_text['format'] ?? NULL,
     ];
@@ -131,7 +131,7 @@ class SubmissionSettingsForm extends EntityForm {
     $form['allowed_media_types'] = [
       '#type' => 'checkboxes',
       '#title' => $this->t('Allowed media types'),
-      '#description' => $this->t('Restrict which kinds of media a visitor may attach on the public submission form. Only applies to content types with a media field configured on their Submission form display.'),
+      '#description' => $this->t('Restrict which kinds of media a visitor may attach on the submission form. Only applies to content types with a media field configured on their Submission form display.'),
       '#options' => $this->getMediaTypeOptions(),
       '#default_value' => $this->entity->getAllowedMediaTypes() ?: self::MEDIA_TYPES,
     ];
@@ -300,7 +300,7 @@ class SubmissionSettingsForm extends EntityForm {
     $form['fields_table_description'] = [
       '#type' => 'html_tag',
       '#tag' => 'p',
-      '#value' => $this->t("Choose which of this content type's fields appear on the public submission form, drag to reorder them, and optionally assign each to a group above."),
+      '#value' => $this->t("Choose which of this content type's fields appear on the submission form, drag to reorder them, and optionally assign each to a group above."),
       '#attributes' => ['class' => ['description']],
     ];
 

--- a/modules/mukurtu_submissions/src/Plugin/Field/FieldWidget/SimpleMediaUploadWidget.php
+++ b/modules/mukurtu_submissions/src/Plugin/Field/FieldWidget/SimpleMediaUploadWidget.php
@@ -164,7 +164,7 @@ class SimpleMediaUploadWidget extends WidgetBase {
    *   $form_state->getValue([$field_name, 'upload']).
    * @param int $owner_uid
    *   The uid to own the created Media entities (and, transitively, their
-   *   file usage) - normally the "Public Submissions" service account.
+   *   file usage) - normally the "Submission Forms" service account.
    *
    * @return array
    *   A entity_reference-field-ready array of ['target_id' => media_id].

--- a/modules/mukurtu_submissions/src/SubmissionPermissions.php
+++ b/modules/mukurtu_submissions/src/SubmissionPermissions.php
@@ -47,7 +47,7 @@ class SubmissionPermissions implements ContainerInjectionInterface {
       $label = $info[$bundle]['label'] ?? $bundle;
 
       $permissions["submit $entity_type_id $bundle content"] = [
-        'title' => $this->t('Submit %type content via the public submission form', ['%type' => $label]),
+        'title' => $this->t('Submit %type content via the submission form', ['%type' => $label]),
         'dependencies' => [
           $setting->getConfigDependencyKey() => [$setting->getConfigDependencyName()],
         ],

--- a/modules/mukurtu_submissions/tests/src/Kernel/MukurtuSubmissionsKernelTestBase.php
+++ b/modules/mukurtu_submissions/tests/src/Kernel/MukurtuSubmissionsKernelTestBase.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\mukurtu_submissions\Kernel;
+
+use Drupal\KernelTests\Core\Entity\EntityKernelTestBase;
+
+/**
+ * Base class for mukurtu_submissions kernel tests.
+ *
+ * Deliberately excludes mukurtu_notifications, message, message_notify,
+ * message_subscribe, mukurtu_media, and mukurtu_protocol - none of
+ * SubmissionSettings/SubmissionPermissions/SubmissionAccessCheck/the
+ * module's update hooks touch those directly, and KernelTestBase's
+ * $modules list never resolves or installs hard dependencies (no
+ * hook_install() runs), so leaving them out is safe rather than a gap.
+ */
+abstract class MukurtuSubmissionsKernelTestBase extends EntityKernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'field',
+    'file',
+    'options',
+    'path_alias',
+    'node',
+    'views',
+    'mukurtu_submissions',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->installEntitySchema('path_alias');
+    $this->installConfig(['user']);
+  }
+
+}

--- a/modules/mukurtu_submissions/tests/src/Kernel/SubmissionsNamingUpdateTest.php
+++ b/modules/mukurtu_submissions/tests/src/Kernel/SubmissionsNamingUpdateTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\mukurtu_submissions\Kernel;
+
+use Drupal\user\Entity\User;
+
+/**
+ * Tests the "Public Submissions" -> "Submission Forms" naming cleanup:
+ * permission titles still resolve under their unchanged machine names, and
+ * mukurtu_submissions_update_40002() only renames a service account whose
+ * name still matches the old default.
+ *
+ * @group mukurtu_submissions
+ */
+class SubmissionsNamingUpdateTest extends MukurtuSubmissionsKernelTestBase {
+
+  /**
+   * The static permissions keep their machine names; only their
+   * human-readable titles changed, so admin/people/permissions and any
+   * existing role grants keep working unmodified.
+   */
+  public function testStaticPermissionTitlesUpdated(): void {
+    $permissions = $this->container->get('user.permissions')->getPermissions();
+
+    $this->assertArrayHasKey('administer mukurtu submissions', $permissions);
+    $this->assertEquals('Administer submission forms', (string) $permissions['administer mukurtu submissions']['title']);
+
+    $this->assertArrayHasKey('review mukurtu submissions', $permissions);
+    $this->assertEquals('Review submissions', (string) $permissions['review mukurtu submissions']['title']);
+  }
+
+  /**
+   * Calls the update hook directly, the same way update.php would.
+   */
+  protected function runNamingUpdateHook(): void {
+    $this->container->get('module_handler')->loadInclude('mukurtu_submissions', 'install');
+    mukurtu_submissions_update_40002();
+  }
+
+  public function testServiceAccountRenamedWhenStillDefault(): void {
+    $account = User::create(['name' => 'Public Submissions', 'status' => 0]);
+    $account->save();
+    \Drupal::configFactory()->getEditable('mukurtu_submissions.settings')
+      ->set('service_account_uid', (int) $account->id())
+      ->save();
+
+    $this->runNamingUpdateHook();
+
+    $account = User::load($account->id());
+    $this->assertEquals('Submission Forms', $account->getAccountName());
+  }
+
+  public function testServiceAccountLeftAloneWhenAlreadyCustomized(): void {
+    $account = User::create(['name' => 'Visitor Intake Bot', 'status' => 0]);
+    $account->save();
+    \Drupal::configFactory()->getEditable('mukurtu_submissions.settings')
+      ->set('service_account_uid', (int) $account->id())
+      ->save();
+
+    $this->runNamingUpdateHook();
+
+    $account = User::load($account->id());
+    $this->assertEquals('Visitor Intake Bot', $account->getAccountName());
+  }
+
+  public function testUpdateHookNoOpWithoutServiceAccountConfigured(): void {
+    // No exception, no crash, when no site has ever configured a service
+    // account (e.g. a site that installed the module but never enabled any
+    // bundle yet).
+    $this->runNamingUpdateHook();
+    $this->assertTrue(TRUE);
+  }
+
+}


### PR DESCRIPTION
## Summary

Part 1 of a stacked-PR series implementing the follow-up work tracked in #1924 (the "Part 2" follow-up to #272's visitor submission workflow, built in #1890). This PR is scoped to the "Naming" work item only: renaming leftover "Public Submission(s)" wording to "Submission Form(s)" throughout `modules/mukurtu_submissions`, now that the feature is headed toward supporting more than just Digital Heritage.

**Stacks on #1890** (not yet merged) - this branch is based on `272-visitor-submission-workflow`, not `main`, and will be rebased once #1890 lands. Later PRs in the stack (configurable thank-you message, generalized reviewer permissions + default forms for all content types, publishing-workflow verification) will stack on top of this one.

- Renamed titles/descriptions only: `administer mukurtu submissions` / `review mukurtu submissions` permission titles+descriptions, the submissions-settings menu link description, the node-edit-form review fieldset title, the dynamic per-bundle "submit" permission title, the public-form access-denied message, and several `SubmissionSettingsForm` field titles/descriptions.
- **Permission machine names and route names are unchanged** - only human-readable copy changed, so no existing role grants or bookmarked admin URLs break.
- Renamed the module's blocked service account from "Public Submissions" to "Submission Forms"; new `mukurtu_submissions_update_40002()` renames it on already-installed sites too, guarded to skip any site that already customized the name.
- Added the module's first kernel test coverage (it had none before this PR): `MukurtuSubmissionsKernelTestBase` + `SubmissionsNamingUpdateTest`, covering the two static permission titles and all three update-hook branches (rename / no-clobber / no-op).

## Test plan

- [x] New kernel tests (`SubmissionsNamingUpdateTest`, 4 methods) pass in a DDEV sandbox.
- [x] Manually confirmed permission machine names (`administer mukurtu submissions`, `review mukurtu submissions`) and all route names are unchanged - verified via `grep` across `mukurtu_submissions.routing.yml`, `.permissions.yml`, and `SubmissionPermissions.php`.
- [x] Swept the module for any remaining "Public Submission(s)" strings; confirmed the only leftovers are PHPDoc comments (dev-facing only) and the `PublicSubmissionForm` class name (a class identifier, not user-facing text) - intentionally out of scope.
- [ ] CI run on this PR (pending).

## Pre-merge checklist

- [x] I have checked for and if required, created update hooks. (`mukurtu_submissions_update_40002`)
- [x] I have run an accessibility check, and resolved any issues. (No regressions found - text-only changes, no markup/structure changed.)
- [x] I have recompiled SCSS if required. (Not required - no SCSS changes.)
- [x] I have updated or created CI/CD tests, if required. (Added the module's first kernel test coverage.)
- [ ] I have updated from `main` and resolved any merge conflicts. (N/A for this PR - stacks on `272-visitor-submission-workflow` / #1890, not `main`; will rebase once #1890 merges.)
- [ ] I have verified that all expected checks pass. (Pending CI run on this PR; passes locally in DDEV.)
- [x] I have run the pr-expert-review skill and resolved all relevant issues. (No blocking or non-blocking findings.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)