### PR TITLE
Pin drupal/facets below 3.0.4 to avoid known getSearchApiQuery() crash

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "drupal/entity_reference_revisions": "*",
         "drupal/extlink": "^2.0",
         "drupal/facet_bot_blocker": "^1.0",
-        "drupal/facets": "^3.0",
+        "drupal/facets": ">=3.0 <3.0.4",
         "drupal/facets_reset_button": "^1.0",
         "drupal/field_group": "^4.0",
         "drupal/flag": "^4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "18cf3099d88e24bed9e46774d572550c",
+    "content-hash": "a1de3d6e1ccd6695b155bf61ca4b7a04",
     "packages": [
         {
             "name": "altcha-org/altcha",


### PR DESCRIPTION
## Summary
- `drupal/facets` 3.0.4 has an active, unfixed upstream regression ([drupal.org #3617839](https://www.drupal.org/project/facets/issues/3617839), from changes in #3589162) that fatally crashes `FacetsFilter::query()` with `Call to a member function getSearchApiQuery() on null` whenever a facets-based exposed filter block is rendered standalone via `drupal_block()` outside the view's own execution - exactly the pattern `mukurtu-browse.html.twig` uses for `/digital-heritage` (and likely `/browse`, `/dictionary`).
- This is the **real** root cause of the CI flake investigated in #2011 - #2012's timeout bump didn't help because the page isn't slow, it 500s outright, on every load, even with zero content.
- This repo's own `composer.lock` already correctly pins `3.0.3`, but the `"^3.0"` constraint let Tugboat's build (`.tugboat/config.yml` runs `composer update` against `mukurtu/mukurtu-template`'s own constraints rather than installing from this repo's lock) drift onto the broken 3.0.4 on every fresh preview - which is what's been causing the consistent Playwright "Grid" timeout on PRs #1927/#1930.
- Tightens the constraint to `>=3.0 <3.0.4` so `composer update` can never re-resolve onto the broken release, regardless of lock file. Regenerated `composer.lock`'s content-hash to match; the pinned version itself doesn't change (already 3.0.3).
- Upstream fix MR `!395` was opened today but isn't merged yet, so pin below 3.0.4 until a fixed release ships - then this constraint should be loosened again.
- `MukurtuCMS/mukurtu-template` (the separate repo Tugboat actually resolves dependencies from) likely needs the same constraint; flagging separately rather than in this PR since it's a different repo.

## Test plan
- [x] Reproduced locally: built a fresh DDEV sandbox tracking `main`, confirmed `drupal/facets` 3.0.4 → `/digital-heritage` returns HTTP 500 with zero content installed; downgrading to 3.0.3 in the same sandbox → HTTP 200, Grid/List/Map toggle renders normally.
- [ ] CI passes on this PR.

## Pre-merge checklist:

- [x] I have checked for and if required, created update hooks. (not applicable - composer dependency only, no schema/config change)
- [x] I have run an accessibility check, and resolved any issues. (not applicable - dependency version pin only)
- [x] I have recompiled SCSS if required. (not applicable)
- [x] I have updated or created CI/CD tests, if required. (not applicable - this fixes the environment the existing tests run against)
- [x] I have updated from `main` and resolved any merge conflicts.
- [ ] If this PR's base branch is not `main`, I understand it needs to be retargeted once that base branch's own PR merges (see docs/stacked-prs.md). (not applicable - based on `main`)
- [ ] I have verified that all expected checks pass.
- [ ] I have run the pr-expert-review skill and resolved all relevant issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)