### PR TITLE
Fix collections/personal collections grid-list-map styling regressions

### DIFF
--- a/modules/mukurtu_browse/js/mukurtu-browse-view-switch.js
+++ b/modules/mukurtu_browse/js/mukurtu-browse-view-switch.js
@@ -6,7 +6,6 @@
 
   const browseModes = ["list", "grid", "map"];
   const DEFAULT_BROWSE_MODE = "list";
-  let gridLink, listLink, mapLink, mapContent, listContent, gridContent, browseLinks;
 
   function getBrowseMode() {
     const browseMode = localStorage.getItem("browseMode");
@@ -23,69 +22,73 @@
     localStorage.setItem("browseMode", mode);
   }
 
-  function listCheck() {
-    return getBrowseMode() === "list";
+  // Toggling `hidden` off a column-count masonry grid doesn't reliably make
+  // the browser recompute column balance (especially once the grid has
+  // already been balanced once before, e.g. on a prior grid->list->grid
+  // switch), leaving stale, overlapping column layout. Briefly collapsing to
+  // a single column and forcing a reflow before restoring it fixes that.
+  function forceMasonryReflow(el) {
+    const previousColumnCount = el.style.columnCount;
+    el.style.columnCount = "1";
+    void el.offsetHeight;
+    el.style.columnCount = previousColumnCount;
   }
 
-  function gridCheck() {
-    return getBrowseMode() === "grid";
-  }
+  // Each `.browse-container` on the page (e.g. the /browse page and a
+  // Leaflet map popup rendering a Collection's own item browser) gets its
+  // own independent set of elements and state, so switching modes in one
+  // container never affects another container elsewhere on the same page.
+  function init(browseContainer) {
+    const listContent = browseContainer.querySelector(".list");
+    const mapContent = browseContainer.querySelector(".map");
+    const gridContent = browseContainer.querySelector(".grid");
+    const browseLinks = browseContainer.querySelector(".browse-links");
 
-  function mapCheck() {
-    return getBrowseMode() === "map";
-  }
+    const gridLink = browseContainer.querySelector("[data-browse-mode=grid]");
+    const listLink = browseContainer.querySelector("[data-browse-mode=list]");
+    const mapLink = browseContainer.querySelector("[data-browse-mode=map]");
 
-  function handleToggleBrowseMode(e) {
-    toggleBrowseMode(e.target.dataset.browseMode);
-  }
+    function toggleBrowseMode(browseMode) {
+      setBrowseMode(browseMode);
+      const mode = getBrowseMode();
 
-  function toggleBrowseMode(browseMode) {
-    setBrowseMode(browseMode);
+      if (mode === "list") {
+        listLink.classList.add("active-toggle");
+        gridLink?.classList.remove("active-toggle");
+        mapLink?.classList.remove("active-toggle");
 
-    // Then perform class toggling/content visibility toggling based on which
-    // browse mode was set.
-    if (listCheck()) {
-      listLink.classList.add("active-toggle");
-      gridLink?.classList.remove("active-toggle");
-      mapLink?.classList.remove("active-toggle");
+        listContent.hidden = false;
+        mapContent.hidden = true;
+        gridContent.hidden = true;
+      }
 
-      listContent.hidden = false;
-      mapContent.hidden = true;
-      gridContent.hidden = true;
+      if (mode === "grid") {
+        gridLink.classList.add("active-toggle");
+        listLink?.classList.remove("active-toggle");
+        mapLink?.classList.remove("active-toggle");
+
+        gridContent.hidden = false;
+        mapContent.hidden = true;
+        listContent.hidden = true;
+        forceMasonryReflow(gridContent);
+      }
+
+      if (mode === "map") {
+        mapLink.classList.add("active-toggle");
+        listLink?.classList.remove("active-toggle");
+        gridLink?.classList.remove("active-toggle");
+
+        mapContent.hidden = false;
+        listContent.hidden = true;
+        gridContent.hidden = true;
+      }
     }
 
-    if (gridCheck()) {
-      gridLink.classList.add("active-toggle");
-      listLink?.classList.remove("active-toggle");
-      mapLink?.classList.remove("active-toggle");
-
-      gridContent.hidden = false;
-      mapContent.hidden = true;
-      listContent.hidden = true;
-    }
-
-    if (mapCheck()) {
-      mapLink.classList.add("active-toggle");
-      listLink?.classList.remove("active-toggle");
-      gridLink?.classList.remove("active-toggle");
-
-      mapContent.hidden = false;
-      listContent.hidden = true;
-      gridContent.hidden = true;
-    }
-  }
-
-  function init() {
-    listContent = document.querySelector(".list");
-    mapContent = document.querySelector(".map");
-    gridContent = document.querySelector(".grid");
-    browseLinks = document.querySelector(".browse-links");
-
-    gridLink = document.querySelector("[data-browse-mode=grid]");
-    listLink = document.querySelector("[data-browse-mode=list]");
-    mapLink = document.querySelector("[data-browse-mode=map]");
-
-    browseLinks.addEventListener("click", handleToggleBrowseMode);
+    browseLinks.addEventListener("click", (e) => {
+      if (e.target.dataset.browseMode) {
+        toggleBrowseMode(e.target.dataset.browseMode);
+      }
+    });
     toggleBrowseMode(getBrowseMode());
   }
 

--- a/modules/mukurtu_collection/config/install/core.entity_view_display.personal_collection.personal_collection.full.yml
+++ b/modules/mukurtu_collection/config/install/core.entity_view_display.personal_collection.personal_collection.full.yml
@@ -26,11 +26,9 @@ content:
     weight: 0
     region: content
   field_items_in_collection:
-    type: entity_reference_entity_view
-    label: above
-    settings:
-      view_mode: grid_browse
-      link: false
+    type: mukurtu_collection_items_browse
+    label: hidden
+    settings: {  }
     third_party_settings: {  }
     weight: 4
     region: content

--- a/modules/mukurtu_collection/config/install/views.view.mukurtu_collection_items.yml
+++ b/modules/mukurtu_collection/config/install/views.view.mukurtu_collection_items.yml
@@ -14,7 +14,7 @@ dependencies:
 id: mukurtu_collection_items
 label: 'Mukurtu Collection Items'
 module: views
-description: 'Grid/list/map display of the items referenced by a Collection, used on the collection page.'
+description: 'Grid/list/map display of the items referenced by a Collection or Personal collection, used on the collection/personal collection page.'
 tag: ''
 base_table: node_field_data
 base_field: nid
@@ -97,7 +97,6 @@ display:
             fail: 'not found'
           validate_options: {  }
           break_phrase: false
-          not: false
       filters: {  }
       filter_groups:
         operator: AND
@@ -167,6 +166,124 @@ display:
         options:
           view_mode: grid_browse
       defaults:
+        row: false
+        css_class: false
+      css_class: 'browse-content grid'
+      display_description: ''
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_interface'
+        - url
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  mukurtu_personal_collection_items_block:
+    id: mukurtu_personal_collection_items_block
+    display_title: 'Personal Collection List View Block'
+    display_plugin: block
+    position: 4
+    display_options:
+      arguments:
+        nid:
+          id: nid
+          table: node_field_data
+          field: mukurtu_personal_collection_items
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: mukurtu_personal_collection_items
+          default_action: empty
+          exception:
+            title_enable: false
+            title: All
+            value: all
+          title_enable: false
+          title: ''
+          default_argument_type: fixed
+          default_argument_options:
+            argument: ''
+          summary_options:
+            base_path: ''
+            count: true
+            override: false
+            items_per_page: 25
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: false
+      row:
+        type: entity:node
+        options:
+          view_mode: browse
+      defaults:
+        arguments: false
+        row: false
+        css_class: false
+      css_class: 'browse-content list'
+      display_description: ''
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_interface'
+        - url
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  mukurtu_personal_collection_items_block_grid:
+    id: mukurtu_personal_collection_items_block_grid
+    display_title: 'Personal Collection Grid View Block'
+    display_plugin: block
+    position: 5
+    display_options:
+      arguments:
+        nid:
+          id: nid
+          table: node_field_data
+          field: mukurtu_personal_collection_items
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: mukurtu_personal_collection_items
+          default_action: empty
+          exception:
+            title_enable: false
+            title: All
+            value: all
+          title_enable: false
+          title: ''
+          default_argument_type: fixed
+          default_argument_options:
+            argument: ''
+          summary_options:
+            base_path: ''
+            count: true
+            override: false
+            items_per_page: 25
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: false
+      row:
+        type: entity:node
+        options:
+          view_mode: grid_browse
+      defaults:
+        arguments: false
         row: false
         css_class: false
       css_class: 'browse-content grid'
@@ -391,6 +508,268 @@ display:
       row:
         type: fields
       defaults:
+        fields: false
+        style: false
+        row: false
+        css_class: false
+      css_class: 'browse-content map'
+      display_description: ''
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  mukurtu_personal_collection_items_block_map:
+    id: mukurtu_personal_collection_items_block_map
+    display_title: 'Personal Collection Map View Block'
+    display_plugin: block
+    position: 6
+    display_options:
+      arguments:
+        nid:
+          id: nid
+          table: node_field_data
+          field: mukurtu_personal_collection_items
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: mukurtu_personal_collection_items
+          default_action: empty
+          exception:
+            title_enable: false
+            title: All
+            value: all
+          title_enable: false
+          title: ''
+          default_argument_type: fixed
+          default_argument_options:
+            argument: ''
+          summary_options:
+            base_path: ''
+            count: true
+            override: false
+            items_per_page: 25
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: false
+      fields:
+        nid:
+          id: nid
+          table: node_field_data
+          field: nid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: nid
+          plugin_id: field
+          label: ''
+          exclude: true
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: number_integer
+          settings:
+            thousand_separator: ''
+            prefix_suffix: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: field
+          label: ''
+          exclude: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_coverage:
+          id: field_coverage
+          table: node__field_coverage
+          field: field_coverage
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: field_coverage
+          plugin_id: field
+          label: ''
+          exclude: true
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: geofield_default
+          settings:
+            output_format: json
+            output_escape: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+      style:
+        type: leaflet_map
+        options:
+          grouping:
+            -
+              field: field_coverage
+              rendered: true
+              overlays_options:
+                disabled_overlays: {  }
+                hidden_overlays_controls: {  }
+          data_source:
+            field_coverage: field_coverage
+          entity_source: __base_table
+          name_field: title
+          leaflet_tooltip:
+            value: ''
+            options: '{"permanent":false,"direction":"center"}'
+          leaflet_popup:
+            value: '#rendered_view_fields'
+            view_mode: map_browse
+            options: '{"maxWidth":"400","minWidth":"300","autoPan":true}'
+          leaflet_map: 'OSM Mapnik'
+          height: '600'
+          height_unit: px
+          hide_empty_map: true
+          disable_wheel: false
+          gesture_handling: false
+          fitbounds_options: '{"padding":[0,0]}'
+          reset_map:
+            control: false
+            options: '{"position":"topleft","title":"Reset View"}'
+          map_scale:
+            control: false
+            options: '{"position":"bottomright","maxWidth":100,"metric":true,"imperial":false,"updateWhenIdle":false}'
+          locate:
+            control: false
+            options: '{"position":"topright","setView":"untilPanOrZoom","returnToPrevBounds":true,"keepCurrentZoomLevel":true,"strings":{"title":"Locate my position"}}'
+            automatic: false
+          map_position:
+            force: false
+            center:
+              lat: 0.0
+              lon: 0.0
+            zoomControlPosition: topleft
+            zoom: 12
+            minZoom: 2
+            maxZoom: 18
+            zoomFiner: 0
+          weight: ''
+          icon:
+            iconType: marker
+            iconUrl: ''
+            shadowUrl: ''
+            className: ''
+            iconSize:
+              x: ''
+              'y': ''
+            iconAnchor:
+              x: ''
+              'y': ''
+            shadowSize:
+              x: ''
+              'y': ''
+            shadowAnchor:
+              x: ''
+              'y': ''
+            popupAnchor:
+              x: ''
+              'y': ''
+            html: '<div></div>'
+            html_class: leaflet-map-divicon
+            circle_marker_options: '{"radius":100,"color":"red","fillColor":"#f03","fillOpacity":0.5}'
+          leaflet_markercluster:
+            control: true
+            excluded: ''
+            options: '{"spiderfyOnMaxZoom":true,"showCoverageOnHover":true,"removeOutsideVisibleBounds": false}'
+            include_path: true
+          fullscreen:
+            control: false
+            options: '{"position":"topleft","pseudoFullscreen":false}'
+          path: '{"color":"#3388ff","opacity":"1.0","stroke":true,"weight":3,"fill":"depends","fillColor":"*","fillOpacity":"0.2","radius":"6"}'
+          feature_properties:
+            values: ''
+          map_lazy_load:
+            lazy_load: false
+      row:
+        type: fields
+      defaults:
+        arguments: false
         fields: false
         style: false
         row: false

--- a/modules/mukurtu_collection/mukurtu_collection.install
+++ b/modules/mukurtu_collection/mukurtu_collection.install
@@ -396,3 +396,37 @@ function mukurtu_collection_update_40018(): void {
   $config->set('content.field_coverage.settings.map.map_position.singlePointZoom', 12);
   $config->save();
 }
+
+/**
+ * Give personal collections the same grid/list/map switcher as collections.
+ *
+ * Re-imports the mukurtu_collection_items view (now with personal-collection
+ * scoped displays) and switches field_items_in_collection on the personal
+ * collection full display to the mukurtu_collection_items_browse formatter,
+ * matching the regular collection page (#1993).
+ */
+function mukurtu_collection_update_40019(): void {
+  $config_source = new \Drupal\Core\Config\FileStorage(
+    \Drupal::service('extension.list.module')->getPath('mukurtu_collection') . '/config/install'
+  );
+
+  $view_name = 'views.view.mukurtu_collection_items';
+  $data = $config_source->read($view_name);
+  if ($data) {
+    \Drupal::configFactory()->getEditable($view_name)->setData($data)->save(TRUE);
+  }
+
+  $config = \Drupal::configFactory()->getEditable('core.entity_view_display.personal_collection.personal_collection.full');
+  if ($config->isNew()) {
+    return;
+  }
+  $config->set('content.field_items_in_collection', [
+    'type' => 'mukurtu_collection_items_browse',
+    'label' => 'hidden',
+    'settings' => [],
+    'third_party_settings' => [],
+    'weight' => 4,
+    'region' => 'content',
+  ]);
+  $config->save();
+}

--- a/modules/mukurtu_collection/mukurtu_collection.module
+++ b/modules/mukurtu_collection/mukurtu_collection.module
@@ -64,6 +64,15 @@ function mukurtu_collection_views_data_alter(array &$data) {
       'real field' => 'nid',
     ],
   ];
+  $data['node_field_data']['mukurtu_personal_collection_items'] = [
+    'title' => t('Items in Personal Collection'),
+    'help' => t('Scope Content to the items referenced by a Personal collection.'),
+    'argument' => [
+      'id' => 'mukurtu_personal_collection_items',
+      'field' => 'nid',
+      'real field' => 'nid',
+    ],
+  ];
 }
 
 /**

--- a/modules/mukurtu_collection/src/Plugin/Field/FieldFormatter/CollectionItemsBrowseFormatter.php
+++ b/modules/mukurtu_collection/src/Plugin/Field/FieldFormatter/CollectionItemsBrowseFormatter.php
@@ -24,13 +24,17 @@ class CollectionItemsBrowseFormatter extends FormatterBase {
    */
   public function viewElements(FieldItemListInterface $items, $langcode) {
     $collection = $items->getEntity();
-    $nid = $collection->id();
+    $id = $collection->id();
 
-    if (!$nid) {
+    if (!$id) {
       return [];
     }
 
-    $displays = [
+    $displays = $collection->getEntityTypeId() === 'personal_collection' ? [
+      'list_results' => 'mukurtu_personal_collection_items_block',
+      'grid_results' => 'mukurtu_personal_collection_items_block_grid',
+      'map_results' => 'mukurtu_personal_collection_items_block_map',
+    ] : [
       'list_results' => 'mukurtu_collection_items_block',
       'grid_results' => 'mukurtu_collection_items_block_grid',
       'map_results' => 'mukurtu_collection_items_block_map',
@@ -43,7 +47,7 @@ class CollectionItemsBrowseFormatter extends FormatterBase {
         $results[$key] = [];
         continue;
       }
-      $results[$key] = $view->buildRenderable($display_id, [$nid]);
+      $results[$key] = $view->buildRenderable($display_id, [$id]);
     }
 
     return [

--- a/modules/mukurtu_collection/src/Plugin/views/argument/PersonalCollectionItemsArgument.php
+++ b/modules/mukurtu_collection/src/Plugin/views/argument/PersonalCollectionItemsArgument.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Drupal\mukurtu_collection\Plugin\views\argument;
+
+use Drupal\views\Attribute\ViewsArgument;
+use Drupal\views\Plugin\views\argument\ArgumentPluginBase;
+use Drupal\views\Plugin\views\query\Sql;
+
+/**
+ * Argument handler to scope a Content view to the items in a personal collection.
+ *
+ * Accepts the id of a Personal collection and filters the base Content query
+ * to only the nodes referenced by that personal collection's
+ * field_items_in_collection, ordered to match the collection's curated
+ * order.
+ */
+#[ViewsArgument(
+  id: 'mukurtu_personal_collection_items',
+)]
+class PersonalCollectionItemsArgument extends ArgumentPluginBase {
+
+  public function query($group_by = FALSE): void {
+    $this->ensureMyTable();
+
+    $query = $this->query;
+    if (!$query instanceof Sql) {
+      return;
+    }
+
+    $configuration = [
+      'table' => 'personal_collection__field_items_in_collection',
+      'field' => 'field_items_in_collection_target_id',
+      'left_table' => $this->tableAlias,
+      'left_field' => 'nid',
+      'operator' => '=',
+      'extra' => [
+        ['field' => 'deleted', 'value' => 0],
+      ],
+    ];
+    $join = \Drupal::service('plugin.manager.views.join')->createInstance('standard', $configuration);
+    $alias = $query->addTable('personal_collection__field_items_in_collection', $this->relationship, $join);
+
+    $query->addWhere(0, "$alias.entity_id", $this->argument, '=');
+    $query->addOrderBy($alias, 'delta', 'ASC');
+  }
+
+}

--- a/modules/mukurtu_collection/tests/src/Kernel/PersonalCollectionItemsBrowseTest.php
+++ b/modules/mukurtu_collection/tests/src/Kernel/PersonalCollectionItemsBrowseTest.php
@@ -1,0 +1,263 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\mukurtu_collection\Kernel;
+
+use PHPUnit\Framework\Attributes\Group;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\Core\Config\FileStorage;
+use Drupal\Core\Render\RenderContext;
+use Drupal\mukurtu_collection\Entity\PersonalCollection;
+use Drupal\node\Entity\Node;
+use Drupal\node\Entity\NodeType;
+use Drupal\user\Entity\Role;
+use Drupal\user\Entity\User;
+use Drupal\views\Views;
+
+/**
+ * Tests the grid/list/map item browse view and formatter for personal collections.
+ *
+ * Regression coverage for #1993: personal collections used to render
+ * field_items_in_collection with a plain entity_reference_entity_view
+ * formatter instead of the mukurtu_collection_items_browse switcher that
+ * regular collections already had.
+ */
+#[Group('mukurtu_collection')]
+class PersonalCollectionItemsBrowseTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   *
+   * This list matches Drupal\Tests\mukurtu_protocol\Kernel\ProtocolAwareEntityTestBase's
+   * module set (plus leaflet_views/mukurtu_collection): installEntitySchema('node')
+   * computes the shared node table schema across *every* registered bundle
+   * field, including the Collection bundle's field_cultural_protocols,
+   * field_collection_image, field_keywords, etc. -- so every field
+   * type/target entity type those fields reference must be resolvable here
+   * even though this test never creates a "collection" bundle node.
+   */
+  protected static $modules = [
+    'content_moderation',
+    'field',
+    'file',
+    'filter',
+    'geofield',
+    'image',
+    'layout_builder',
+    'leaflet',
+    'leaflet_views',
+    'media',
+    'node',
+    'og',
+    'options',
+    'path_alias',
+    'system',
+    'taxonomy',
+    'text',
+    'user',
+    'views',
+    'workflows',
+    'mukurtu_core',
+    'mukurtu_collection',
+    'mukurtu_local_contexts',
+    'mukurtu_protocol',
+  ];
+
+  /**
+   * The owner of the test personal collection and its items.
+   *
+   * @var \Drupal\user\Entity\User
+   */
+  protected $owner;
+
+  /**
+   * The test personal collection.
+   *
+   * @var \Drupal\mukurtu_collection\Entity\PersonalCollectionInterface
+   */
+  protected $personalCollection;
+
+  /**
+   * The nodes referenced by the test personal collection, in curated order.
+   *
+   * @var \Drupal\node\Entity\Node[]
+   */
+  protected $items = [];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('node');
+    $this->installEntitySchema('personal_collection');
+    $this->installEntitySchema('og_membership');
+    $this->installEntitySchema('path_alias');
+    $this->installSchema('system', ['sequences']);
+    $this->installSchema('node', ['node_access']);
+    $this->installConfig(['system']);
+
+    // Import only the specific shipped config this test exercises, rather
+    // than installConfig()'ing the whole mukurtu_core/mukurtu_collection
+    // module (which pulls in unrelated config -- media types, entity
+    // browsers, taxonomy vocabularies, etc. -- with their own heavy module
+    // dependency chains that have nothing to do with the grid/list/map
+    // switcher being tested here).
+    $this->importModuleConfig('mukurtu_collection', 'views.view.mukurtu_collection_items');
+    $this->importModuleConfig('mukurtu_collection', 'core.entity_view_display.personal_collection.personal_collection.full');
+
+    NodeType::create([
+      'type' => 'page',
+      'name' => 'Basic page',
+    ])->save();
+
+    $role = Role::create([
+      'id' => 'authenticated',
+      'label' => 'authenticated',
+    ]);
+    $role->grantPermission('access content');
+    $role->grantPermission('view published personal collection entities');
+    $role->save();
+
+    $owner = User::create(['name' => $this->randomString()]);
+    $owner->save();
+    $this->owner = $owner;
+
+    // Field rendering (FieldItemList::view()) checks entity/field access
+    // against the current user, which otherwise defaults to anonymous
+    // (uid 0, no permissions) in a Kernel test.
+    \Drupal::service('current_user')->setAccount($owner);
+
+    foreach (range(0, 2) as $delta) {
+      $node = Node::create([
+        // randomMachineName() (not randomString()) so the title is safe to
+        // string-match against rendered, HTML-escaped output.
+        'title' => $this->randomMachineName(),
+        'type' => 'page',
+        'status' => TRUE,
+        'uid' => $owner->id(),
+      ]);
+      $node->save();
+      $this->items[] = $node;
+    }
+
+    $this->personalCollection = PersonalCollection::create([
+      'name' => $this->randomString(),
+      'status' => TRUE,
+      'uid' => $owner->id(),
+      'field_items_in_collection' => array_map(
+        fn(Node $node) => $node->id(),
+        $this->items
+      ),
+    ]);
+    $this->personalCollection->save();
+  }
+
+  /**
+   * Imports a single shipped config object from a module's config/install.
+   */
+  protected function importModuleConfig(string $module, string $name): void {
+    $storage = new FileStorage(
+      \Drupal::service('extension.list.module')->getPath($module) . '/config/install'
+    );
+    $data = $storage->read($name);
+    $this->assertNotFalse($data, "Missing shipped config $name in module $module.");
+    \Drupal::configFactory()->getEditable($name)->setData($data)->save(TRUE);
+  }
+
+  /**
+   * Data provider of the personal-collection block display ids to test.
+   */
+  public static function personalCollectionDisplayProvider(): array {
+    return [
+      'list display' => ['mukurtu_personal_collection_items_block'],
+      'grid display' => ['mukurtu_personal_collection_items_block_grid'],
+    ];
+  }
+
+  /**
+   * The new personal-collection displays return the collection's own items.
+   */
+  #[\PHPUnit\Framework\Attributes\DataProvider('personalCollectionDisplayProvider')]
+  public function testPersonalCollectionDisplayReturnsItemsInOrder(string $displayId): void {
+    $view = Views::getView('mukurtu_collection_items');
+    $this->assertNotNull($view, 'The mukurtu_collection_items view exists.');
+
+    $view->setDisplay($displayId);
+    $view->preExecute([(string) $this->personalCollection->id()]);
+    $view->execute();
+
+    $resultNids = array_map(fn($row) => (int) $row->nid, $view->result);
+    $expectedNids = array_map(fn(Node $node) => (int) $node->id(), $this->items);
+
+    $this->assertSame($expectedNids, $resultNids, "The $displayId display must return the personal collection's items, in curated order.");
+  }
+
+  /**
+   * The new displays are scoped to the given personal collection only.
+   */
+  public function testPersonalCollectionDisplayIsScopedToOwnItems(): void {
+    $otherNode = Node::create([
+      'title' => $this->randomString(),
+      'type' => 'page',
+      'status' => TRUE,
+      'uid' => $this->owner->id(),
+    ]);
+    $otherNode->save();
+
+    $otherPersonalCollection = PersonalCollection::create([
+      'name' => $this->randomString(),
+      'status' => TRUE,
+      'uid' => $this->owner->id(),
+      'field_items_in_collection' => [$otherNode->id()],
+    ]);
+    $otherPersonalCollection->save();
+
+    $view = Views::getView('mukurtu_collection_items');
+    $view->setDisplay('mukurtu_personal_collection_items_block');
+    $view->preExecute([(string) $this->personalCollection->id()]);
+    $view->execute();
+
+    $resultNids = array_map(fn($row) => (int) $row->nid, $view->result);
+    $this->assertNotContains((int) $otherNode->id(), $resultNids, 'A personal collection must not show another personal collection\'s items.');
+  }
+
+  /**
+   * The field formatter picks the personal-collection displays by entity type.
+   */
+  public function testFormatterUsesPersonalCollectionDisplays(): void {
+    $build = $this->personalCollection
+      ->get('field_items_in_collection')
+      ->view('full');
+
+    // The field formatter output is the single mukurtu_collection_items_browse
+    // theme element produced by CollectionItemsBrowseFormatter::viewElements().
+    $element = $build[0] ?? NULL;
+    $this->assertNotNull($element);
+    $this->assertSame('mukurtu_collection_items_browse', $element['#theme'] ?? NULL);
+
+    // Render only the list results (not the whole element, which would also
+    // render the map results -- the Leaflet map style isn't fully
+    // renderable in this minimal Kernel test environment, a pre-existing gap
+    // in the identical, already-shipped map display, unrelated to this fix).
+    $renderer = \Drupal::service('renderer');
+    $listHtml = (string) $renderer->executeInRenderContext(new RenderContext(), function () use ($renderer, $element) {
+      return $renderer->render($element['#list_results']);
+    });
+
+    // The grid/list/map switcher markup must be present (mukurtu-collection-items-browse.html.twig
+    // renders the buttons statically alongside the results), and the
+    // personal collection's own items must actually be listed -- regression
+    // coverage for #1993, where personal collections fell back to a plain,
+    // switcher-less item list.
+    $this->assertArrayHasKey('#grid_results', $element);
+    $this->assertArrayHasKey('#map_results', $element);
+    foreach ($this->items as $node) {
+      $this->assertStringContainsString($node->label(), $listHtml);
+    }
+  }
+
+}

--- a/themes/mukurtu_v4/components/02-molecules/menus/js/nav-resize.js
+++ b/themes/mukurtu_v4/components/02-molecules/menus/js/nav-resize.js
@@ -20,7 +20,6 @@
     // navigation items always causes the primary navigation to wrap, and the
     // page is loaded at a narrower viewport and then widened, the mobile nav
     // may not be enabled.
-    console.log(navWrapper.clientHeight, navItem.clientHeight);
     if (navWrapper.clientHeight > navItem.clientHeight) {
       document.body.classList.add('is-always-mobile-nav');
     }
@@ -64,9 +63,19 @@
    *
    * @param {Element} primaryNav - The primary navigation's top-level <ul> element.
    */
-  function init(primaryNav) { console.log('init');
+  function init(primaryNav) {
     const resizeObserver = new ResizeObserver(checkIfDesktopNavigationWraps);
-    resizeObserver.observe(primaryNav);
+
+    // Wait for web fonts to finish loading before taking the first
+    // measurement. Fallback font metrics can render wider/narrower than the
+    // final font, causing a transient wrap that this observer would
+    // otherwise lock in as "always mobile nav" for the rest of the page
+    // view, even though the nav fits fine once the real font is in place.
+    if (document.fonts) {
+      document.fonts.ready.then(() => resizeObserver.observe(primaryNav));
+    } else {
+      resizeObserver.observe(primaryNav);
+    }
   }
 
   /**

--- a/themes/mukurtu_v4/templates/navigation/menu--main.html.twig
+++ b/themes/mukurtu_v4/templates/navigation/menu--main.html.twig
@@ -20,7 +20,7 @@
  * @ingroup themeable
  */
 #}
-{{ attach_library('mukurtu_v4/navigation-primary') }}
+{{ attach_library('mukurtu_v4/olivero-navigation') }}
 
 {% import _self as menus %}
 


### PR DESCRIPTION
## Summary

- Personal collections had lost the grid/list/map item browse switcher entirely (#1993) — `field_items_in_collection` fell back to a plain `entity_reference_entity_view` list with no view toggle. Gives personal collections the same `mukurtu_collection_items_browse` formatter regular collections use, backed by a new personal-collection-scoped views argument (`PersonalCollectionItemsArgument`) and three new block displays (list/grid/map) on the `mukurtu_collection_items` view.
- Switching Grid -> List -> Grid on a collection's item browser left stale, overlapping masonry column layout (#1994). Fixed with a `forceMasonryReflow()` step, and the view-switcher JS is now scoped per `.browse-container` instance instead of sharing module-level state across every instance on a page (which would have broken as soon as personal collections started reusing this same widget).
- Incidental fix found while working on the above: a stale `attach_library('mukurtu_v4/navigation-primary')` reference in the main nav template (that library was never actually defined — only `olivero-navigation` is, in `mukurtu_v4.libraries.yml`), plus a font-loading race in the nav-wrap `ResizeObserver` that could lock a page into "always mobile nav" if measured before web fonts finished loading.

## Test plan

- [x] New kernel test `PersonalCollectionItemsBrowseTest.php` (4 tests / 144 assertions) covers: scoped + ordered results for both new personal-collection block displays, and that the formatter picks the personal-collection displays and renders the switcher + items. Passing in a DDEV sandbox.
- [x] Manually verified in a DDEV sandbox: personal collection page now shows the grid/list/map switcher with correct items; collection page grid<->list<->grid switching no longer leaves stale column layout; primary nav renders correctly at desktop and mobile widths.
- [x] `php -l` clean on all touched/new PHP files.
- [x] Verified new update hook `mukurtu_collection_update_40019()` doesn't collide with any hook added on `main` since this branch started, and updated from `main` after landing the PR (merge, no conflicts).

## Pre-merge checklist:

- [x] I have checked for and if required, created update hooks.
- [x] I have run an accessibility check, and resolved any issues.
- [x] I have recompiled SCSS if required. (No SCSS touched in this PR.)
- [x] I have updated or created CI/CD tests, if required.
- [x] I have updated from `main` and resolved any merge conflicts.
- [ ] If this PR's base branch is not `main`, I understand it needs to be retargeted once that base branch's own PR merges (see [docs/stacked-prs.md](../docs/stacked-prs.md)). (N/A — based on `main`.)
- [ ] I have verified that all expected checks pass. (Pending CI.)
- [x] I have run the pr-expert-review skill and resolved all relevant issues.

Fixes #1993
Fixes #1994

🤖 Generated with [Claude Code](https://claude.com/claude-code)