### PR TITLE
Fix protocol/community names shown in wrong language on admin surfaces (#1671)

### DIFF
--- a/modules/mukurtu_protocol/src/Form/AddMemberToCommunityForm.php
+++ b/modules/mukurtu_protocol/src/Form/AddMemberToCommunityForm.php
@@ -6,9 +6,11 @@ use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\mukurtu_core\Service\EntityTranslationResolver;
 use Drupal\og\Og;
 use Drupal\mukurtu_protocol\Entity\Community;
 use Drupal\user\Entity\User;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Two-step form to enrol a user in a community and its child protocols.
@@ -22,6 +24,17 @@ use Drupal\user\Entity\User;
  * in the form.
  */
 class AddMemberToCommunityForm extends FormBase {
+
+  public function __construct(protected EntityTranslationResolver $entityTranslationResolver) {}
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('mukurtu_core.entity_translation_resolver'),
+    );
+  }
 
   /**
    * {@inheritdoc}
@@ -85,6 +98,7 @@ class AddMemberToCommunityForm extends FormBase {
    *   'community_name', 'protocol_name', 'protocol' (entity).
    */
   protected function getProtocolsForCommunity(Community $community, User $target): array {
+    $community = $this->entityTranslationResolver->translate($community);
     $rows = [];
     $current_user = User::load($this->currentUser()->id());
     $is_admin = $this->currentUser()->hasPermission('administer users');
@@ -103,6 +117,7 @@ class AddMemberToCommunityForm extends FormBase {
     }
 
     foreach ($community->getProtocols() as $protocol) {
+      $protocol = $this->entityTranslationResolver->translate($protocol);
       if ($manageable_protocol_ids !== NULL && !in_array($protocol->id(), $manageable_protocol_ids)) {
         continue;
       }
@@ -192,6 +207,7 @@ class AddMemberToCommunityForm extends FormBase {
     if (!$group) {
       return $form;
     }
+    $group = $this->entityTranslationResolver->translate($group);
 
     $form_state->set('community_id', $group->id());
     $step = $form_state->get('step') ?? 1;
@@ -442,7 +458,7 @@ class AddMemberToCommunityForm extends FormBase {
       $community = \Drupal::entityTypeManager()->getStorage('community')->load($cid);
       if ($community) {
         $community->addMember($user, $selected_roles);
-        $added[] = $community->getName();
+        $added[] = $this->entityTranslationResolver->translate($community)->getName();
       }
     }
 
@@ -474,7 +490,7 @@ class AddMemberToCommunityForm extends FormBase {
       $protocol = \Drupal::entityTypeManager()->getStorage('protocol')->load($pid);
       if ($protocol) {
         $protocol->addMember($user, $selected_roles);
-        $added[] = $protocol->getName();
+        $added[] = $this->entityTranslationResolver->translate($protocol)->getName();
       }
     }
 

--- a/modules/mukurtu_protocol/src/Form/AddUserToCommunityForm.php
+++ b/modules/mukurtu_protocol/src/Form/AddUserToCommunityForm.php
@@ -7,8 +7,10 @@ use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Url;
+use Drupal\mukurtu_core\Service\EntityTranslationResolver;
 use Drupal\og\Og;
 use Drupal\user\Entity\User;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Two-step form to enrol a user in communities and their child protocols.
@@ -18,6 +20,17 @@ use Drupal\user\Entity\User;
  *           have child protocols; skipped automatically otherwise).
  */
 class AddUserToCommunityForm extends FormBase {
+
+  public function __construct(protected EntityTranslationResolver $entityTranslationResolver) {}
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('mukurtu_core.entity_translation_resolver'),
+    );
+  }
 
   /**
    * {@inheritdoc}
@@ -103,6 +116,10 @@ class AddUserToCommunityForm extends FormBase {
       }
     }
 
+    $communities = array_map(
+      fn ($community) => $this->entityTranslationResolver->translate($community),
+      $communities
+    );
     uasort($communities, fn($a, $b) => strcmp($a->getName(), $b->getName()));
     return $communities;
   }
@@ -154,7 +171,9 @@ class AddUserToCommunityForm extends FormBase {
       if (!$community) {
         continue;
       }
+      $community = $this->entityTranslationResolver->translate($community);
       foreach ($community->getProtocols() as $protocol) {
+        $protocol = $this->entityTranslationResolver->translate($protocol);
         // Skip if current user cannot manage this protocol.
         if ($manageable_protocol_ids !== NULL && !in_array($protocol->id(), $manageable_protocol_ids)) {
           continue;
@@ -478,7 +497,7 @@ class AddUserToCommunityForm extends FormBase {
       $community = \Drupal::entityTypeManager()->getStorage('community')->load($cid);
       if ($community) {
         $community->addMember($user, $selected_roles);
-        $added[] = $community->getName();
+        $added[] = $this->entityTranslationResolver->translate($community)->getName();
       }
     }
 
@@ -510,7 +529,7 @@ class AddUserToCommunityForm extends FormBase {
       $protocol = \Drupal::entityTypeManager()->getStorage('protocol')->load($pid);
       if ($protocol) {
         $protocol->addMember($user, $selected_roles);
-        $added[] = $protocol->getName();
+        $added[] = $this->entityTranslationResolver->translate($protocol)->getName();
       }
     }
 

--- a/modules/mukurtu_protocol/src/Form/CommunityManagerUserCreationForm.php
+++ b/modules/mukurtu_protocol/src/Form/CommunityManagerUserCreationForm.php
@@ -4,8 +4,10 @@ namespace Drupal\mukurtu_protocol\Form;
 
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\mukurtu_core\Service\EntityTranslationResolver;
 use Drupal\user\Entity\User;
 use Drupal\og\Og;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Form controller for Community Manager user creation form.
@@ -16,6 +18,17 @@ class CommunityManagerUserCreationForm extends FormBase {
 
   // Have a place to save the communities in this entity.
   protected $communities;
+
+  public function __construct(protected EntityTranslationResolver $entityTranslationResolver) {}
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('mukurtu_core.entity_translation_resolver'),
+    );
+  }
 
   /**
    * {@inheritdoc}
@@ -65,7 +78,10 @@ class CommunityManagerUserCreationForm extends FormBase {
     $communities = [];
     $communityMemberships = array_filter(Og::getMemberships($currentUser), fn ($m) => $m->getGroupBundle() === 'community');
     $managerMemberships = array_filter($communityMemberships, fn ($m) => $m->hasPermission('manage members'));
-    $managerCommunities = array_filter(array_map(fn ($m) => $m->getGroup(), $managerMemberships));
+    $managerCommunities = array_map(
+      fn ($community) => $this->entityTranslationResolver->translate($community),
+      array_filter(array_map(fn ($m) => $m->getGroup(), $managerMemberships))
+    );
 
     /** @var \Drupal\mukurtu_protocol\Entity\Community $community */
     foreach ($managerCommunities as $community) {
@@ -81,7 +97,10 @@ class CommunityManagerUserCreationForm extends FormBase {
       fn ($m) => $m->getGroupBundle() === 'protocol'
     );
     $stewardMemberships = array_filter($protocolMemberships, fn ($m) => $m->hasPermission('manage members'));
-    $stewardProtocols = array_filter(array_map(fn ($m) => $m->getGroup(), $stewardMemberships));
+    $stewardProtocols = array_map(
+      fn ($protocol) => $this->entityTranslationResolver->translate($protocol),
+      array_filter(array_map(fn ($m) => $m->getGroup(), $stewardMemberships))
+    );
 
     // Group protocols (as objects) by parent community ID, for the membership section.
     $protocolsByCommunity = [];

--- a/modules/mukurtu_protocol/src/Plugin/Field/FieldWidget/CulturalProtocolWidget.php
+++ b/modules/mukurtu_protocol/src/Plugin/Field/FieldWidget/CulturalProtocolWidget.php
@@ -8,6 +8,7 @@ use Drupal\Core\Field\FieldFilteredMarkup;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Field\WidgetBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\mukurtu_core\Service\EntityTranslationResolver;
 use Drupal\mukurtu_protocol\Entity\CommunityInterface;
 use Drupal\mukurtu_protocol\Entity\ProtocolInterface;
 use Drupal\mukurtu_protocol\Plugin\Field\FieldType\CulturalProtocolItem;
@@ -33,18 +34,26 @@ class CulturalProtocolWidget extends WidgetBase {
   protected $entityTypeManager;
 
   /**
+   * The entity translation resolver.
+   *
+   * @var \Drupal\mukurtu_core\Service\EntityTranslationResolver
+   */
+  protected $entityTranslationResolver;
+
+  /**
    * {@inheritdoc}
    */
-  public function __construct($plugin_id, $plugin_definition, FieldDefinitionInterface $field_definition, array $settings, array $third_party_settings, EntityTypeManagerInterface $entityTypeManager) {
+  public function __construct($plugin_id, $plugin_definition, FieldDefinitionInterface $field_definition, array $settings, array $third_party_settings, EntityTypeManagerInterface $entityTypeManager, EntityTranslationResolver $entityTranslationResolver) {
     parent::__construct($plugin_id, $plugin_definition, $field_definition, $settings, $third_party_settings);
     $this->entityTypeManager = $entityTypeManager;
+    $this->entityTranslationResolver = $entityTranslationResolver;
   }
 
   /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
-    return new static($plugin_id, $plugin_definition, $configuration['field_definition'], $configuration['settings'], $configuration['third_party_settings'], $container->get('entity_type.manager'));
+    return new static($plugin_id, $plugin_definition, $configuration['field_definition'], $configuration['settings'], $configuration['third_party_settings'], $container->get('entity_type.manager'), $container->get('mukurtu_core.entity_translation_resolver'));
   }
 
   /**
@@ -70,13 +79,21 @@ class CulturalProtocolWidget extends WidgetBase {
 
     /** @var \Drupal\mukurtu_protocol\Entity\ProtocolInterface[] $protocols */
     if (!empty($protocol_ids)) {
-      $protocols = $this->entityTypeManager->getStorage('protocol')->loadMultiple($protocol_ids);
+      $protocols = array_map(
+        fn ($protocol) => $this->entityTranslationResolver->translate($protocol),
+        $this->entityTypeManager->getStorage('protocol')->loadMultiple($protocol_ids)
+      );
     }
 
     $multipleCommunities['#title'] = $this->t('Multiple Communities');
     $multipleCommunities['#id'] = 'protocols-with-multiple-communities';
     foreach ($protocols as $protocol) {
-      $communities = $protocol->getCommunities();
+      // getCommunities() loads its own (untranslated) copies via the field's
+      // referencedEntities(), so translate them here too.
+      $communities = array_map(
+        fn ($community) => $this->entityTranslationResolver->translate($community),
+        $protocol->getCommunities()
+      );
 
       // Handle orphaned protocols, even though that shouldn't happen...
       if (empty($communities)) {
@@ -247,7 +264,10 @@ class CulturalProtocolWidget extends WidgetBase {
     }
 
     // Fetch the communities for all the protocols the user is not able to see.
-    $protocols = $this->entityTypeManager->getStorage('protocol')->loadMultiple($missing_protocol_ids);
+    $protocols = array_map(
+      fn ($protocol) => $this->entityTranslationResolver->translate($protocol),
+      $this->entityTypeManager->getStorage('protocol')->loadMultiple($missing_protocol_ids)
+    );
     $user_can_view_all_communities = TRUE;
     $visible_missing_protocol_names = [];
     $missing_protocol_communities = [];
@@ -260,8 +280,13 @@ class CulturalProtocolWidget extends WidgetBase {
 
       // Check if the user can see the community. If they can, we want to
       // show them the name so they have some idea who to talk to if they need
-      // to get these inaccessible protocols changed.
-      $communities = $protocol->getCommunities();
+      // to get these inaccessible protocols changed. getCommunities() loads
+      // its own (untranslated) copies via the field's referencedEntities(),
+      // so translate them here too.
+      $communities = array_map(
+        fn ($community) => $this->entityTranslationResolver->translate($community),
+        $protocol->getCommunities()
+      );
       foreach ($communities as $community) {
         if ($community->access('view')) {
           $missing_protocol_communities[$community->id()] = $community->getName();

--- a/modules/mukurtu_protocol/src/ProtocolListBuilder.php
+++ b/modules/mukurtu_protocol/src/ProtocolListBuilder.php
@@ -10,6 +10,7 @@ use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Link;
 use Drupal\Core\Url;
+use Drupal\mukurtu_core\Service\EntityTranslationResolver;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -23,10 +24,13 @@ class ProtocolListBuilder extends EntityListBuilder {
 
   protected EntityTypeManagerInterface $entityTypeManager;
 
-  public function __construct(EntityTypeInterface $entity_type, EntityStorageInterface $storage, AccessManagerInterface $access_manager, EntityTypeManagerInterface $entity_type_manager) {
+  protected EntityTranslationResolver $entityTranslationResolver;
+
+  public function __construct(EntityTypeInterface $entity_type, EntityStorageInterface $storage, AccessManagerInterface $access_manager, EntityTypeManagerInterface $entity_type_manager, EntityTranslationResolver $entity_translation_resolver) {
     parent::__construct($entity_type, $storage);
     $this->accessManager = $access_manager;
     $this->entityTypeManager = $entity_type_manager;
+    $this->entityTranslationResolver = $entity_translation_resolver;
   }
 
   /**
@@ -37,7 +41,8 @@ class ProtocolListBuilder extends EntityListBuilder {
       $entity_type,
       $container->get('entity_type.manager')->getStorage($entity_type->id()),
       $container->get('access_manager'),
-      $container->get('entity_type.manager')
+      $container->get('entity_type.manager'),
+      $container->get('mukurtu_core.entity_translation_resolver'),
     );
   }
 
@@ -51,7 +56,10 @@ class ProtocolListBuilder extends EntityListBuilder {
       ->accessCheck(TRUE)
       ->sort('name')
       ->execute();
-    $communities = $this->entityTypeManager->getStorage('community')->loadMultiple($community_ids);
+    $communities = array_map(
+      fn (EntityInterface $community) => $this->entityTranslationResolver->translate($community),
+      $this->entityTypeManager->getStorage('community')->loadMultiple($community_ids)
+    );
 
     // Load all accessible protocols and index by community ID using field
     // values (IDs only) to avoid re-loading already-loaded community entities.
@@ -60,7 +68,10 @@ class ProtocolListBuilder extends EntityListBuilder {
       ->accessCheck(TRUE)
       ->sort('name')
       ->execute();
-    $all_protocols = $this->entityTypeManager->getStorage('protocol')->loadMultiple($protocol_ids);
+    $all_protocols = array_map(
+      fn (EntityInterface $protocol) => $this->entityTranslationResolver->translate($protocol),
+      $this->entityTypeManager->getStorage('protocol')->loadMultiple($protocol_ids)
+    );
 
     $protocols_by_community = [];
     $orphan_protocols = [];
@@ -172,10 +183,13 @@ class ProtocolListBuilder extends EntityListBuilder {
       'no_striping' => TRUE,
     ];
 
-    // Recurse into accessible child communities.
+    // Recurse into accessible child communities. getChildCommunities() loads
+    // its own (untranslated) copies via the field's referencedEntities(), so
+    // look the child up in $all_communities - already translated above - by
+    // ID instead of passing the untranslated one along.
     foreach ($community->getChildCommunities() as $child) {
       if (isset($all_communities[$child->id()])) {
-        $this->addCommunityRows($child, $all_communities, $protocols_by_community, $rows, $depth + 1, $visited);
+        $this->addCommunityRows($all_communities[$child->id()], $all_communities, $protocols_by_community, $rows, $depth + 1, $visited);
       }
     }
   }

--- a/modules/mukurtu_protocol/tests/src/Kernel/AdminSurfaceLabelTranslationTest.php
+++ b/modules/mukurtu_protocol/tests/src/Kernel/AdminSurfaceLabelTranslationTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\mukurtu_protocol\Kernel;
+
+use Drupal\Core\Language\Language;
+use Drupal\Core\Language\LanguageInterface;
+use Drupal\language\Entity\ConfigurableLanguage;
+use Drupal\mukurtu_protocol\Entity\Community;
+use Drupal\mukurtu_protocol\Entity\Protocol;
+use Drupal\mukurtu_protocol\Form\AddMemberToCommunityForm;
+use Drupal\mukurtu_protocol\Form\AddUserToCommunityForm;
+use Drupal\mukurtu_protocol\ProtocolListBuilder;
+
+/**
+ * Tests that admin/editor-facing surfaces show protocol/community names in
+ * the active content language, covering the same anti-pattern fixed for
+ * visitor-facing surfaces in #1671 (see ProtocolLabelTranslationTest).
+ *
+ * @group mukurtu_protocol
+ */
+class AdminSurfaceLabelTranslationTest extends ProtocolAwareEntityTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'language',
+    'content_translation',
+  ];
+
+  protected Community $community;
+
+  protected Protocol $protocol;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    ConfigurableLanguage::createFromLangcode('en')->save();
+    ConfigurableLanguage::createFromLangcode('es')->save();
+    \Drupal::service('content_translation.manager')->setEnabled('protocol', 'protocol', TRUE);
+    \Drupal::service('content_translation.manager')->setEnabled('community', 'community', TRUE);
+
+    $this->community = Community::create(['name' => 'Open Community']);
+    $this->community->save();
+    $this->community->addTranslation('es', ['name' => 'Comunidad Abierta'])->save();
+
+    $this->protocol = Protocol::create([
+      'name' => 'Open Protocol',
+      'field_communities' => [['target_id' => $this->community->id()]],
+    ]);
+    $this->protocol->save();
+    $this->protocol->addTranslation('es', ['name' => 'Protocolo Abierto'])->save();
+
+    $languageManager = \Drupal::languageManager();
+    $property = new \ReflectionProperty($languageManager, 'negotiatedLanguages');
+    $property->setAccessible(TRUE);
+    $property->setValue($languageManager, [LanguageInterface::TYPE_CONTENT => new Language(['id' => 'es'])]);
+  }
+
+  public function testProtocolListBuilderShowsTranslatedNames(): void {
+    $definition = \Drupal::entityTypeManager()->getDefinition('protocol');
+    $listBuilder = ProtocolListBuilder::createInstance(\Drupal::getContainer(), $definition);
+    $build = $listBuilder->render();
+
+    $rendered = (string) \Drupal::service('renderer')->renderInIsolation($build);
+    $this->assertStringContainsString('Comunidad Abierta', $rendered);
+    $this->assertStringContainsString('Protocolo Abierto', $rendered);
+    $this->assertStringNotContainsString('Open Community', $rendered);
+    $this->assertStringNotContainsString('Open Protocol', $rendered);
+  }
+
+  public function testAddMemberToCommunityFormShowsTranslatedNames(): void {
+    $user = $this->createUser();
+
+    $form = AddMemberToCommunityForm::create(\Drupal::getContainer());
+    $method = new \ReflectionMethod($form, 'getProtocolsForCommunity');
+    $method->setAccessible(TRUE);
+    $rows = $method->invoke($form, $this->community, $user);
+
+    $row = reset($rows);
+    $this->assertEquals('Comunidad Abierta', $row['community_name']);
+    $this->assertEquals('Protocolo Abierto', $row['protocol_name']);
+  }
+
+  public function testAddUserToCommunityFormShowsTranslatedNames(): void {
+    $user = $this->createUser();
+
+    $form = AddUserToCommunityForm::create(\Drupal::getContainer());
+
+    $availableMethod = new \ReflectionMethod($form, 'getAvailableCommunities');
+    $availableMethod->setAccessible(TRUE);
+    // Grant the current user (used internally via $this->currentUser()) an
+    // admin role so the admin branch (loads and translates all communities)
+    // is the one under test.
+    $this->setCurrentUser($this->createUser([], NULL, TRUE));
+    $communities = $availableMethod->invoke($form, $user);
+    $this->assertEquals('Comunidad Abierta', reset($communities)->getName());
+
+    $protocolsMethod = new \ReflectionMethod($form, 'getProtocolsForCommunities');
+    $protocolsMethod->setAccessible(TRUE);
+    $rows = $protocolsMethod->invoke($form, [$this->community->id()], $user);
+    $row = reset($rows);
+    $this->assertEquals('Comunidad Abierta', $row['community_name']);
+    $this->assertEquals('Protocolo Abierto', $row['protocol_name']);
+  }
+
+}


### PR DESCRIPTION
## Summary

Stacked on #1960 (which this PR depends on for the new `EntityTranslationResolver` service) — extends the entity-translation-context fix to admin/editor-facing surfaces that load protocol/community entities directly instead of through `entity.repository`'s translation context:

- `ProtocolListBuilder` (admin protocol/community list at `/admin/protocols`)
- `CulturalProtocolWidget` (the cultural-protocol field widget shown on content edit forms)
- `CommunityManagerUserCreationForm`, `AddMemberToCommunityForm`, `AddUserToCommunityForm` (community/protocol membership management forms)

On a multilingual site, these surfaces were showing protocol/community names in the site's default language instead of the active content language, because each loaded the entity via `EntityStorageInterface::load()`/`loadMultiple()` and called `->label()`/`->getName()` directly, bypassing translation-context resolution. This is the same anti-pattern fixed for visitor-facing surfaces in #1671/#1960, applied here to the admin/editor side.

**Bonus fix**: `ProtocolListBuilder::addCommunityRows()` had a latent recursion bug — when recursing into child communities, it passed the *untranslated* child entity (from `Community::getChildCommunities()`, which loads its own copies) into the recursive call, instead of looking it up in the already-translated `$communities` array built earlier in `render()`.

## Test plan

- New kernel test `AdminSurfaceLabelTranslationTest` covers all three admin/editor surfaces: creates a Protocol/Community pair with Spanish translations, sets the active content language to Spanish via the language manager, and asserts the translated names appear (and the English originals do not) in `ProtocolListBuilder::render()`, `AddMemberToCommunityForm::getProtocolsForCommunity()`, and `AddUserToCommunityForm::getAvailableCommunities()`/`getProtocolsForCommunities()`.
- Red/green verified: reverted the fix in `ProtocolListBuilder.php`, `AddMemberToCommunityForm.php`, `AddUserToCommunityForm.php` and confirmed all 3 new test methods fail with the untranslated English name; restored the fix and confirmed all 3 pass.
- `CommunityManagerUserCreationForm` and `CulturalProtocolWidget` are fixed with the same pattern but not covered by a dedicated test — their translation-relevant logic is a few lines inline in already-large form/widget classes with substantial existing untested surface area; adding narrow coverage for just these lines would need test scaffolding disproportionate to the fix. Flagging for reviewer visibility rather than silently skipping.
- Full kernel suite run locally (`vendor/bin/phpunit --testsuite kernel`): 257 tests, 0 failures.

## Pre-merge checklist

- [x] Branched off #1960 (`1671-translation-context-resolver`), not `main` — this PR cannot stand alone since it depends on the `EntityTranslationResolver` service added there. Retarget to `main` once #1960 merges.
- [x] Kernel test added, red/green verified
- [x] Full kernel suite passes locally (257/257)
- [ ] No user-facing text changes in this PR (no new/changed strings)
- [ ] Update hooks: none required — no config/schema changes
- [ ] WCAG/accessibility: no markup changes, N/A