### PR TITLE
Backfill 'view the administration theme' permission (fixes #1992)

### DIFF
--- a/modules/mukurtu_core/tests/src/Kernel/AdminThemePermissionUpdateTest.php
+++ b/modules/mukurtu_core/tests/src/Kernel/AdminThemePermissionUpdateTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\mukurtu_core\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\user\Entity\Role;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Tests mukurtu_update_40003(), which grants the admin theme permission.
+ *
+ * @see mukurtu_update_40003()
+ */
+#[Group('mukurtu_core')]
+class AdminThemePermissionUpdateTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $profile_path = \Drupal::service('extension.list.profile')->getPath('mukurtu');
+    require_once $profile_path . '/mukurtu.install';
+  }
+
+  /**
+   * The update hook grants the permission when it's missing.
+   */
+  public function testUpdateGrantsPermission(): void {
+    $role = Role::create(['id' => 'authenticated', 'label' => 'Authenticated user']);
+    $role->save();
+
+    mukurtu_update_40003();
+
+    $role = Role::load('authenticated');
+    $this->assertTrue($role->hasPermission('view the administration theme'));
+  }
+
+  /**
+   * The update hook is idempotent when the permission is already granted.
+   */
+  public function testUpdateIsIdempotent(): void {
+    $role = Role::create(['id' => 'authenticated', 'label' => 'Authenticated user']);
+    $role->grantPermission('view the administration theme');
+    $role->save();
+
+    mukurtu_update_40003();
+
+    $role = Role::load('authenticated');
+    $this->assertTrue($role->hasPermission('view the administration theme'));
+  }
+
+  /**
+   * The update hook is a no-op when the authenticated role doesn't exist.
+   */
+  public function testUpdateIsNoOpWithoutRole(): void {
+    $this->assertNull(Role::load('authenticated'));
+    mukurtu_update_40003();
+    $this->assertNull(Role::load('authenticated'));
+  }
+
+}

--- a/mukurtu.install
+++ b/mukurtu.install
@@ -918,4 +918,25 @@ function mukurtu_update_40002(): void {
   }
 }
 
+/**
+ * Grant the authenticated role permission to view the administration theme.
+ *
+ * Entity Browser's modal routes only render in the Gin admin theme when the
+ * current user has this permission (see AdminNegotiator::applies()).
+ * mukurtu_install() grants it to 'authenticated', but no update hook ever
+ * backfilled it for sites installed before that grant existed - unlike
+ * mukurtu_core_update_40028(), which backfilled the sibling "access ...
+ * entity browser pages" permissions. Sites missing this permission see
+ * entity browser modals (collections, word lists, related content, personal
+ * collections, protocol community-select, featured content) fall back to
+ * the front-end theme, which lacks Gin's ajax-throbber styling.
+ */
+function mukurtu_update_40003(): void {
+  $authenticated = Role::load('authenticated');
+  if ($authenticated) {
+    $authenticated->grantPermission('view the administration theme');
+    $authenticated->save();
+  }
+}
+
 


### PR DESCRIPTION
## Summary
- Entity Browser's modal routes only render in the Gin admin theme when the current user holds the `view the administration theme` permission (core's `AdminNegotiator`). `mukurtu_install()` grants it to `authenticated` on fresh installs, but no update hook ever backfilled it for existing/upgraded sites — unlike the sibling entity-browser "access" permissions, which were backfilled in `mukurtu_core_update_40028()`.
- That gap is why logged-in users on existing sites could open collections/word lists/related content/personal collections/protocol community-select/featured content pickers and select items (the access permission was backfilled), but saw the front-end theme instead of Gin with a perpetually stuck AJAX throbber (Gin's throbber CSS never loaded because Gin never rendered).
- Adds `mukurtu_update_40003()` to grant `view the administration theme` to the `authenticated` role, mirroring the exact pattern of `mukurtu_update_40028()`/`mukurtu_update_40002()`.
- Adds a kernel test (`AdminThemePermissionUpdateTest`) covering grant-when-missing, idempotency, and no-op-without-role, mirroring the existing `ArticlePermissionUpdateTest`.

Fixes #1992

## Pre-merge checklist:

- [x] I have checked for and if required, created update hooks.
- [x] I have run an accessibility check, and resolved any issues. (N/A — no UI/markup changes; permission grant only.)
- [x] I have recompiled SCSS if required. (N/A — no SCSS changes.)
- [x] I have updated or created CI/CD tests, if required.
- [x] I have updated from `main` and resolved any merge conflicts.
- [x] If this PR's base branch is not `main`, I understand it needs to be retargeted once that base branch's own PR merges (see [docs/stacked-prs.md](../docs/stacked-prs.md)). (N/A — base is `main`.)
- [ ] I have verified that all expected checks pass.
- [x] I have run the pr-expert-review skill and resolved all relevant issues.

## Test plan
- [ ] CI kernel tests pass (`AdminThemePermissionUpdateTest`)
- [ ] Manually verify on a site missing the permission: run `drush updatedb`, confirm `view the administration theme` is now granted to `authenticated`
- [ ] Log in as an authenticated (non-admin) user and confirm collection/word-list/related-content/personal-collection/protocol/featured-content entity browser modals render in Gin and the throbber clears normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)