### PR TITLE
Fix persistent toolbar-gap after logout

### DIFF
--- a/modules/mukurtu_gin_custom/mukurtu_gin_custom.libraries.yml
+++ b/modules/mukurtu_gin_custom/mukurtu_gin_custom.libraries.yml
@@ -17,7 +17,6 @@ mukurtu-gin-custom:
     - core/drupal
     - core/once
     - core/drupalSettings
-    - toolbar/toolbar
 
 entity-browser-toggle:
   version: 1.x

--- a/modules/mukurtu_gin_custom/tests/src/Kernel/GinCustomLibraryTest.php
+++ b/modules/mukurtu_gin_custom/tests/src/Kernel/GinCustomLibraryTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\mukurtu_gin_custom\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Tests the mukurtu_gin_custom/mukurtu-gin-custom library definition.
+ *
+ * hook_page_attachments() attaches this library unconditionally on every
+ * page, including for anonymous users. A hard dependency on toolbar/toolbar
+ * previously bypassed core's "access toolbar" permission gate and loaded
+ * toolbar.anti-flicker.js for every visitor, which could read a stale
+ * Drupal.toolbar.toolbarState left in sessionStorage from a prior logged-in
+ * session and reserve toolbar-height blank space at the top of the page
+ * after logout.
+ */
+#[Group('mukurtu_gin_custom')]
+class GinCustomLibraryTest extends KernelTestBase {
+
+  protected static $modules = [
+    'mukurtu_gin_custom',
+  ];
+
+  /**
+   * Tests the library does not pull in toolbar/toolbar for every visitor.
+   */
+  public function testLibraryDoesNotDependOnToolbar(): void {
+    $library = $this->container->get('library.discovery')
+      ->getLibraryByName('mukurtu_gin_custom', 'mukurtu-gin-custom');
+
+    $this->assertNotFalse($library);
+    $this->assertArrayNotHasKey('toolbar/toolbar', array_flip($library['dependencies'] ?? []));
+  }
+
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -100,6 +100,9 @@
     <testsuite name="kernel">
       <directory>web/profiles/mukurtu/modules/mukurtu_notifications/tests/src/Kernel</directory>
     </testsuite>
+    <testsuite name="kernel">
+      <directory>web/profiles/mukurtu/modules/mukurtu_gin_custom/tests/src/Kernel</directory>
+    </testsuite>
     <testsuite name="functional">
       <directory>web/profiles/mukurtu/modules/mukurtu_protocol/tests/src/Functional</directory>
     </testsuite>


### PR DESCRIPTION
## Summary

After logging out of a Mukurtu site, users who previously had the Gin admin toolbar were left with a persistent blank white gap at the top of the page until they logged back in.

**Root cause:** `mukurtu_gin_custom`'s `hook_page_attachments()` attaches its `mukurtu-gin-custom` library unconditionally on every page, for every visitor, including anonymous users. That library hard-depended on core's `toolbar/toolbar`, which bypassed core's own `access toolbar` permission gate and forced `toolbar.anti-flicker.js` to run even for visitors with no toolbar markup at all. That script trusts a `Drupal.toolbar.toolbarState` entry in `sessionStorage`, which can be stale from a prior logged-in session in the same browser tab, and adds `toolbar-fixed`/`toolbar-loading` classes that reserve toolbar-height padding on `body`. Because an anonymous page never renders `#toolbar-administration`, the only code that normally clears those classes never runs, so the gap sticks until the next login.

**Fix:** removed the unnecessary `toolbar/toolbar` dependency from the `mukurtu-gin-custom` library ([mukurtu_gin_custom.libraries.yml](modules/mukurtu_gin_custom/mukurtu_gin_custom.libraries.yml)). The one file in that library that references `Drupal.toolbar` (`js/mukurtu-gin-custom.js`) already guards with optional chaining and only acts on Layout Builder pages, where core loads `toolbar/toolbar` on its own for privileged users — so no admin-facing behavior changes.

Confirmed via grep that no other library in the profile has this unconditional `toolbar/toolbar` dependency pattern, so this is an isolated fix, not part of a broader sweep.

## Verification

- Live in DDEV: before the fix, the anonymous homepage's blocking header JS aggregate contained the literal string `toolbar.toolbarState`; after the fix, no header-scoped JS aggregate is attached at all for anonymous requests.
- Added a Kernel test ([GinCustomLibraryTest.php](modules/mukurtu_gin_custom/tests/src/Kernel/GinCustomLibraryTest.php)) asserting the library no longer depends on `toolbar/toolbar`; confirmed it fails without the fix and passes with it.
- Ran the WCAG accessibility skill and the pr-review-expert skill — no findings (no markup/ARIA changes; library-dependency fix only).

## Test plan

- [x] New Kernel test added and passing (`mukurtu_gin_custom/tests/src/Kernel/GinCustomLibraryTest.php`)
- [ ] CI kernel suite passes
- [ ] Manual: log in as a role with Gin toolbar access, log out, confirm no blank gap at the top of the page

## Pre-merge checklist:

- [x] I have checked for and if required, created update hooks. (Not required — library-definition change only, no schema/config.)
- [x] I have run an accessibility check, and resolved any issues. (No WCAG concerns — no markup/ARIA changes.)
- [x] I have recompiled SCSS if required. (Not required — no SCSS changed.)
- [x] I have updated or created CI/CD tests, if required.
- [x] I have updated from `main` and resolved any merge conflicts. (Branched fresh from `origin/main`.)
- [ ] If this PR's base branch is not `main`, I understand it needs to be retargeted once that base branch's own PR merges. (N/A — base is `main`.)
- [ ] I have verified that all expected checks pass.
- [x] I have run the pr-expert-review skill and resolved all relevant issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)