### PR TITLE
Fix invisible password-match text in Gin dark mode

### DIFF
--- a/modules/mukurtu_gin_custom/css/mukurtu-gin-custom.css
+++ b/modules/mukurtu_gin_custom/css/mukurtu-gin-custom.css
@@ -24,6 +24,28 @@ on any one class. */
   max-width: 100% !important;
 }
 
+/* The password confirm widget's "Passwords match: yes/no" message
+(.password-match-message / .password-match-message__text, built at runtime
+by core's user.js) is styled by Claro's own form--password-confirm.css using
+Claro-specific --progress-bar-label-color/--progress-bar-description-color
+variables, which are either undefined or resolve to a static dark value
+outside Claro's own theme, rendering as unreadable dark text on Gin's dark
+background. Gin re-themes the password strength meter directly above this
+message (.password-strength__title/__text) but never this selector, so
+there's no Gin rule to win the cascade on its own. Verified via computed
+styles that Claro's theme CSS loads after this module's CSS at equal
+specificity, so - same reasoning as the other Claro/Gin cascade-order
+overrides in this file (e.g. .ui-dialog further down) - !important is
+required to reliably win regardless of load order. Matches the title/text
+color pattern
+Gin already uses for .password-strength__title/__text. */
+.password-match-message {
+  color: var(--gin-color-text-light) !important;
+}
+.password-match-message__text {
+  color: var(--gin-color-title) !important;
+}
+
 /* The "create a new collection/word list/personal collection" quick-create
 dialogs (see the "mukurtu-quick-create-form" class added in
 mukurtu_collection.module / mukurtu_dictionary.module) keep only a couple of


### PR DESCRIPTION
## Summary
- On `/admin/people/create` (and any other password-confirm form) with Gin's dark admin mode, the "Passwords match: yes/no" text rendered as unreadable dark-on-dark.
- Root cause: Claro's `form--password-confirm.css` styles `.password-match-message`/`.password-match-message__text` using Claro-only CSS variables that never resolve to a dark-mode-aware value outside Claro's own theme, and Gin never re-themes this specific selector (only the adjacent password-strength meter).
- Fix: add two rules to `mukurtu_gin_custom.css` re-theming those classes with Gin's own dark-mode-aware `--gin-color-text-light`/`--gin-color-title` variables, matching the same color pattern Gin already uses for the strength meter directly above it. `!important` is required since Claro's theme CSS loads after this module's CSS at equal specificity (same pattern as other Claro/Gin overrides already in this file).

## Test plan
- [x] Verified live in a DDEV environment: text was unreadable before, confirmed correct classes/cascade via DevTools computed styles, confirmed the fix renders correctly in both Gin dark and light mode after the corrected CSS selectors were applied.
- [x] Ran the accessibility check skill — confirmed all four text/background combinations (label + status text, light + dark mode) clear WCAG 1.4.3's 4.5:1 contrast minimum with comfortable margin (lowest 5.40:1), and the change doesn't affect the existing `aria-live="polite"` region.
- [x] Ran the pr-review-expert skill — no blocking issues; pure CSS fix, no tests/migrations/security implications applicable.

## Pre-merge checklist:

- [x] I have checked for and if required, created update hooks. (not applicable — CSS only)
- [x] I have run an accessibility check, and resolved any issues.
- [x] I have recompiled SCSS if required. (not applicable — this file has no SCSS source)
- [x] I have updated or created CI/CD tests, if required. (not applicable — CSS-only visual fix)
- [x] I have updated from `main` and resolved any merge conflicts.
- [ ] If this PR's base branch is not `main`, I understand it needs to be retargeted once that base branch's own PR merges (see docs/stacked-prs.md). (not applicable — based on main)
- [ ] I have verified that all expected checks pass.
- [x] I have run the pr-expert-review skill and resolved all relevant issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)