### PR TITLE
Close 12 bundle translation-config gaps found by a new coverage guard (#1260)

### DIFF
--- a/modules/mukurtu_multilingual/config/install/language.content_settings.block_content.mukurtu_footer.yml
+++ b/modules/mukurtu_multilingual/config/install/language.content_settings.block_content.mukurtu_footer.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.mukurtu_footer
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '0'
+id: block_content.mukurtu_footer
+target_entity_type_id: block_content
+target_bundle: mukurtu_footer
+default_langcode: site_default
+language_alterable: true

--- a/modules/mukurtu_multilingual/config/install/language.content_settings.media.audio.yml
+++ b/modules/mukurtu_multilingual/config/install/language.content_settings.media.audio.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.audio
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '0'
+id: media.audio
+target_entity_type_id: media
+target_bundle: audio
+default_langcode: site_default
+language_alterable: true

--- a/modules/mukurtu_multilingual/config/install/language.content_settings.media.document.yml
+++ b/modules/mukurtu_multilingual/config/install/language.content_settings.media.document.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.document
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '0'
+id: media.document
+target_entity_type_id: media
+target_bundle: document
+default_langcode: site_default
+language_alterable: true

--- a/modules/mukurtu_multilingual/config/install/language.content_settings.media.external_embed.yml
+++ b/modules/mukurtu_multilingual/config/install/language.content_settings.media.external_embed.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.external_embed
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '0'
+id: media.external_embed
+target_entity_type_id: media
+target_bundle: external_embed
+default_langcode: site_default
+language_alterable: true

--- a/modules/mukurtu_multilingual/config/install/language.content_settings.media.image.yml
+++ b/modules/mukurtu_multilingual/config/install/language.content_settings.media.image.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.image
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '0'
+id: media.image
+target_entity_type_id: media
+target_bundle: image
+default_langcode: site_default
+language_alterable: true

--- a/modules/mukurtu_multilingual/config/install/language.content_settings.media.remote_video.yml
+++ b/modules/mukurtu_multilingual/config/install/language.content_settings.media.remote_video.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.remote_video
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '0'
+id: media.remote_video
+target_entity_type_id: media
+target_bundle: remote_video
+default_langcode: site_default
+language_alterable: true

--- a/modules/mukurtu_multilingual/config/install/language.content_settings.media.soundcloud.yml
+++ b/modules/mukurtu_multilingual/config/install/language.content_settings.media.soundcloud.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.soundcloud
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '0'
+id: media.soundcloud
+target_entity_type_id: media
+target_bundle: soundcloud
+default_langcode: site_default
+language_alterable: true

--- a/modules/mukurtu_multilingual/config/install/language.content_settings.media.video.yml
+++ b/modules/mukurtu_multilingual/config/install/language.content_settings.media.video.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.video
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '0'
+id: media.video
+target_entity_type_id: media
+target_bundle: video
+default_langcode: site_default
+language_alterable: true

--- a/modules/mukurtu_multilingual/config/install/language.content_settings.paragraph.footer_logo.yml
+++ b/modules/mukurtu_multilingual/config/install/language.content_settings.paragraph.footer_logo.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - paragraphs.paragraphs_type.footer_logo
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '0'
+id: paragraph.footer_logo
+target_entity_type_id: paragraph
+target_bundle: footer_logo
+default_langcode: site_default
+language_alterable: true

--- a/modules/mukurtu_multilingual/config/install/language.content_settings.paragraph.footer_social_link.yml
+++ b/modules/mukurtu_multilingual/config/install/language.content_settings.paragraph.footer_social_link.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - paragraphs.paragraphs_type.footer_social_link
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '0'
+id: paragraph.footer_social_link
+target_entity_type_id: paragraph
+target_bundle: footer_social_link
+default_langcode: site_default
+language_alterable: true

--- a/modules/mukurtu_multilingual/config/install/language.content_settings.paragraph.text_section_with_title.yml
+++ b/modules/mukurtu_multilingual/config/install/language.content_settings.paragraph.text_section_with_title.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - paragraphs.paragraphs_type.text_section_with_title
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '0'
+id: paragraph.text_section_with_title
+target_entity_type_id: paragraph
+target_bundle: text_section_with_title
+default_langcode: site_default
+language_alterable: true

--- a/modules/mukurtu_multilingual/config/install/language.content_settings.taxonomy_term.place_type.yml
+++ b/modules/mukurtu_multilingual/config/install/language.content_settings.taxonomy_term.place_type.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.place_type
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '0'
+id: taxonomy_term.place_type
+target_entity_type_id: taxonomy_term
+target_bundle: place_type
+default_langcode: site_default
+language_alterable: true

--- a/modules/mukurtu_multilingual/mukurtu_multilingual.install
+++ b/modules/mukurtu_multilingual/mukurtu_multilingual.install
@@ -235,3 +235,50 @@ function mukurtu_multilingual_update_40006(): void {
 function mukurtu_multilingual_update_40007(): void {
   _mukurtu_multilingual_apply_language_negotiation_defaults();
 }
+
+/**
+ * Enables content translation for 12 bundles that were never covered by any
+ * language.content_settings.* config: the 7 media bundles (audio, document,
+ * external_embed, image, remote_video, soundcloud, video - meaning media
+ * names, alt text, and other translatable fields could not be translated on
+ * a multilingual site), the place_type taxonomy vocabulary, the
+ * mukurtu_footer block type, and 2 footer paragraph types
+ * (footer_logo, footer_social_link). A 12th bundle, the
+ * text_section_with_title paragraph type, already had its base field
+ * overrides shipped but was missing the content_settings file that actually
+ * enables translation for the bundle.
+ *
+ * Guarded by isNew() so this is a no-op if the config already exists (e.g.
+ * on a site that installed after this fix shipped, which already got these
+ * via config/install).
+ */
+function mukurtu_multilingual_update_40008(): void {
+  $module_path = \Drupal::service('extension.list.module')->getPath('mukurtu_multilingual');
+  $config_source = new \Drupal\Core\Config\FileStorage($module_path . '/config/install');
+  $config_factory = \Drupal::configFactory();
+
+  $bundles = [
+    ['media', 'audio'],
+    ['media', 'document'],
+    ['media', 'external_embed'],
+    ['media', 'image'],
+    ['media', 'remote_video'],
+    ['media', 'soundcloud'],
+    ['media', 'video'],
+    ['taxonomy_term', 'place_type'],
+    ['block_content', 'mukurtu_footer'],
+    ['paragraph', 'footer_logo'],
+    ['paragraph', 'footer_social_link'],
+    ['paragraph', 'text_section_with_title'],
+  ];
+
+  foreach ($bundles as [$entity_type_id, $bundle]) {
+    $config_name = "language.content_settings.$entity_type_id.$bundle";
+    if ($config_factory->get($config_name)->isNew()) {
+      $data = $config_source->read($config_name);
+      if ($data) {
+        $config_factory->getEditable($config_name)->setData($data)->save();
+      }
+    }
+  }
+}

--- a/modules/mukurtu_multilingual/tests/src/Kernel/BundleTranslationEnablementTest.php
+++ b/modules/mukurtu_multilingual/tests/src/Kernel/BundleTranslationEnablementTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\mukurtu_multilingual\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\media\Entity\MediaType;
+
+/**
+ * Tests mukurtu_multilingual_update_40008(), which closes the 12 bundle
+ * translation gaps found by ConfigTranslationCoverageTest - most notably
+ * that none of the 7 media bundles had content translation enabled at all,
+ * so media names and other translatable fields (already correctly marked
+ * translatable in each bundle's own field definitions) could never actually
+ * be translated on a multilingual site.
+ *
+ * media.image is used here as the representative case; the same
+ * language.content_settings.<type>.<bundle> import logic applies uniformly
+ * to all 12 bundles the update hook covers.
+ *
+ * @see mukurtu_multilingual_update_40008()
+ * @see ConfigTranslationCoverageTest
+ * @group mukurtu_multilingual
+ */
+class BundleTranslationEnablementTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'file',
+    'image',
+    'media',
+    'language',
+    'content_translation',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('media');
+    $this->installConfig(['field', 'media']);
+
+    // The bundle referenced by the config under test must exist as a real
+    // entity - ContentLanguageSettings::calculateDependencies() throws a
+    // LogicException otherwise (same lesson as TranslationOverridesTest).
+    MediaType::create(['id' => 'image', 'label' => 'Image', 'source' => 'image'])->save();
+
+    $module_path = \Drupal::service('extension.list.module')->getPath('mukurtu_multilingual');
+    require_once $module_path . '/mukurtu_multilingual.install';
+  }
+
+  /**
+   * Before the update hook runs, the bundle has no translation support.
+   */
+  public function testMediaImageIsNotTranslatableBeforeUpdate(): void {
+    $this->assertFalse(\Drupal::service('content_translation.manager')->isEnabled('media', 'image'));
+  }
+
+  /**
+   * The update hook enables content translation for the bundle.
+   */
+  public function testUpdateEnablesMediaImageTranslation(): void {
+    mukurtu_multilingual_update_40008();
+
+    $this->assertTrue(\Drupal::service('content_translation.manager')->isEnabled('media', 'image'));
+  }
+
+  /**
+   * Running the update twice does not error and stays converged.
+   */
+  public function testUpdateIsIdempotent(): void {
+    mukurtu_multilingual_update_40008();
+    mukurtu_multilingual_update_40008();
+
+    $this->assertTrue(\Drupal::service('content_translation.manager')->isEnabled('media', 'image'));
+  }
+
+}

--- a/modules/mukurtu_multilingual/tests/src/Unit/ConfigTranslationCoverageTest.php
+++ b/modules/mukurtu_multilingual/tests/src/Unit/ConfigTranslationCoverageTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\mukurtu_multilingual\Unit;
+
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Guards against a bundle silently shipping with no translation support.
+ *
+ * This is the failure class behind the historical update_40005 bug: the 5
+ * Layout Builder block types added by #1770 shipped with no
+ * language.content_settings.* config at all, so they had no translation
+ * support on a multilingual site and nobody noticed until it was reported.
+ * This test globs every bundle-defining config file in the profile and
+ * asserts a matching language.content_settings.* exists in
+ * mukurtu_multilingual/config/install/, so a new bundle added without
+ * translation support fails CI instead of shipping silently.
+ *
+ * A pure filesystem check - no Drupal bootstrap needed.
+ *
+ * @group mukurtu_multilingual
+ */
+class ConfigTranslationCoverageTest extends UnitTestCase {
+
+  /**
+   * Bundles that legitimately have no language.content_settings.* file.
+   *
+   * Keyed by "entity_type_id.bundle", value is the reason it's exempt.
+   */
+  private const EXEMPTIONS = [
+    // Content translation is enabled imperatively in
+    // _mukurtu_multilingual_apply_translation_overrides(), not via a shipped
+    // config file, because the owning module's own config/install ships
+    // language_alterable: false with no content_translation settings and
+    // mukurtu_multilingual can't ship a colliding language.content_settings
+    // file of its own (see mukurtu_multilingual.install).
+    'node.landing_page' => 'enabled imperatively in mukurtu_multilingual.install, see _mukurtu_multilingual_apply_translation_overrides()',
+  ];
+
+  /**
+   * Maps a bundle-defining config file's prefix to its entity type ID and
+   * the config-name segment language.content_settings.* uses for it.
+   */
+  private const BUNDLE_CONFIG_PATTERNS = [
+    'node.type.' => 'node',
+    'block_content.type.' => 'block_content',
+    'media.type.' => 'media',
+    'paragraphs.paragraphs_type.' => 'paragraph',
+    'taxonomy.vocabulary.' => 'taxonomy_term',
+  ];
+
+  /**
+   * Every bundle-defining config file in the profile has a matching
+   * language.content_settings.* file, unless explicitly exempted above.
+   */
+  public function testEveryBundleHasContentTranslationSettings(): void {
+    $profileRoot = dirname(__DIR__, 5);
+    $this->assertDirectoryExists($profileRoot . '/modules', 'Sanity check: resolved profile root is wrong.');
+
+    $contentSettingsDir = $profileRoot . '/modules/mukurtu_multilingual/config/install';
+    $existing = [];
+    foreach (glob($contentSettingsDir . '/language.content_settings.*.yml') as $file) {
+      $existing[] = basename($file, '.yml');
+    }
+
+    $configInstallDirs = array_merge(
+      glob($profileRoot . '/config/install'),
+      glob($profileRoot . '/modules/*/config/install'),
+    );
+
+    $gaps = [];
+    foreach ($configInstallDirs as $dir) {
+      foreach (scandir($dir) as $file) {
+        foreach (self::BUNDLE_CONFIG_PATTERNS as $prefix => $entityTypeId) {
+          if (str_starts_with($file, $prefix) && str_ends_with($file, '.yml')) {
+            $bundle = substr($file, strlen($prefix), -4);
+            $key = "$entityTypeId.$bundle";
+            if (isset(self::EXEMPTIONS[$key])) {
+              continue;
+            }
+            if (!in_array("language.content_settings.$entityTypeId.$bundle", $existing, TRUE)) {
+              $gaps[$key] = "$dir/$file";
+            }
+          }
+        }
+      }
+    }
+
+    $message = "The following bundles have no language.content_settings.* file "
+      . "(so translation is silently unavailable on a multilingual site). "
+      . "Either ship modules/mukurtu_multilingual/config/install/language.content_settings.<type>.<bundle>.yml "
+      . "(plus an update hook for existing sites), or add a documented exemption:\n"
+      . implode("\n", array_map(fn ($key, $path) => "  $key ($path)", array_keys($gaps), $gaps));
+
+    $this->assertSame([], $gaps, $message);
+  }
+
+}


### PR DESCRIPTION
## Summary

Stacked on #1962, which this PR depends on for the negotiation-defaults helper structure it follows for its own update hook.

Adds `ConfigTranslationCoverageTest` (unit, no bootstrap): globs every bundle-defining config file in the profile (`node.type.*`, `block_content.type.*`, `media.type.*`, `paragraphs.paragraphs_type.*`, `taxonomy.vocabulary.*`) and asserts a matching `language.content_settings.*` exists in `mukurtu_multilingual/config/install/`, with an explicit, commented exemption list for legitimate exceptions (currently just `landing_page`, which is enabled imperatively — see the existing `_mukurtu_multilingual_apply_translation_overrides()`). This is a direct guard against the exact failure class behind the historical `update_40005` bug: 5 Layout Builder block types shipped with zero translation support and nobody noticed until it was reported.

Running it against the current tree found **12 real gaps**:
- **All 7 media bundles** (audio, document, external_embed, image, remote_video, soundcloud, video) — none had content translation enabled at all. Media names, captions, and other fields are already correctly marked translatable in their own field definitions (`Audio.php`, `Image.php`, etc. all call `setTranslatable()` explicitly per field), but none of that mattered because the bundle itself was never translation-enabled.
- `taxonomy_term.place_type`, `block_content.mukurtu_footer`, and 3 paragraph types (`footer_logo`, `footer_social_link`, `text_section_with_title`) — same gap, smaller blast radius. `text_section_with_title` already had its field-level `core.base_field_override.*` config shipped (mirroring its sibling `formatted_text_with_title`) but was missing the one file that actually turns translation on for the bundle.

Closes all 12 by shipping the missing `language.content_settings.*.yml` files, plus `mukurtu_multilingual_update_40008()` so existing sites converge without reinstalling (same `isNew()`-guarded import pattern as `update_40005`).

**Verified no per-field overrides are needed**: before writing the fix, I checked empirically (via a Drupal shell script in a local sandbox) whether `field_media_image`'s effective `FieldDefinition::isTranslatable()` was already `TRUE` with zero `core.base_field_override` config present — it was. Every field on all 12 bundles already declares its correct translatable state in code (base fields) or in its shipped `field.field.*.yml` (configurable fields); Drupal honors that once the bundle has content translation enabled. No content-model changes here beyond turning translation on at the bundle level.

## Test plan

- New unit test `ConfigTranslationCoverageTest`: pure filesystem glob, no Drupal bootstrap. Red/green verified by temporarily removing one of the new config files and confirming the test fails with the exact gap listed, then restoring it.
- New kernel test `BundleTranslationEnablementTest`: verifies `update_40008()` actually enables content translation at runtime (`content_translation.manager->isEnabled('media', 'image')`), using media.image as the representative case for all 12. Covers the not-yet-enabled state, post-update state, and idempotency of re-running the update. Red/green verified: reverted the update hook and one config file, confirmed the relevant test methods fail (undefined function / still disabled), restored and confirmed all pass.
- Full kernel suite run locally: 333 tests, 0 failures.
- Full unit suite run locally: 30 tests, 0 failures.

## Pre-merge checklist

- [x] Branched off #1962 (`1260-multilingual-idempotent-negotiation`) — stacked per this phase's established dependency chain (#1950 → #1962 → this PR). Retarget to `main` once the chain merges.
- [x] Kernel + unit tests added, red/green verified
- [x] Full kernel + unit suites pass locally
- [ ] No user-facing text changes in this PR
- [x] Update hook added (`mukurtu_multilingual_update_40008`) — `isNew()`-guarded, safe no-op on sites that already have the config
- [ ] WCAG/accessibility: no markup changes, N/A
- [ ] **Reindex note for release**: enabling translation on 7 media bundles changes what Search API considers translatable content on those bundles going forward — flag in release notes per the roadmap's Phase 4 guidance, though no index config changes in this PR itself.