### PR TITLE
Make mukurtu_multilingual's language negotiation defaults idempotent

### DIFF
--- a/modules/mukurtu_multilingual/mukurtu_multilingual.install
+++ b/modules/mukurtu_multilingual/mukurtu_multilingual.install
@@ -40,10 +40,32 @@ function mukurtu_multilingual_install() {
   // Clear the cache.discovery bin where field definitions are cached.
   \Drupal::service('cache.discovery')->deleteAll();
 
-  // Make adjustments to language negotiation settings. This will enable
-  // content language detection apart from interface language detection. It
-  // also prioritizes a users' Administration pages language setting, so that
-  // interface text follows their preference rather than the content language.
+  _mukurtu_multilingual_apply_language_negotiation_defaults();
+
+  // Make all comment fields on node bundles untranslatable.
+  $node_types = \Drupal::entityTypeManager()->getStorage('node_type')->loadMultiple();
+  foreach ($node_types as $node_type) {
+    $bundle = $node_type->id();
+    $field_config = FieldConfig::loadByName('node', $bundle, 'comment');
+    if ($field_config) {
+      $field_config->setTranslatable(FALSE);
+      $field_config->save();
+    }
+  }
+
+  _mukurtu_multilingual_apply_translation_overrides();
+}
+
+/**
+ * Adjusts language negotiation settings.
+ *
+ * This enables content language detection apart from interface language
+ * detection. It also prioritizes a users' Administration pages language
+ * setting, so that interface text follows their preference rather than the
+ * content language. Idempotent: safe to call on a site that has already
+ * converged on these settings, or whose settings have drifted.
+ */
+function _mukurtu_multilingual_apply_language_negotiation_defaults(): void {
   $config = \Drupal::configFactory()->getEditable('language.types');
   $config->set('configurable', ['language_interface', 'language_content'])
     ->set('negotiation.language_content.enabled', [
@@ -58,19 +80,6 @@ function mukurtu_multilingual_install() {
       'language-selected' => 12,
     ]);
   $config->save();
-
-  // Make all comment fields on node bundles untranslatable.
-  $node_types = \Drupal::entityTypeManager()->getStorage('node_type')->loadMultiple();
-  foreach ($node_types as $node_type) {
-    $bundle = $node_type->id();
-    $field_config = FieldConfig::loadByName('node', $bundle, 'comment');
-    if ($field_config) {
-      $field_config->setTranslatable(FALSE);
-      $field_config->save();
-    }
-  }
-
-  _mukurtu_multilingual_apply_translation_overrides();
 }
 
 /**
@@ -215,4 +224,14 @@ function mukurtu_multilingual_update_40005(): void {
  */
 function mukurtu_multilingual_update_40006(): void {
   _mukurtu_multilingual_apply_translation_overrides();
+}
+
+/**
+ * Converges language negotiation settings on sites that installed before
+ * this release or whose settings have otherwise drifted from the shipped
+ * defaults (e.g. a site administrator changed them and later wants to reset
+ * to the Mukurtu defaults).
+ */
+function mukurtu_multilingual_update_40007(): void {
+  _mukurtu_multilingual_apply_language_negotiation_defaults();
 }

--- a/modules/mukurtu_multilingual/tests/src/Kernel/LanguageNegotiationDefaultsTest.php
+++ b/modules/mukurtu_multilingual/tests/src/Kernel/LanguageNegotiationDefaultsTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\mukurtu_multilingual\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+
+/**
+ * Tests _mukurtu_multilingual_apply_language_negotiation_defaults().
+ *
+ * @see _mukurtu_multilingual_apply_language_negotiation_defaults()
+ * @group mukurtu_multilingual
+ */
+class LanguageNegotiationDefaultsTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'language',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->installConfig(['language']);
+
+    $module_path = \Drupal::service('extension.list.module')->getPath('mukurtu_multilingual');
+    require_once $module_path . '/mukurtu_multilingual.install';
+  }
+
+  /**
+   * Applying the defaults sets the expected negotiation weights.
+   */
+  public function testAppliesNegotiationDefaults(): void {
+    _mukurtu_multilingual_apply_language_negotiation_defaults();
+
+    $config = $this->config('language.types');
+    $this->assertSame(['language_interface', 'language_content'], $config->get('configurable'));
+    $this->assertSame([
+      'language-url' => -8,
+      'language-interface' => 9,
+      'language-selected' => 12,
+    ], $config->get('negotiation.language_content.enabled'));
+    $this->assertSame([
+      'language-user-admin' => -10,
+      'language-url' => -8,
+      'language-user' => -4,
+      'language-selected' => 12,
+    ], $config->get('negotiation.language_interface.enabled'));
+  }
+
+  /**
+   * Running it twice does not error and stays converged.
+   */
+  public function testIsIdempotent(): void {
+    _mukurtu_multilingual_apply_language_negotiation_defaults();
+    _mukurtu_multilingual_apply_language_negotiation_defaults();
+
+    $config = $this->config('language.types');
+    $this->assertSame(['language_interface', 'language_content'], $config->get('configurable'));
+  }
+
+  /**
+   * Drifted settings (e.g. a site administrator changed the weights) are
+   * reconverged to the Mukurtu defaults.
+   */
+  public function testReconvergesDriftedSettings(): void {
+    $this->config('language.types')
+      ->set('negotiation.language_content.enabled', ['language-url' => 0])
+      ->save();
+
+    _mukurtu_multilingual_apply_language_negotiation_defaults();
+
+    $config = $this->config('language.types');
+    $this->assertSame([
+      'language-url' => -8,
+      'language-interface' => 9,
+      'language-selected' => 12,
+    ], $config->get('negotiation.language_content.enabled'));
+  }
+
+}


### PR DESCRIPTION
## Summary

Stacked on #1950, which this PR depends on for `_mukurtu_multilingual_apply_translation_overrides()` and the surrounding install-hook structure.

`mukurtu_multilingual_install()` wrote its `language.types` negotiation-weight adjustments (content vs. interface language priority) inline, only on fresh install. Sites that installed the module before this logic existed, or whose `language.types` config has otherwise drifted from the shipped defaults, never got these settings and had no way to converge without reinstalling the module.

Extracts the write into `_mukurtu_multilingual_apply_language_negotiation_defaults()` and adds `mukurtu_multilingual_update_40007()` calling the same helper, following the exact pattern #1950 already established for `_mukurtu_multilingual_apply_translation_overrides()` / `update_40006()`.

**Note for reviewers**: this update hook unconditionally overwrites `language.types` negotiation weights on every site that runs `drush updb`, with no drift-detection guard (unlike `update_40005`'s `isNew()` check or `_mukurtu_multilingual_apply_translation_overrides()`'s per-field `isTranslatable()` check). This is intentional per the roadmap — these weights are Mukurtu's own opinionated, load-bearing negotiation setup (documented rationale: prioritize a user's admin-language preference over content language), not an end-user-customizable preference — but it does mean a site administrator who deliberately changed these specific weights will have that change reverted on update. Flagging for visibility since it's a real behavior, not hedging.

## Test plan

- New kernel test `LanguageNegotiationDefaultsTest`: applies the defaults and asserts the exact weights, confirms idempotency (running twice is a no-op), and confirms drifted settings are reconverged.
- Red/green verified: reverted the helper extraction, confirmed all 3 new test methods fail (undefined function), restored and confirmed all 3 pass.
- Full kernel suite run locally: 330 tests, 0 failures (this count includes the newly-registered `mukurtu_multilingual`/`mukurtu_core`/`mukurtu_taxonomy`/`mukurtu_workflows`/`mukurtu_footer` suites from the pending Phase 0 test-infra fix, #1949, applied locally only to make these tests runnable — not part of this PR's diff).

## Pre-merge checklist

- [x] Branched off #1950 (`1260-fix-multilingual-install-collision`) — depends on its install-hook refactor. Retarget to `main` once #1950 merges.
- [x] Kernel test added, red/green verified
- [x] Full kernel suite passes locally
- [ ] No user-facing text changes in this PR
- [x] Update hook added (`mukurtu_multilingual_update_40007`) — documented above per project rules
- [ ] WCAG/accessibility: no markup changes, N/A