### PR TITLE
Guard dashboard Security block update hook against a missing menu

### DIFF
--- a/modules/mukurtu_core/mukurtu_core.install
+++ b/modules/mukurtu_core/mukurtu_core.install
@@ -2991,7 +2991,7 @@ function mukurtu_core_update_40085(): void {
   // here would leave a dangling "block is broken or missing" placeholder on
   // the dashboard instead of failing loudly.
   if (!\Drupal::entityTypeManager()->getStorage('menu')->load('dashboard-security')) {
-    \Drupal::logger('mukurtu_core')->warning('Skipped adding the Security block to the admin dashboard because the dashboard-security menu does not exist. Ensure the mukurtu_bot_protection module and its dependencies are installed, then rerun database updates.');
+    \Drupal::logger('mukurtu_core')->warning('Skipped adding the Security block to the admin dashboard because the dashboard-security menu does not exist. Install the mukurtu_bot_protection module and its dependencies, then manually re-invoke mukurtu_core_update_40085() (e.g. via `drush php:eval "mukurtu_core_update_40085();"`) to add the block.');
     return;
   }
 

--- a/modules/mukurtu_core/mukurtu_core.install
+++ b/modules/mukurtu_core/mukurtu_core.install
@@ -2984,6 +2984,17 @@ function mukurtu_core_update_40085(): void {
     return;
   }
 
+  // The block plugin is a menu derivative: it only resolves once the
+  // dashboard-security menu (shipped by mukurtu_bot_protection's default
+  // config) actually exists. If module installation in
+  // mukurtu_core_update_40084() didn't complete, adding the block reference
+  // here would leave a dangling "block is broken or missing" placeholder on
+  // the dashboard instead of failing loudly.
+  if (!\Drupal::entityTypeManager()->getStorage('menu')->load('dashboard-security')) {
+    \Drupal::logger('mukurtu_core')->warning('Skipped adding the Security block to the admin dashboard because the dashboard-security menu does not exist. Ensure the mukurtu_bot_protection module and its dependencies are installed, then rerun database updates.');
+    return;
+  }
+
   $uuid = '3f8b6c1a-2e4d-4a9f-9c7b-5d1e8a2f6b3c';
   $sections = $config->get('sections') ?? [];
   if (isset($sections[0]['components'][$uuid])) {

--- a/modules/mukurtu_core/tests/src/Kernel/DashboardSecurityBlockUpdateTest.php
+++ b/modules/mukurtu_core/tests/src/Kernel/DashboardSecurityBlockUpdateTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\mukurtu_core\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Tests mukurtu_core_update_40085(), which adds the Security block to the
+ * Mukurtu admin dashboard.
+ *
+ * @see mukurtu_core_update_40085()
+ */
+#[Group('mukurtu_core')]
+class DashboardSecurityBlockUpdateTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+  ];
+
+  /**
+   * The hook writes a partial dashboards config fixture, not full schema data.
+   *
+   * {@inheritdoc}
+   */
+  protected $strictConfigSchema = FALSE;
+
+  /**
+   * The uuid the update hook uses for the Security block component.
+   */
+  protected const UUID = '3f8b6c1a-2e4d-4a9f-9c7b-5d1e8a2f6b3c';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $module_path = \Drupal::service('extension.list.module')->getPath('mukurtu_core');
+    require_once $module_path . '/mukurtu_core.install';
+  }
+
+  /**
+   * Saves a minimal dashboard config fixture, mirroring the hook's shape.
+   */
+  protected function saveDashboardConfig(): void {
+    \Drupal::configFactory()->getEditable('dashboards.dashboard.mukurtu_dashboard')
+      ->setData([
+        'id' => 'mukurtu_dashboard',
+        'sections' => [
+          [
+            'components' => [],
+          ],
+        ],
+      ])
+      ->save();
+  }
+
+  /**
+   * The update hook adds the block once the dashboard-security menu exists.
+   */
+  public function testUpdateAddsBlockWhenMenuExists(): void {
+    \Drupal::entityTypeManager()->getStorage('menu')->create([
+      'id' => 'dashboard-security',
+      'label' => 'Security',
+    ])->save();
+    $this->saveDashboardConfig();
+
+    mukurtu_core_update_40085();
+
+    $components = \Drupal::config('dashboards.dashboard.mukurtu_dashboard')->get('sections.0.components');
+    $this->assertArrayHasKey(self::UUID, $components);
+    $this->assertEquals('system_menu_block:dashboard-security', $components[self::UUID]['configuration']['id']);
+  }
+
+  /**
+   * The update hook is a no-op when the dashboard-security menu is missing,
+   * so it never writes a block reference the plugin can't resolve.
+   */
+  public function testUpdateSkipsBlockWhenMenuMissing(): void {
+    $this->assertNull(\Drupal::entityTypeManager()->getStorage('menu')->load('dashboard-security'));
+    $this->saveDashboardConfig();
+
+    mukurtu_core_update_40085();
+
+    $components = \Drupal::config('dashboards.dashboard.mukurtu_dashboard')->get('sections.0.components');
+    $this->assertSame([], $components);
+  }
+
+  /**
+   * The update hook is a no-op when the dashboard config doesn't exist.
+   */
+  public function testUpdateIsNoOpWithoutDashboardConfig(): void {
+    \Drupal::entityTypeManager()->getStorage('menu')->create([
+      'id' => 'dashboard-security',
+      'label' => 'Security',
+    ])->save();
+    $this->assertTrue(\Drupal::config('dashboards.dashboard.mukurtu_dashboard')->isNew());
+
+    mukurtu_core_update_40085();
+
+    $this->assertTrue(\Drupal::config('dashboards.dashboard.mukurtu_dashboard')->isNew());
+  }
+
+  /**
+   * The update hook doesn't duplicate the component if it's already present.
+   */
+  public function testUpdateIsIdempotent(): void {
+    \Drupal::entityTypeManager()->getStorage('menu')->create([
+      'id' => 'dashboard-security',
+      'label' => 'Security',
+    ])->save();
+    \Drupal::configFactory()->getEditable('dashboards.dashboard.mukurtu_dashboard')
+      ->setData([
+        'id' => 'mukurtu_dashboard',
+        'sections' => [
+          [
+            'components' => [
+              self::UUID => [
+                'uuid' => self::UUID,
+                'region' => 'three',
+                'configuration' => [
+                  'id' => 'system_menu_block:dashboard-security',
+                ],
+                'weight' => 9,
+              ],
+            ],
+          ],
+        ],
+      ])
+      ->save();
+
+    mukurtu_core_update_40085();
+
+    $components = \Drupal::config('dashboards.dashboard.mukurtu_dashboard')->get('sections.0.components');
+    $this->assertCount(1, $components);
+  }
+
+}


### PR DESCRIPTION
## Summary
- `mukurtu_core_update_40085()` unconditionally wrote a `system_menu_block:dashboard-security` block reference into the admin dashboard's active config, even if the `dashboard-security` menu (shipped by `mukurtu_bot_protection`'s default config, installed in the paired `mukurtu_core_update_40084()`) never actually got created — e.g. because module installation failed partway on the upgrade path.
- That left affected sites with a dangling block reference the plugin can't resolve, showing "This block is broken or missing" on the dashboard after upgrading (reported on a beta28 -> beta30 upgrade).
- Guard the hook: only add the block if the `dashboard-security` menu entity exists; otherwise skip and log a warning explaining how to recover (install the missing module/deps, then manually re-invoke the hook, since a plain `drush updb` won't re-run an already-executed numbered hook).
- Added a Kernel test (`DashboardSecurityBlockUpdateTest`) covering: adds block when menu exists, skips when menu missing, no-op without dashboard config, and idempotency when the component is already present.

Note: this only prevents the issue on future/other upgrades. Sites that already ran `40085` (like the one that reported this) need the live-site remediation (verify `mukurtu_bot_protection` + deps are installed, then manually re-invoke `mukurtu_core_update_40085()` or recreate the `dashboard-security` menu config directly) — tracked separately, not part of this PR.

## Test plan
- [x] New Kernel test added, follows the existing `*UpdateTest.php` pattern in `modules/mukurtu_core/tests/src/Kernel/` (`require_once` the `.install` file, call the hook directly).
- [ ] CI kernel test suite passes (no local DDEV sandbox was available this session to run it directly; verify via GitHub Actions).
- [ ] After merge, manually verify on a fresh install / with `mukurtu_bot_protection` uninstalled that the hook skips and logs a warning instead of adding a broken block.

## Pre-merge checklist
- [x] I have checked for and if required, created update hooks. (No new update hook needed — this guards an existing one.)
- [x] I have run an accessibility check, and resolved any issues. (N/A — no UI/markup changes, backend-only logic guard.)
- [x] I have recompiled SCSS if required. (N/A — no SCSS changes.)
- [x] I have updated or created CI/CD tests, if required.
- [x] I have updated from `main` and resolved any merge conflicts.
- [x] If this PR's base branch is not `main`, I understand it needs to be retargeted once that base branch's own PR merges. (N/A — based on `main`.)
- [ ] I have verified that all expected checks pass. (Pending CI run.)
- [x] I have run the pr-expert-review skill and resolved all relevant issues. (Found and fixed an inaccurate warning message before pushing.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)