### PR TITLE
Add regression test for base-field-override label translation sync (#1260)

### DIFF
--- a/modules/mukurtu_multilingual/tests/modules/mukurtu_multilingual_translation_test/config/install/core.base_field_override.node.mlt_test.title.yml
+++ b/modules/mukurtu_multilingual/tests/modules/mukurtu_multilingual_translation_test/config/install/core.base_field_override.node.mlt_test.title.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.mlt_test
+id: node.mlt_test.title
+field_name: title
+entity_type: node
+bundle: mlt_test
+label: 'MLT Test Label'
+description: 'MLT Test Description'
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/modules/mukurtu_multilingual/tests/modules/mukurtu_multilingual_translation_test/config/install/node.type.mlt_test.yml
+++ b/modules/mukurtu_multilingual/tests/modules/mukurtu_multilingual_translation_test/config/install/node.type.mlt_test.yml
@@ -1,0 +1,10 @@
+langcode: en
+status: true
+dependencies: {  }
+name: 'MLT Test'
+type: mlt_test
+description: ''
+help: ''
+new_revision: true
+preview_mode: 1
+display_submitted: true

--- a/modules/mukurtu_multilingual/tests/modules/mukurtu_multilingual_translation_test/mukurtu_multilingual_translation_test.info.yml
+++ b/modules/mukurtu_multilingual/tests/modules/mukurtu_multilingual_translation_test/mukurtu_multilingual_translation_test.info.yml
@@ -1,0 +1,8 @@
+name: 'Mukurtu Multilingual translation testing module'
+type: module
+description: 'Ships a real config/install base field override, so BaseFieldOverrideLabelTranslationTest can exercise Drupal core''s locale config-sync path against actually-shipped default configuration rather than a programmatically-created entity.'
+package: Testing
+version: '8.x-1.x-dev'
+dependencies:
+  - drupal:node
+  - drupal:field

--- a/modules/mukurtu_multilingual/tests/src/Kernel/BaseFieldOverrideLabelTranslationTest.php
+++ b/modules/mukurtu_multilingual/tests/src/Kernel/BaseFieldOverrideLabelTranslationTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\mukurtu_multilingual\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\language\Entity\ConfigurableLanguage;
+use Drupal\locale\SourceString;
+
+/**
+ * Confirms that Drupal core's own locale config-sync mechanism, not any
+ * Mukurtu code, is what makes a field label/description's interface
+ * translation appear on core.base_field_override.* config.
+ *
+ * The Phase 1 t()-wrapping sweep (#1611) only matters on a multilingual
+ * site for fields with no bundle-specific override (their label renders
+ * directly from the code's t() call). For any field that HAS a
+ * core.base_field_override.* - which is common in this codebase, and
+ * Phase 3.2 (#1260) just added more of them for the 12 media/taxonomy/
+ * block/paragraph bundles it covers - the override's plain-string label
+ * shadows the code's t() call entirely on the edit form. This was
+ * initially assumed to need new sync code (see the original Phase 3.3
+ * plan), but core.base_field_override.*'s label/description are already
+ * marked translatable in Drupal core's own schema
+ * (core.data_types.schema.yml: field_config_base.label -> required_label
+ * -> label, and .description -> text; both translatable: true), and
+ * core's locale module already calls
+ * LocaleConfigManager::updateConfigTranslations() - via
+ * _locale_refresh_configuration() - both when a translator saves a string
+ * at /admin/config/regional/translate (TranslateEditForm::submitForm())
+ * and when a new language's .po translations are imported
+ * (LocaleImportBatch, LocaleConfigBatch). No Mukurtu code is involved.
+ *
+ * LocaleConfigManager::getTranslatableDefaultConfig() reads from each
+ * enabled module's actually-shipped config/install/*.yml (via
+ * LocaleDefaultConfigStorage), not from an arbitrary active config entity,
+ * so this test uses a small fixture module (mukurtu_multilingual_
+ * translation_test) that ships one real core.base_field_override.*.yml,
+ * rather than mukurtu_multilingual itself, whose real base field
+ * overrides all live behind a heavy dependency chain (mukurtu_protocol,
+ * mukurtu_collection, mukurtu_multipage_items).
+ *
+ * @group mukurtu_multilingual
+ */
+class BaseFieldOverrideLabelTranslationTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'node',
+    'language',
+    'locale',
+    'content_translation',
+    'mukurtu_multilingual_translation_test',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('node');
+    $this->installSchema('locale', ['locales_source', 'locales_target', 'locales_location']);
+    $this->installConfig(['field', 'node', 'mukurtu_multilingual_translation_test']);
+
+    ConfigurableLanguage::createFromLangcode('es')->save();
+  }
+
+  /**
+   * Translating a field label's source string via the standard locale
+   * storage API - the same path /admin/config/regional/translate uses -
+   * causes the translation to appear on the field's base field override
+   * config, for the exact langcode translated, with no other langcode
+   * affected and no Mukurtu code involved.
+   */
+  public function testInterfaceTranslationSyncsToBaseFieldOverride(): void {
+    $config_name = 'core.base_field_override.node.mlt_test.title';
+    $this->assertSame('MLT Test Label', \Drupal::config($config_name)->get('label'));
+
+    $storage = \Drupal::service('locale.storage');
+    $source = new SourceString();
+    $source->setString('MLT Test Label');
+    $source->setStorage($storage);
+    $source->save();
+
+    $translation = $storage->createTranslation([
+      'lid' => $source->lid,
+      'language' => 'es',
+      'translation' => 'Etiqueta de prueba MLT',
+    ]);
+    $translation->save();
+
+    // On a real site, _locale_refresh_configuration() - called by
+    // TranslateEditForm::submitForm() after saving a translation in the UI -
+    // resolves the lid to this config name via {locales_location}, a table
+    // populated by locale's own config-translation processing (e.g. a prior
+    // visit to /admin/config/regional/translate), which this test does not
+    // exercise. Call the underlying sync directly with the known config
+    // name instead - LocaleConfigManager::updateConfigTranslations() is the
+    // actual translation-sync logic under test; the lid lookup is a mature,
+    // separately-tested Drupal core concern.
+    \Drupal::service('locale.config_manager')->updateConfigTranslations([$config_name], ['es']);
+
+    $override_es = \Drupal::languageManager()->getLanguageConfigOverride('es', $config_name);
+    $this->assertFalse($override_es->isNew(), 'Expected a language override to have been created for es.');
+    $this->assertSame('Etiqueta de prueba MLT', $override_es->get('label'));
+
+    // The base (default-language) config is untouched.
+    $this->assertSame('MLT Test Label', \Drupal::config($config_name)->get('label'));
+
+    // A langcode with no translation gets no override.
+    ConfigurableLanguage::createFromLangcode('fr')->save();
+    $override_fr = \Drupal::languageManager()->getLanguageConfigOverride('fr', $config_name);
+    $this->assertTrue($override_fr->isNew(), 'Did not expect an override for a langcode with no translation.');
+  }
+
+}


### PR DESCRIPTION
## Summary

Stacked on #1970. This PR started as the originally-planned Phase 3.3 ("sync locale/interface translations of field label/description source strings into `language.<langcode>.core.base_field_override.*` config overrides... genuinely new code, add `mukurtu_multilingual.module` + a small `src/` service"), but that turned out to be based on an incorrect premise.

**Why no new code**: Phase 1 (#1611) wrapped field `setLabel()`/`setDescription()` calls in `t()`. That only matters on a multilingual site for fields with no bundle-specific `core.base_field_override.*` — when an override exists (common in this codebase; #1970 just added more), the override's plain-string `label`/`description` shadows the code's `t()` call entirely on the edit form. I initially assumed this needed new sync code, matching the roadmap. Before writing it, I verified empirically that Drupal core already handles this with no Mukurtu code involved:

- `core.base_field_override.*`'s `label` and `description` are already marked `translatable: true` in Drupal core's own schema (`core.data_types.schema.yml`: `field_config_base.label` → `required_label` → `label`, and `.description` → `text`).
- Core's `locale` module already calls `LocaleConfigManager::updateConfigTranslations()` (via `_locale_refresh_configuration()`) both when a translator saves a string at `/admin/config/regional/translate` (`TranslateEditForm::submitForm()`) and when a new language's `.po` translations are imported (`LocaleImportBatch`, `LocaleConfigBatch`).
- Reproduced this against a real Mukurtu site in a local sandbox before writing any test: saved an interface translation for a field label's source string via the same locale storage API core's translate form uses, called core's own sync function, and confirmed the `language.es.core.base_field_override.*` override was created with the translated label — zero custom code.

Given that, this PR adds only a regression test locking in the reliance on this core behavior, so a future Drupal core change that breaks it is caught here instead of silently reappearing as untranslated field labels on multilingual sites.

**Test module note**: `LocaleConfigManager::getTranslatableDefaultConfig()` reads from each enabled module's actually-shipped `config/install/*.yml` (via `LocaleDefaultConfigStorage`), not from an arbitrary active config entity — a plain `BaseFieldOverride::create()->save()` in a test doesn't exercise the real path. `mukurtu_multilingual` itself has a heavy dependency chain (`mukurtu_protocol`, `mukurtu_collection`, `mukurtu_multipage_items`) unsuitable for a kernel test, so this adds a small fixture module (`mukurtu_multilingual_translation_test`, under `tests/modules/`) shipping one real `core.base_field_override.*.yml`, following the same pattern already used by `mukurtu_drafts`'s `drafts_entity_test`.

**Docs note**: the roadmap's Phase 0 also planned a `docs/content-language-policy.md` doc (PR #1949, not yet merged, not in this branch's lineage) that this finding should be noted in. Deferring that doc update to whoever finishes #1949, rather than forcing an artificial dependency on an unrelated, unmerged phase.

## Test plan

- New kernel test `BaseFieldOverrideLabelTranslationTest`: saves an interface translation for a real shipped field label via the standard locale storage API, calls Drupal core's own `LocaleConfigManager::updateConfigTranslations()` (the same sync `_locale_refresh_configuration()` triggers), and asserts the translated override was created for the translated langcode only, the base config is untouched, and an untranslated langcode gets no override.
- Red/green verified: removed the sync call, confirmed the test fails, restored it and confirmed it passes.
- Full kernel suite run locally: 334 tests, 0 failures.

## Pre-merge checklist

- [x] Branched off #1970 (`1260-multilingual-config-coverage`) — part of the same Phase 3 dependency chain (#1950 → #1962 → #1970 → this PR). Retarget to `main` once the chain merges.
- [x] Kernel test added, red/green verified
- [x] Full kernel suite passes locally
- [ ] No user-facing text changes in this PR
- [ ] No update hook needed — no production code changes
- [ ] WCAG/accessibility: no markup changes, N/A