### PR TITLE
Fix FooterBlockTest schema violation on legacy settings fixture

### DIFF
--- a/modules/mukurtu_footer/tests/src/Kernel/FooterBlockTest.php
+++ b/modules/mukurtu_footer/tests/src/Kernel/FooterBlockTest.php
@@ -15,6 +15,18 @@ use Drupal\paragraphs\Entity\Paragraph;
  */
 class FooterBlockTest extends KernelTestBase {
 
+  /**
+   * testUpdateHookMigratesBlockSettings() seeds a legacy pre-migration block
+   * settings fixture (social_media, contact_email_address, etc.) that the
+   * current block.settings.mukurtu_footer schema no longer declares, since
+   * the plugin's settings moved into a block_content entity. Production code
+   * only ever reads that legacy config, never re-saves it, so this is a
+   * test-fixture concern, not a real schema gap.
+   *
+   * {@inheritdoc}
+   */
+  protected $strictConfigSchema = FALSE;
+
   protected static $modules = [
     'system',
     'field',


### PR DESCRIPTION
## Summary

Fixes a pre-existing test bug in `mukurtu_footer` surfaced by registering its kernel test suite in `phpunit.xml` (a separate, still-open PR, #1949) - this test never ran in CI before.

`testUpdateHookMigratesBlockSettings()` seeds a pre-migration block settings fixture (`social_media`, `contact_email_address`, `email_us_text`, `copyright_message`, `logo_upload`) to test `mukurtu_footer_update_40001()`'s migration path from the old plugin-settings format to the current `block_content`-entity-based one. The *current* `block.settings.mukurtu_footer` schema correctly declares no settings at all (`mapping: {}`), since the plugin's content moved into a block_content entity - so under `KernelTestBase`'s default strict schema checking, saving that legacy-shaped fixture throws `SchemaIncompleteException`.

Production code only ever *reads* this legacy config in the update hook (never re-saves it), so this is a test-fixture-only concern, not a real schema gap - the schema is correct for the plugin's current (empty) settings. Disable strict schema checking for this test class, matching the existing precedent in this repo for update-hook tests that seed fixtures in a pre-migration shape (`CategoryViewAdminLinksUpdateTest`).

## Test plan

- [x] Ran the test locally in a DDEV sandbox: all 4 tests in `FooterBlockTest` pass.
- [ ] CI passes.

## Pre-merge checklist:

- [x] I have checked for and if required, created update hooks. (N/A - test-only change.)
- [x] I have run an accessibility check, and resolved any issues. (N/A - test-only change.)
- [x] I have recompiled SCSS if required. (N/A.)
- [x] I have updated or created CI/CD tests, if required. (Fixed the existing test.)
- [x] I have updated from `main` and resolved any merge conflicts.
- [ ] I have verified that all expected checks pass. (Pending CI.)
- [x] I have run the pr-expert-review skill and resolved all relevant issues.
- [x] If I added a content entity bundle... (N/A.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)