### PR TITLE
Add configurable thank-you message to submission forms (#1924, part 2/4)

### DIFF
--- a/modules/mukurtu_submissions/config/schema/mukurtu_submissions.schema.yml
+++ b/modules/mukurtu_submissions/config/schema/mukurtu_submissions.schema.yml
@@ -49,6 +49,9 @@ mukurtu_submissions.mukurtu_submission_settings.*:
     intro_text:
       type: text_format
       label: 'Introductory text'
+    thank_you_text:
+      type: text_format
+      label: 'Thank-you message'
     field_groups:
       type: sequence
       label: 'Field groups'

--- a/modules/mukurtu_submissions/src/Controller/ThankYouController.php
+++ b/modules/mukurtu_submissions/src/Controller/ThankYouController.php
@@ -11,25 +11,50 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class ThankYouController extends ControllerBase {
 
-  public function __construct(protected EntityTypeBundleInfoInterface $entityBundleInfo) {}
+  public function __construct(
+    protected EntityTypeBundleInfoInterface $entityBundleInfo,
+  ) {}
 
   /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container) {
-    return new static($container->get('entity_type.bundle.info'));
+    return new static(
+      $container->get('entity_type.bundle.info'),
+    );
   }
 
   /**
    * Builds the thank-you page.
    */
   public function view(string $entity_type_id, string $bundle): array {
-    $bundle_info = $this->entityBundleInfo->getBundleInfo($entity_type_id);
-    $label = $bundle_info[$bundle]['label'] ?? $bundle;
+    $matches = $this->entityTypeManager()->getStorage('mukurtu_submission_settings')->loadByProperties([
+      'target_entity_type_id' => $entity_type_id,
+      'target_bundle' => $bundle,
+    ]);
+    $settings = reset($matches) ?: NULL;
 
-    return [
-      '#markup' => $this->t('Thank you for your submission. Your @type has been received and will be reviewed by a site administrator before it is published.', ['@type' => $label]),
-    ];
+    $thank_you_text = $settings ? $settings->getThankYouText() : [];
+    if (!empty($thank_you_text['value'])) {
+      $build = [
+        '#type' => 'processed_text',
+        '#text' => $thank_you_text['value'],
+        '#format' => $thank_you_text['format'] ?? NULL,
+      ];
+    }
+    else {
+      $bundle_info = $this->entityBundleInfo->getBundleInfo($entity_type_id);
+      $label = $bundle_info[$bundle]['label'] ?? $bundle;
+      $build = [
+        '#markup' => $this->t('Thank you for your submission. Your @type has been received and will be reviewed by a site administrator before it is published.', ['@type' => $label]),
+      ];
+    }
+
+    if ($settings) {
+      $build['#cache']['tags'] = $settings->getCacheTags();
+    }
+
+    return $build;
   }
 
 }

--- a/modules/mukurtu_submissions/src/Entity/SubmissionSettings.php
+++ b/modules/mukurtu_submissions/src/Entity/SubmissionSettings.php
@@ -48,6 +48,7 @@ use Drupal\Core\Config\Entity\ConfigEntityBase;
  *     "access_expectations_enabled",
  *     "access_level",
  *     "intro_text",
+ *     "thank_you_text",
  *     "field_groups",
  *     "field_group_assignments",
  *   }
@@ -114,6 +115,15 @@ class SubmissionSettings extends ConfigEntityBase implements SubmissionSettingsI
   protected $intro_text = [];
 
   /**
+   * Text shown on the confirmation page after a successful submission, as
+   * a text_format-style ["value" => ..., "format" => ...] array. Empty
+   * means the controller falls back to a generic message.
+   *
+   * @var array
+   */
+  protected $thank_you_text = [];
+
+  /**
    * Collapsible section definitions for grouping fields on the public
    * submission form, in display order.
    *
@@ -171,6 +181,13 @@ class SubmissionSettings extends ConfigEntityBase implements SubmissionSettingsI
    */
   public function getIntroText(): array {
     return $this->intro_text ?? [];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getThankYouText(): array {
+    return $this->thank_you_text ?? [];
   }
 
   /**

--- a/modules/mukurtu_submissions/src/Entity/SubmissionSettingsInterface.php
+++ b/modules/mukurtu_submissions/src/Entity/SubmissionSettingsInterface.php
@@ -61,6 +61,17 @@ interface SubmissionSettingsInterface extends ConfigEntityInterface {
   public function getIntroText(): array;
 
   /**
+   * Gets the text shown on the confirmation page after a successful
+   * submission.
+   *
+   * @return array
+   *   A text_format-style array with "value" and "format" keys, or an empty
+   *   array if none is configured (the confirmation page falls back to a
+   *   generic message in that case).
+   */
+  public function getThankYouText(): array;
+
+  /**
    * Gets the collapsible section definitions for grouping fields on the
    * public submission form.
    *

--- a/modules/mukurtu_submissions/src/Form/SubmissionSettingsForm.php
+++ b/modules/mukurtu_submissions/src/Form/SubmissionSettingsForm.php
@@ -119,6 +119,15 @@ class SubmissionSettingsForm extends EntityForm {
       '#format' => $intro_text['format'] ?? NULL,
     ];
 
+    $thank_you_text = $this->entity->getThankYouText();
+    $form['thank_you_text'] = [
+      '#type' => 'text_format',
+      '#title' => $this->t('Thank-you message'),
+      '#description' => $this->t('Optional text shown on the confirmation page after a successful submission. If left blank, a generic message is shown instead.'),
+      '#default_value' => $thank_you_text['value'] ?? '',
+      '#format' => $thank_you_text['format'] ?? NULL,
+    ];
+
     // Only shown once a bundle is actually assigned - a new, unsaved entity
     // has none yet, so there's nothing to build this list from until it's
     // saved (auto-provisioning seeds every field as included at that point;

--- a/modules/mukurtu_submissions/tests/src/Kernel/MukurtuSubmissionsKernelTestBase.php
+++ b/modules/mukurtu_submissions/tests/src/Kernel/MukurtuSubmissionsKernelTestBase.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\Tests\mukurtu_submissions\Kernel;
 
 use Drupal\KernelTests\Core\Entity\EntityKernelTestBase;
+use Drupal\node\Entity\NodeType;
 
 /**
  * Base class for mukurtu_submissions kernel tests.
@@ -32,6 +33,12 @@ abstract class MukurtuSubmissionsKernelTestBase extends EntityKernelTestBase {
   ];
 
   /**
+   * The node bundle used to create mukurtu_submission_settings entities
+   * against, for tests that need one.
+   */
+  const TEST_BUNDLE = 'submission_test_content';
+
+  /**
    * {@inheritdoc}
    */
   protected function setUp(): void {
@@ -39,6 +46,11 @@ abstract class MukurtuSubmissionsKernelTestBase extends EntityKernelTestBase {
 
     $this->installEntitySchema('path_alias');
     $this->installConfig(['user']);
+
+    NodeType::create([
+      'type' => static::TEST_BUNDLE,
+      'name' => 'Submission Test Content',
+    ])->save();
   }
 
 }

--- a/modules/mukurtu_submissions/tests/src/Kernel/ThankYouMessageTest.php
+++ b/modules/mukurtu_submissions/tests/src/Kernel/ThankYouMessageTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\mukurtu_submissions\Kernel;
+
+use Drupal\mukurtu_submissions\Controller\ThankYouController;
+use Drupal\mukurtu_submissions\Entity\SubmissionSettings;
+
+/**
+ * Tests that the thank-you page renders a configured custom message when
+ * one is set, falls back to the generic message otherwise, and carries the
+ * settings entity's cache tags so edits to it invalidate the cached page.
+ *
+ * @group mukurtu_submissions
+ */
+class ThankYouMessageTest extends MukurtuSubmissionsKernelTestBase {
+
+  protected function viewThankYouPage(): array {
+    $controller = ThankYouController::create($this->container);
+    return $controller->view('node', static::TEST_BUNDLE);
+  }
+
+  public function testFallbackMessageWithNoSettingsEntity(): void {
+    $build = $this->viewThankYouPage();
+
+    $this->assertArrayHasKey('#markup', $build);
+    $this->assertStringContainsString('Thank you for your submission.', (string) $build['#markup']);
+    $this->assertArrayNotHasKey('tags', $build['#cache'] ?? []);
+  }
+
+  public function testFallbackMessageWhenThankYouTextEmpty(): void {
+    SubmissionSettings::create([
+      'id' => 'submission_test_content',
+      'label' => 'Test settings',
+      'target_entity_type_id' => 'node',
+      'target_bundle' => static::TEST_BUNDLE,
+    ])->save();
+
+    $build = $this->viewThankYouPage();
+
+    $this->assertArrayHasKey('#markup', $build);
+    $this->assertStringContainsString('Thank you for your submission.', (string) $build['#markup']);
+  }
+
+  public function testCustomThankYouTextOverridesDefault(): void {
+    $settings = SubmissionSettings::create([
+      'id' => 'submission_test_content',
+      'label' => 'Test settings',
+      'target_entity_type_id' => 'node',
+      'target_bundle' => static::TEST_BUNDLE,
+      'thank_you_text' => [
+        'value' => '<p>Custom thanks!</p>',
+        'format' => 'plain_text',
+      ],
+    ]);
+    $settings->save();
+
+    $build = $this->viewThankYouPage();
+
+    $this->assertEquals('processed_text', $build['#type']);
+    $this->assertEquals('<p>Custom thanks!</p>', $build['#text']);
+    $this->assertEquals('plain_text', $build['#format']);
+    $this->assertContains($settings->getCacheTags()[0], $build['#cache']['tags']);
+  }
+
+}


### PR DESCRIPTION
## Summary

Part 2 of the stacked-PR series implementing #1924. Stacks on #1935 (naming cleanup). Scoped to the "Thank-you message" work item only.

- Adds a `thank_you_text` `text_format` field to the `mukurtu_submission_settings` config entity (`SubmissionSettings.php`, `SubmissionSettingsInterface.php`, `config/schema/mukurtu_submissions.schema.yml`), structured identically to the existing `intro_text` field.
- New admin form field in `SubmissionSettingsForm.php`, right after "Introductory text".
- `ThankYouController` now loads the matching settings entity and renders the custom text via `#type => processed_text` when configured; falls back to the original hardcoded message otherwise. Also adds `#cache` tags from the settings entity - previously the controller returned zero cache metadata at all.
- **Deliberately no update hook and no change to the shipped `digital_heritage` config/install YAML** - the property null-coalesces to an empty array, and the code-level fallback (translatable via `t()`) reproduces identical current behavior. This exactly mirrors how `intro_text` is already absent from that same shipped YAML.

## Test plan

- [x] New kernel test (`ThankYouMessageTest`, 3 methods) covers: no settings entity -> fallback with no cache tags; settings entity with no custom text -> fallback; settings entity with custom text -> `processed_text` render array + cache tag present.
- [x] Existing `SubmissionsNamingUpdateTest` (from #1935) still passes unchanged.
- [x] Confirmed the new field is config-translatable via the same generic mechanism `intro_text` already relies on (config schema `text_format` type).
- [ ] CI run on this PR (pending).

## Pre-merge checklist

- [x] I have checked for and if required, created update hooks. (None needed - see rationale above.)
- [x] I have run an accessibility check, and resolved any issues. (No regressions - new field/render path is a structural clone of the existing `intro_text` pattern.)
- [x] I have recompiled SCSS if required. (Not required - no SCSS changes.)
- [x] I have updated or created CI/CD tests, if required. (Added `ThankYouMessageTest`.)
- [ ] I have updated from `main` and resolved any merge conflicts. (N/A - stacks on #1935 / `272-visitor-submission-workflow`, not `main`.)
- [ ] I have verified that all expected checks pass. (Pending CI run on this PR; passes locally in DDEV.)
- [x] I have run the pr-expert-review skill and resolved all relevant issues. (No blocking findings.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)