### PR TITLE
Validate upstream cross-migration lookup columns against the upstream file's headers

### DIFF
--- a/modules/mukurtu_import/src/Entity/MukurtuImportStrategy.php
+++ b/modules/mukurtu_import/src/Entity/MukurtuImportStrategy.php
@@ -433,15 +433,21 @@ class MukurtuImportStrategy extends ConfigEntityBase implements MukurtuImportStr
   /**
    * {@inheritdoc}
    */
-  public function getIdentifierColumn(): ?string {
+  public function getIdentifierColumn(?FileInterface $file = NULL): ?string {
     $column = $this->getConfig('identifier_column');
-    return !empty($column) ? $column : NULL;
+    if (empty($column)) {
+      return NULL;
+    }
+    if ($file && !in_array($column, $this->getCSVHeaders($file), TRUE)) {
+      return NULL;
+    }
+    return $column;
   }
 
   /**
    * {@inheritdoc}
    */
-  public function getLabelSourceColumn(): ?string {
+  public function getLabelSourceColumn(?FileInterface $file = NULL): ?string {
     $entity_type_id = $this->getTargetEntityTypeId();
     $label_key = $this->entityTypeManager()
       ->getDefinition($entity_type_id)
@@ -451,8 +457,12 @@ class MukurtuImportStrategy extends ConfigEntityBase implements MukurtuImportStr
       return NULL;
     }
 
+    $headers = $file ? $this->getCSVHeaders($file) : [];
     foreach ($this->getMapping() as $mapping) {
       if ($mapping['target'] === $label_key) {
+        if ($file && !in_array($mapping['source'], $headers, TRUE)) {
+          return NULL;
+        }
         return $mapping['source'];
       }
     }
@@ -463,7 +473,7 @@ class MukurtuImportStrategy extends ConfigEntityBase implements MukurtuImportStr
   /**
    * {@inheritdoc}
    */
-  public function getMediaSourceColumn(): ?string {
+  public function getMediaSourceColumn(?FileInterface $file = NULL): ?string {
     if ($this->getTargetEntityTypeId() !== 'media') {
       return NULL;
     }
@@ -507,10 +517,14 @@ class MukurtuImportStrategy extends ConfigEntityBase implements MukurtuImportStr
       }
     }
 
+    $headers = $file ? $this->getCSVHeaders($file) : [];
     foreach ($this->getMapping() as $mapping) {
       $target = $mapping['target'];
       // Match the source field directly or its target_id subfield.
       if ($target === $source_field || $target === $source_field . '/target_id') {
+        if ($file && !in_array($mapping['source'], $headers, TRUE)) {
+          return NULL;
+        }
         return $mapping['source'];
       }
     }

--- a/modules/mukurtu_import/src/Form/ExecuteImportForm.php
+++ b/modules/mukurtu_import/src/Form/ExecuteImportForm.php
@@ -240,6 +240,7 @@ class ExecuteImportForm extends ImportBaseForm {
       $this->detectUpstreamDependencies(
         $config,
         $entity_type_index,
+        $files_by_fid,
         $upstream_lookup_columns
       );
     }
@@ -317,12 +318,16 @@ class ExecuteImportForm extends ImportBaseForm {
    *   The import config to scan.
    * @param \Drupal\mukurtu_import\MukurtuImportStrategyInterface[] $entity_type_index
    *   Index of entity_type => [fid => config].
+   * @param \Drupal\file\FileInterface[] $files_by_fid
+   *   Index of fid => file, so upstream lookup columns can be validated
+   *   against the upstream file's actual headers.
    * @param array &$upstream_lookup_columns
    *   Accumulator: fid => array of source column names (label, media source).
    */
   protected function detectUpstreamDependencies(
     MukurtuImportStrategyInterface $config,
     array $entity_type_index,
+    array $files_by_fid,
     array &$upstream_lookup_columns
   ): void {
     $entity_type_id = $config->getTargetEntityTypeId();
@@ -358,7 +363,8 @@ class ExecuteImportForm extends ImportBaseForm {
         if (!$upstream_config instanceof MukurtuImportStrategyInterface) {
           continue;
         }
-        $identifier_column = $upstream_config->getIdentifierColumn();
+        $upstream_file = $files_by_fid[$upstream_fid] ?? NULL;
+        $identifier_column = $upstream_file ? $upstream_config->getIdentifierColumn($upstream_file) : NULL;
         if ($identifier_column) {
           // User-configured identifier column takes exclusive precedence.
           $existing = $upstream_lookup_columns[$upstream_fid] ?? [];
@@ -369,11 +375,11 @@ class ExecuteImportForm extends ImportBaseForm {
         else {
           // Fall back to label and media source columns.
           $columns = [];
-          $label_column = $upstream_config->getLabelSourceColumn();
+          $label_column = $upstream_file ? $upstream_config->getLabelSourceColumn($upstream_file) : NULL;
           if ($label_column) {
             $columns[] = $label_column;
           }
-          $media_source_column = $upstream_config->getMediaSourceColumn();
+          $media_source_column = $upstream_file ? $upstream_config->getMediaSourceColumn($upstream_file) : NULL;
           if ($media_source_column && !in_array($media_source_column, $columns)) {
             $columns[] = $media_source_column;
           }

--- a/modules/mukurtu_import/src/MukurtuImportStrategyInterface.php
+++ b/modules/mukurtu_import/src/MukurtuImportStrategyInterface.php
@@ -67,12 +67,16 @@ interface MukurtuImportStrategyInterface extends ConfigEntityInterface, EntityOw
    * cross-migration lookups by arbitrary user-defined values (e.g. for
    * paragraph entities that have no natural label).
    *
+   * @param \Drupal\file\FileInterface|null $file
+   *   Optional file to validate the configured column against. When given,
+   *   returns NULL instead of a column absent from the file's own headers.
+   *
    * @return string|null
    *   The CSV column name, or NULL if not configured.
    */
-  public function getIdentifierColumn(): ?string;
+  public function getIdentifierColumn(?FileInterface $file = NULL): ?string;
 
-  public function getLabelSourceColumn(): ?string;
+  public function getLabelSourceColumn(?FileInterface $file = NULL): ?string;
 
   /**
    * Get the source column mapped to the media source field (e.g., filename).
@@ -81,10 +85,14 @@ interface MukurtuImportStrategyInterface extends ConfigEntityInterface, EntityOw
    * source field (e.g., field_media_image for Image media). Returns NULL for
    * non-media entity types or if the source field is not mapped.
    *
+   * @param \Drupal\file\FileInterface|null $file
+   *   Optional file to validate the mapped column against. When given,
+   *   returns NULL instead of a column absent from the file's own headers.
+   *
    * @return string|null
    *   The CSV column name mapped to the media source field, or NULL.
    */
-  public function getMediaSourceColumn(): ?string;
+  public function getMediaSourceColumn(?FileInterface $file = NULL): ?string;
 
   /**
    * Get the mapped target field name for a given source column.

--- a/modules/mukurtu_import/tests/src/Kernel/ImportStrategyUpstreamColumnValidationTest.php
+++ b/modules/mukurtu_import/tests/src/Kernel/ImportStrategyUpstreamColumnValidationTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\mukurtu_import\Kernel;
+
+use Drupal\mukurtu_import\Entity\MukurtuImportStrategy;
+use Drupal\Tests\media\Traits\MediaTypeCreationTrait;
+
+/**
+ * Tests file-aware validation of identifier/label/media-source columns.
+ *
+ * ExecuteImportForm::detectUpstreamDependencies() correlates a downstream
+ * migration's entity reference field to an upstream migration's real source
+ * IDs, using whichever of the upstream config's identifier, label, or media
+ * source column is configured. Before validating those columns against the
+ * upstream file's actual headers, a stale/reused template could hand a
+ * column name absent from that file down as a `lookup_source_ids` value,
+ * which aborts the whole migration at Row construction (see
+ * ImportBatchFinishedSuccessGatingTest::testEndToEndMigrationFailureYieldsUnsuccessfulResult
+ * for what that failure looks like). getIdentifierColumn(), getLabelSourceColumn(),
+ * and getMediaSourceColumn() now accept the file being imported and return
+ * NULL instead of a column that isn't actually one of its headers, so
+ * detectUpstreamDependencies() can fall through to record numbers instead.
+ */
+class ImportStrategyUpstreamColumnValidationTest extends MukurtuImportTestBase {
+
+  use MediaTypeCreationTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = ['media', 'image'];
+
+  /**
+   * getIdentifierColumn() only validates against a file's headers when one
+   * is passed; the no-argument call site (e.g. getUnmatchedIdentifierColumns())
+   * is unaffected.
+   */
+  public function testGetIdentifierColumnValidatesAgainstFileHeaders() {
+    $file = $this->createCsvFile([
+      ['title', 'Real Column'],
+      ['Some Title', 'value'],
+    ]);
+
+    $config = MukurtuImportStrategy::create(['uid' => $this->currentUser->id()]);
+    $config->setTargetEntityTypeId('node');
+    $config->setTargetBundle('protocol_aware_content');
+    $config->setConfig('identifier_column', 'Missing Column');
+
+    $this->assertEquals('Missing Column', $config->getIdentifierColumn());
+    $this->assertNull($config->getIdentifierColumn($file));
+
+    $config->setConfig('identifier_column', 'Real Column');
+    $this->assertEquals('Real Column', $config->getIdentifierColumn($file));
+  }
+
+  /**
+   * getLabelSourceColumn() drops a mapped label column that isn't a header
+   * in the given file.
+   */
+  public function testGetLabelSourceColumnValidatesAgainstFileHeaders() {
+    $file = $this->createCsvFile([
+      ['title'],
+      ['Some Title'],
+    ]);
+
+    $config = MukurtuImportStrategy::create(['uid' => $this->currentUser->id()]);
+    $config->setTargetEntityTypeId('node');
+    $config->setTargetBundle('protocol_aware_content');
+    $config->setMapping([
+      ['target' => 'title', 'source' => 'Old Title Column'],
+    ]);
+
+    $this->assertEquals('Old Title Column', $config->getLabelSourceColumn());
+    $this->assertNull($config->getLabelSourceColumn($file));
+
+    $config->setMapping([
+      ['target' => 'title', 'source' => 'title'],
+    ]);
+    $this->assertEquals('title', $config->getLabelSourceColumn($file));
+  }
+
+  /**
+   * getMediaSourceColumn() drops a mapped media source column that isn't a
+   * header in the given file.
+   */
+  public function testGetMediaSourceColumnValidatesAgainstFileHeaders() {
+    $media_type = $this->createMediaType('image');
+    $source_field = $media_type->getSource()->getSourceFieldDefinition($media_type)->getName();
+
+    $file = $this->createCsvFile([
+      ['name', 'Image'],
+      ['Some Media', 'photo.jpg'],
+    ]);
+
+    $config = MukurtuImportStrategy::create(['uid' => $this->currentUser->id()]);
+    $config->setTargetEntityTypeId('media');
+    $config->setTargetBundle($media_type->id());
+    $config->setMapping([
+      ['target' => 'name', 'source' => 'name'],
+      ['target' => "$source_field/target_id", 'source' => 'Old Image Column'],
+    ]);
+
+    $this->assertEquals('Old Image Column', $config->getMediaSourceColumn());
+    $this->assertNull($config->getMediaSourceColumn($file));
+
+    $config->setMapping([
+      ['target' => 'name', 'source' => 'name'],
+      ['target' => "$source_field/target_id", 'source' => 'Image'],
+    ]);
+    $this->assertEquals('Image', $config->getMediaSourceColumn($file));
+  }
+
+}


### PR DESCRIPTION
## Summary

**Rescoped 2026-08-25.** This PR originally targeted issue #154 (a template's own id/label column missing from the file being imported). That exact failure mode was independently fixed on `main` in the meantime via #1929 and #1940 (`MukurtuImportStrategy::getUnmatchedIdentifierColumns()` + `toDefinition()` header validation), so this branch was rebuilt from scratch on top of current `main` rather than merged as originally written, to avoid reverting that already-shipped fix.

What's left is a related but distinct gap in the same subsystem: `ExecuteImportForm::detectUpstreamDependencies()` correlates a downstream migration's entity reference field to an *upstream* migration's identifier/label/media-source column, then hands that column down as a `lookup_source_ids` value. It never checked whether the chosen column actually exists in the **upstream file's** real CSV headers, so a stale/reused template pointing at an absent column aborted the whole migration at Row construction — same class of failure as #154, but on the upstream side of a cross-migration import, which `getUnmatchedIdentifierColumns()` doesn't cover.

## Changes

- `getIdentifierColumn()`, `getLabelSourceColumn()`, and `getMediaSourceColumn()` on `MukurtuImportStrategy` (and its interface) now take an optional `FileInterface $file` and return `NULL` instead of a column absent from that file's headers. Existing no-argument call sites are unaffected.
- `ExecuteImportForm::detectUpstreamDependencies()` now takes the `$files_by_fid` index and validates each upstream lookup column against the actual upstream file before using it.

## Test plan

- [x] New Kernel test `ImportStrategyUpstreamColumnValidationTest` covering all three getters' file-aware validation.
- [x] Full `mukurtu_import` Kernel suite re-run: 62/62 passing.
- [x] Confirmed the new tests actually catch the regression (reverting `MukurtuImportStrategy.php`'s getter changes produces a PHP fatal error from the incompatible interface signature, and reverting to matching-but-unvalidated signatures produces real test failures).

## Pre-merge checklist:

- [x] I have checked for and if required, created update hooks. (Not required — no schema/config changes.)
- [x] I have run an accessibility check, and resolved any issues. (No new UI/markup — n/a.)
- [ ] I have recompiled SCSS if required. (No SCSS changes in this PR.)
- [x] I have updated or created CI/CD tests, if required.
- [x] I have updated from `main` and resolved any merge conflicts. (Branch rebuilt from current `main`; see rescoping note above.)
- [x] If this PR's base branch is not `main`, I understand it needs to be retargeted once that base branch's own PR merges. (Base is `main`.)
- [ ] I have verified that all expected checks pass.
- [x] I have run the pr-expert-review skill and resolved all relevant issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
