### PR TITLE
Harden Digital Heritage browse Playwright test against CI timeouts

### DIFF
--- a/tests/playwright/tests/browse.spec.ts
+++ b/tests/playwright/tests/browse.spec.ts
@@ -5,8 +5,11 @@ import { test, expect, Page } from "@playwright/test";
  */
 test('Browse tests - Digital Heritage', async ({ page, browserName }) => {
   await page.goto('/digital-heritage');
-  await page.getByText('Grid', { exact: true }).click();
-  await page.getByText('List', { exact: true }).click();
+  // /digital-heritage renders the list, grid, and map view displays all at
+  // once (see issue #2011), which can take longer than the default 5s
+  // actionTimeout to become clickable on resource-constrained CI runners.
+  await page.getByText('Grid', { exact: true }).click({ timeout: 15000 });
+  await page.getByText('List', { exact: true }).click({ timeout: 15000 });
   // @todo Re-enable Map clicks when there's default content with location data.
   //await page.getByText('Map', { exact: true }).click();
   // @todo Check default content within each tab.


### PR DESCRIPTION
## Summary
- `Browse tests - Digital Heritage` in `tests/playwright/tests/browse.spec.ts` has been consistently timing out clicking the Grid/List toggle on `/digital-heritage` in CI - observed independently on two unrelated PRs (#1927, #1930), failing on every attempt (initial + 2 retries) each time. See #2011 for the full investigation.
- The toggle markup itself is unconditional and hasn't changed recently, so this looks like a pre-existing characteristic of the page (it renders all three list/grid/map view displays up front) exceeding Playwright's default 5s `actionTimeout` under CI's resource-constrained runners, not a real regression.
- Bumps the click timeout for just this interaction to 15s, rather than the global `actionTimeout`, so an actual future regression elsewhere still fails fast.
- Whether the underlying page-load-speed issue is worth fixing on its own (e.g. lazy-loading the non-default view displays) is tracked separately in #2011 - this PR only addresses the CI noise.

## Test plan
- [x] Manually reviewed `mukurtu-browse.html.twig` and `MukurtuDigitalHeritageBrowseController` - confirmed no other cause (toggle isn't conditionally hidden, test ordering is safe via `dependencies: ['default-content']`).
- [ ] CI passes on this PR (will confirm once checks run).

## Pre-merge checklist:

- [x] I have checked for and if required, created update hooks. (not applicable - test-only change)
- [x] I have run an accessibility check, and resolved any issues. (not applicable - test-only change)
- [x] I have recompiled SCSS if required. (not applicable - no theme/SCSS changes)
- [x] I have updated or created CI/CD tests, if required.
- [x] I have updated from `main` and resolved any merge conflicts.
- [ ] If this PR's base branch is not `main`, I understand it needs to be retargeted once that base branch's own PR merges (see docs/stacked-prs.md). (not applicable - based on `main`)
- [ ] I have verified that all expected checks pass.
- [ ] I have run the pr-expert-review skill and resolved all relevant issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)