### PR TITLE
Fix stale Layout Builder guard test assertion for the page bundle

### DIFF
--- a/modules/mukurtu_core/tests/src/Kernel/FormHooksLayoutBuilderGuardTest.php
+++ b/modules/mukurtu_core/tests/src/Kernel/FormHooksLayoutBuilderGuardTest.php
@@ -69,9 +69,9 @@ class FormHooksLayoutBuilderGuardTest extends KernelTestBase {
   public static function bundleProvider(): array {
     return [
       'unsupported bundle: article' => ['node', 'article', TRUE],
-      'unsupported bundle: page' => ['node', 'page', TRUE],
       'unsupported bundle: digital_heritage' => ['node', 'digital_heritage', TRUE],
       'unsupported bundle: place' => ['node', 'place', TRUE],
+      'supported bundle: page' => ['node', 'page', FALSE],
       'supported node bundle is left alone' => ['node', 'landing_page', FALSE],
       'non-node entity type is left alone' => ['media', 'article', FALSE],
     ];


### PR DESCRIPTION
## Summary

Fixes a pre-existing test bug in `mukurtu_core` surfaced by registering its kernel test suite in `phpunit.xml` (a separate, still-open PR, #1949) - this test never ran in CI before.

`FormHooksLayoutBuilderGuardTest::testLayoutBuilderCheckboxGuard` asserted that the `page` (Basic Page) bundle is in `FormHooks::formEntityViewDisplayEditFormAlter()`'s unsupported-bundles list (Layout Builder checkbox disabled with an explanatory message). That was true when the test was authored in #1814, but #1770 ("Enable Layout Builder on basic pages") intentionally removed `"page"` from `$unsupportedBundles` in the actual hook - the whole point of that PR was to enable Layout Builder for basic pages. The test was never updated to match, and since it never ran in CI, nobody caught the staleness.

Verified via `git log -p` on `FormHooks.php`: the `-"page",` removal is directly attributable to #1770's diff, confirming this is a stale test, not a code regression.

Moves `page` from the "unsupported" group to alongside `landing_page` in the "supported" group in the data provider.

## Test plan

- [x] Ran the test locally in a DDEV sandbox: all 7 cases in `FormHooksLayoutBuilderGuardTest` pass.
- [ ] CI passes.

## Pre-merge checklist:

- [x] I have checked for and if required, created update hooks. (N/A - test-only change.)
- [x] I have run an accessibility check, and resolved any issues. (N/A - test-only change.)
- [x] I have recompiled SCSS if required. (N/A.)
- [x] I have updated or created CI/CD tests, if required. (Fixed the existing test.)
- [x] I have updated from `main` and resolved any merge conflicts.
- [ ] I have verified that all expected checks pass. (Pending CI.)
- [x] I have run the pr-expert-review skill and resolved all relevant issues.
- [x] If I added a content entity bundle... (N/A.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)