### PR TITLE
Make "Do not send emails" a real email frequency option

### DIFF
--- a/modules/mukurtu_notifications/mukurtu_notifications.install
+++ b/modules/mukurtu_notifications/mukurtu_notifications.install
@@ -186,11 +186,16 @@ function mukurtu_notifications_create_field_notify_email_categories(): void {
 
 /**
  * Creates the field_notify_frequency storage and attachment on the user
- * entity if missing.
+ * entity if missing, and backfills any user with an empty value to
+ * 'immediate'.
  *
- * No backfill needed: _mukurtu_notifications_user_wants_digest() already
- * treats an empty/unset value as "immediate" (today's behavior for every
- * existing user), so only the default for brand-new users needs setting.
+ * A user can end up with an empty stored value in more than one way: sites
+ * upgrading from before this field existed, or even a fresh install, since
+ * uid 1 is typically created before this hook runs and FieldConfig's
+ * default_value only populates entities created after the field exists.
+ * Backfilling unconditionally here -- the same way this file's
+ * field_notify_email_categories creation function does above -- covers
+ * every path that calls this function, not just the update-hook path.
  */
 function mukurtu_notifications_create_field_notify_frequency(): void {
   if (!\Drupal\field\Entity\FieldStorageConfig::loadByName('user', 'field_notify_frequency')) {
@@ -219,6 +224,14 @@ function mukurtu_notifications_create_field_notify_frequency(): void {
   }
 
   \Drupal::service('entity_field.manager')->clearCachedFieldDefinitions();
+
+  $uids = \Drupal::entityQuery('user')->accessCheck(FALSE)->execute();
+  foreach (\Drupal\user\Entity\User::loadMultiple($uids) as $user) {
+    if ($user->hasField('field_notify_frequency') && $user->get('field_notify_frequency')->isEmpty()) {
+      $user->set('field_notify_frequency', 'immediate');
+      $user->save();
+    }
+  }
 }
 
 /**
@@ -2019,21 +2032,14 @@ function mukurtu_notifications_update_40055(): void {
  * only works once the field stops offering that synthetic placeholder,
  * which requires marking it required.
  *
- * Every existing user currently has an empty stored value (since "N/A"
- * never actually saved anything different), and empty has always been
- * treated as immediate sending (see _mukurtu_notifications_user_wants_email()
- * and _mukurtu_notifications_user_wants_digest()). Backfill those users to
- * 'immediate' explicitly first, so the required constraint doesn't leave
- * anyone in a stale empty state and nobody's actual email behavior changes.
+ * mukurtu_notifications_create_field_notify_frequency() already backfills
+ * any user with an empty stored value to 'immediate' (today's actual
+ * behavior for such users; see _mukurtu_notifications_user_wants_email()),
+ * so calling it here first ensures the required constraint below doesn't
+ * leave anyone in a stale empty state before it's enforced.
  */
 function mukurtu_notifications_update_40056(): void {
-  $uids = \Drupal::entityQuery('user')->accessCheck(FALSE)->execute();
-  foreach (\Drupal\user\Entity\User::loadMultiple($uids) as $user) {
-    if ($user->hasField('field_notify_frequency') && $user->get('field_notify_frequency')->isEmpty()) {
-      $user->set('field_notify_frequency', 'immediate');
-      $user->save();
-    }
-  }
+  mukurtu_notifications_create_field_notify_frequency();
 
   $field = \Drupal\field\Entity\FieldConfig::loadByName('user', 'user', 'field_notify_frequency');
   if ($field && !$field->isRequired()) {

--- a/modules/mukurtu_notifications/mukurtu_notifications.install
+++ b/modules/mukurtu_notifications/mukurtu_notifications.install
@@ -213,7 +213,7 @@ function mukurtu_notifications_create_field_notify_frequency(): void {
       'bundle' => 'user',
       'label' => 'Email frequency',
       'description' => 'How often you want to receive notification emails.',
-      'required' => FALSE,
+      'required' => TRUE,
       'default_value' => [['value' => 'immediate']],
     ])->save();
   }
@@ -2006,4 +2006,38 @@ function mukurtu_notifications_update_40055(): void {
   $categories[] = 'user_account';
   $uid_one->set('field_notify_email_categories', array_values(array_unique($categories)));
   $uid_one->save();
+}
+
+/**
+ * Adds a real "Do not send emails" option and makes the field required.
+ *
+ * field_notify_frequency previously had no allowed value for opting out --
+ * the "N/A" radio users saw was Drupal's synthetic empty-option placeholder
+ * for optional list fields (OptionsWidgetBase::formElement()), which always
+ * saves as an empty value indistinguishable from "never touched this
+ * field" and cannot suppress email on its own. Adding a real 'none' value
+ * only works once the field stops offering that synthetic placeholder,
+ * which requires marking it required.
+ *
+ * Every existing user currently has an empty stored value (since "N/A"
+ * never actually saved anything different), and empty has always been
+ * treated as immediate sending (see _mukurtu_notifications_user_wants_email()
+ * and _mukurtu_notifications_user_wants_digest()). Backfill those users to
+ * 'immediate' explicitly first, so the required constraint doesn't leave
+ * anyone in a stale empty state and nobody's actual email behavior changes.
+ */
+function mukurtu_notifications_update_40056(): void {
+  $uids = \Drupal::entityQuery('user')->accessCheck(FALSE)->execute();
+  foreach (\Drupal\user\Entity\User::loadMultiple($uids) as $user) {
+    if ($user->hasField('field_notify_frequency') && $user->get('field_notify_frequency')->isEmpty()) {
+      $user->set('field_notify_frequency', 'immediate');
+      $user->save();
+    }
+  }
+
+  $field = \Drupal\field\Entity\FieldConfig::loadByName('user', 'user', 'field_notify_frequency');
+  if ($field && !$field->isRequired()) {
+    $field->setRequired(TRUE);
+    $field->save();
+  }
 }

--- a/modules/mukurtu_notifications/mukurtu_notifications.module
+++ b/modules/mukurtu_notifications/mukurtu_notifications.module
@@ -533,6 +533,7 @@ function mukurtu_notifications_notification_frequency_allowed_values(FieldStorag
     'immediate' => 'Immediate',
     'daily' => 'Daily',
     'weekly' => 'Weekly',
+    'none' => 'Do not send emails',
   ];
 }
 
@@ -580,12 +581,16 @@ function _mukurtu_notifications_user_wants_email(int $uid, string $template): bo
     return TRUE;
   }
 
+  $user = User::load($uid);
+  if ($user && $user->hasField('field_notify_frequency') && $user->get('field_notify_frequency')->value === 'none') {
+    return FALSE;
+  }
+
   $category = _mukurtu_notifications_template_category($template);
   if ($category === NULL) {
     return TRUE;
   }
 
-  $user = User::load($uid);
   if (!$user || !$user->hasField('field_notify_email_categories')) {
     return TRUE;
   }

--- a/modules/mukurtu_notifications/tests/src/Kernel/NotifyFrequencyTest.php
+++ b/modules/mukurtu_notifications/tests/src/Kernel/NotifyFrequencyTest.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\mukurtu_notifications\Kernel;
+
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\user\Entity\User;
+
+/**
+ * Tests the field_notify_frequency 'none' option and its update hook.
+ *
+ * "N/A" used to be Drupal's synthetic empty-option placeholder for this
+ * optional list field, which always saved as an empty value and could
+ * never actually suppress email. mukurtu_notifications_update_40056() adds
+ * a real 'none' allowed value and makes the field required so that
+ * placeholder can no longer appear.
+ *
+ * @see mukurtu_notifications_notification_frequency_allowed_values()
+ * @see _mukurtu_notifications_user_wants_email()
+ * @see mukurtu_notifications_update_40056()
+ * @group mukurtu_notifications
+ */
+class NotifyFrequencyTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'field',
+    'flag',
+    'message',
+    'message_notify',
+    'message_subscribe',
+    'options',
+    'system',
+    'user',
+    'mukurtu_notifications',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $module_path = \Drupal::service('extension.list.module')->getPath('mukurtu_notifications');
+    require_once $module_path . '/mukurtu_notifications.install';
+
+    $this->installEntitySchema('user');
+    $this->installSchema('system', ['sequences']);
+
+    mukurtu_notifications_create_field_notify_frequency();
+
+    // uid 1 bypasses permission checks and is created implicitly; burn it on
+    // a throwaway user so the real test users below aren't accidentally
+    // uid 1. Status must be active -- mukurtu_notifications_user_insert()
+    // otherwise treats an inactive save as a pending-approval registration
+    // and calls into mukurtu_core, which isn't enabled in this test.
+    User::create(['name' => 'throwaway', 'status' => 1])->save();
+  }
+
+  /**
+   * 'none' is a real allowed value alongside the existing three.
+   */
+  public function testNoneIsAnAllowedValue(): void {
+    $definition = FieldStorageConfig::loadByName('user', 'field_notify_frequency');
+    $values = mukurtu_notifications_notification_frequency_allowed_values($definition);
+
+    $this->assertSame([
+      'immediate' => 'Immediate',
+      'daily' => 'Daily',
+      'weekly' => 'Weekly',
+      'none' => 'Do not send emails',
+    ], $values);
+  }
+
+  /**
+   * A user who chose 'none' is never emailed for an ordinary notification.
+   */
+  public function testNoneSuppressesEmail(): void {
+    $user = User::create(['name' => 'opted_out', 'status' => 1]);
+    $user->set('field_notify_frequency', 'none');
+    $user->save();
+
+    $this->assertFalse(_mukurtu_notifications_user_wants_email((int) $user->id(), 'mukurtu_new_user_account_created'));
+  }
+
+  /**
+   * The pending-approval notice to managers is never opt-out-able, even for
+   * a user who chose 'none'.
+   */
+  public function testNoneDoesNotSuppressMandatoryRegistrationNotice(): void {
+    $user = User::create(['name' => 'opted_out_manager', 'status' => 1]);
+    $user->set('field_notify_frequency', 'none');
+    $user->save();
+
+    $this->assertTrue(_mukurtu_notifications_user_wants_email((int) $user->id(), 'mukurtu_new_user_registration'));
+  }
+
+  /**
+   * A user with any other frequency falls through to the normal category
+   * check, which defaults to TRUE when field_notify_email_categories isn't
+   * present.
+   */
+  public function testImmediateFallsThroughToCategoryCheck(): void {
+    $user = User::create(['name' => 'immediate_user', 'status' => 1]);
+    $user->set('field_notify_frequency', 'immediate');
+    $user->save();
+
+    $this->assertTrue(_mukurtu_notifications_user_wants_email((int) $user->id(), 'mukurtu_new_user_account_created'));
+  }
+
+  /**
+   * The update hook backfills only users with an empty stored value.
+   *
+   * A brand new user picks up field_notify_frequency's 'immediate' default
+   * value automatically, so the empty-value scenario this update hook
+   * exists for -- an account that predates the field, or one saved before
+   * "N/A" (the synthetic empty-option placeholder) stopped being offered --
+   * has to be forced explicitly here.
+   */
+  public function testUpdateBackfillsEmptyValuesToImmediate(): void {
+    $untouched = User::create(['name' => 'untouched', 'status' => 1]);
+    $untouched->set('field_notify_frequency', NULL);
+    $untouched->save();
+    $this->assertTrue($untouched->get('field_notify_frequency')->isEmpty());
+
+    $optedOut = User::create(['name' => 'already_opted_out', 'status' => 1]);
+    $optedOut->set('field_notify_frequency', 'none');
+    $optedOut->save();
+
+    mukurtu_notifications_update_40056();
+
+    $untouched = User::load($untouched->id());
+    $this->assertSame('immediate', $untouched->get('field_notify_frequency')->value);
+
+    $optedOut = User::load($optedOut->id());
+    $this->assertSame('none', $optedOut->get('field_notify_frequency')->value);
+  }
+
+  /**
+   * The update hook marks the field required.
+   *
+   * A fresh call to mukurtu_notifications_create_field_notify_frequency()
+   * already creates the field as required, so an existing pre-update site
+   * -- the scenario this hook exists for -- is simulated by explicitly
+   * reverting that here first.
+   */
+  public function testUpdateMakesFieldRequired(): void {
+    $field = FieldConfig::loadByName('user', 'user', 'field_notify_frequency');
+    $field->setRequired(FALSE)->save();
+
+    mukurtu_notifications_update_40056();
+
+    $field = FieldConfig::loadByName('user', 'user', 'field_notify_frequency');
+    $this->assertTrue($field->isRequired());
+  }
+
+  /**
+   * Running the update hook again once required and backfilled is a no-op.
+   */
+  public function testUpdateIsIdempotent(): void {
+    mukurtu_notifications_update_40056();
+    mukurtu_notifications_update_40056();
+
+    $field = FieldConfig::loadByName('user', 'user', 'field_notify_frequency');
+    $this->assertTrue($field->isRequired());
+  }
+
+}

--- a/modules/mukurtu_notifications/tests/src/Kernel/NotifyFrequencyTest.php
+++ b/modules/mukurtu_notifications/tests/src/Kernel/NotifyFrequencyTest.php
@@ -114,6 +114,28 @@ class NotifyFrequencyTest extends KernelTestBase {
   }
 
   /**
+   * The field-creation function itself backfills empty values too, not
+   * just the update hook.
+   *
+   * This is what actually protects uid 1 on a fresh install: it's commonly
+   * created before mukurtu_notifications_install() runs, so its field
+   * value would otherwise stay empty even though FieldConfig's
+   * default_value is 'immediate' -- that default only applies to entities
+   * created after the field already exists.
+   */
+  public function testFieldCreationBackfillsExistingEmptyValues(): void {
+    $existingAdmin = User::create(['name' => 'existing_admin', 'status' => 1]);
+    $existingAdmin->set('field_notify_frequency', NULL);
+    $existingAdmin->save();
+    $this->assertTrue($existingAdmin->get('field_notify_frequency')->isEmpty());
+
+    mukurtu_notifications_create_field_notify_frequency();
+
+    $existingAdmin = User::load($existingAdmin->id());
+    $this->assertSame('immediate', $existingAdmin->get('field_notify_frequency')->value);
+  }
+
+  /**
    * The update hook backfills only users with an empty stored value.
    *
    * A brand new user picks up field_notify_frequency's 'immediate' default


### PR DESCRIPTION
## Summary
- On `/user/{uid}/edit`, the "Email frequency" field's default-selected "N/A" option is actually Drupal's synthetic empty-option placeholder for optional list fields, not a real stored value. Selecting it always saves an empty value indistinguishable from "field never touched," and empty has always been treated as immediate sending (`_mukurtu_notifications_user_wants_email()` / `_mukurtu_notifications_user_wants_digest()`) -- so "N/A" could never actually stop emails, and could never really be "saved" as anything.
- Replaces it with a real `none` allowed value labeled "Do not send emails". Making that value real requires the field to become **required**, since that's the only way `OptionsWidgetBase` stops auto-injecting the synthetic empty placeholder.
- `_mukurtu_notifications_user_wants_email()` now short-circuits to `FALSE` when a user's frequency is `none` (except for `mukurtu_new_user_registration`, which intentionally can't be opted out of).
- Every existing user currently has an empty stored value. `mukurtu_notifications_update_40056()` backfills them to `immediate` (preserving their actual current behavior) and then flips the field to required, so nobody is silently switched to "do not send" and nobody gets stranded by the new required constraint.
- Confirmed with the requester: existing users get backfilled to `immediate` rather than left empty to force a choice on next edit.

## Test plan
- [x] Added `NotifyFrequencyTest` (Kernel) covering: `none` is a real allowed value; `none` suppresses email for an ordinary notification; `none` does *not* suppress the mandatory new-user-registration notice; `immediate` still falls through to the existing category check; the update hook backfills only empty values and leaves other values untouched; the update hook makes the field required; the update hook is idempotent.
- [x] Ran the new test plus the existing `Uid1EmailCategoryUpdateTest`, `NewAccountCreatedRecipientsTest`, and `NotificationsFeedAccessTest` against a DDEV instance as a regression check -- all passing.
- [ ] Manually verify in a browser: `/user/{uid}/edit` no longer offers "N/A", offers "Do not send emails" instead, and a user who picks it stops receiving notification emails.

## Pre-merge checklist:

- [x] I have checked for and if required, created update hooks.
- [ ] I have run an accessibility check, and resolved any issues. *(No new markup -- the widget already renders these allowed values as radio buttons; only the option set and required flag changed.)*
- [x] I have recompiled SCSS if required. *(N/A -- no SCSS touched.)*
- [x] I have updated or created CI/CD tests, if required.
- [x] I have updated from `main` and resolved any merge conflicts.
- [x] If this PR's base branch is not `main`, I understand it needs to be retargeted once that base branch's own PR merges (see [docs/stacked-prs.md](../docs/stacked-prs.md)). *(Base is `main`.)*
- [ ] I have verified that all expected checks pass.
- [x] I have run the pr-expert-review skill and resolved all relevant issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)