### PR TITLE
Fix duplicate "Add to export list" bulk action on /admin/content

### DIFF
--- a/config/install/views.view.mukurtu_manage_all_content.yml
+++ b/config/install/views.view.mukurtu_manage_all_content.yml
@@ -98,8 +98,6 @@ display:
               preconfiguration:
                 add_confirmation: false
                 label_override: Publish
-            40:
-              action_id: mukurtu_export_add_to_list_action
             41:
               action_id: views_bulk_operations_delete_entity
               preconfiguration:

--- a/modules/mukurtu_core/mukurtu_core.install
+++ b/modules/mukurtu_core/mukurtu_core.install
@@ -3656,3 +3656,18 @@ function mukurtu_core_update_40101(): void
       ->save();
   }
 }
+
+/**
+ * Remove duplicate "Add to export list" bulk action entry (issue #2027).
+ */
+function mukurtu_core_update_40102(): void {
+  $profile_path = \Drupal::service('extension.list.profile')->getPath('mukurtu');
+  $config_source = new \Drupal\Core\Config\FileStorage(\Drupal::root() . '/' . $profile_path . '/config/install');
+  $config_data = $config_source->read('views.view.mukurtu_manage_all_content');
+  if ($config_data) {
+    \Drupal::configFactory()
+      ->getEditable('views.view.mukurtu_manage_all_content')
+      ->setData($config_data)
+      ->save();
+  }
+}

--- a/modules/mukurtu_core/tests/src/Kernel/DuplicateExportActionUpdateTest.php
+++ b/modules/mukurtu_core/tests/src/Kernel/DuplicateExportActionUpdateTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\mukurtu_core\Kernel;
+
+use Drupal\Core\Config\FileStorage;
+use Drupal\KernelTests\KernelTestBase;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Tests mukurtu_core_update_40102(), which removes the duplicate
+ * "Add to export list" bulk action entry from the manage-all-content view.
+ *
+ * @see mukurtu_core_update_40102()
+ */
+#[Group('mukurtu_core')]
+class DuplicateExportActionUpdateTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+  ];
+
+  /**
+   * The hook re-imports the real shipped view config, not a fixture.
+   *
+   * {@inheritdoc}
+   */
+  protected $strictConfigSchema = FALSE;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $module_path = \Drupal::service('extension.list.module')->getPath('mukurtu_core');
+    require_once $module_path . '/mukurtu_core.install';
+
+    \Drupal::configFactory()->getEditable('views.view.mukurtu_manage_all_content')
+      ->setData([
+        'id' => 'mukurtu_manage_all_content',
+        'display' => [
+          'default' => [
+            'id' => 'default',
+            'display_options' => [
+              'fields' => [
+                'views_bulk_operations_bulk_form' => [
+                  'id' => 'views_bulk_operations_bulk_form',
+                  'selected_actions' => [
+                    4 => ['action_id' => 'mukurtu_export_add_to_list_action'],
+                    5 => ['action_id' => 'mukurtu_export_remove_from_list_action'],
+                    40 => ['action_id' => 'mukurtu_export_add_to_list_action'],
+                    41 => ['action_id' => 'views_bulk_operations_delete_entity'],
+                  ],
+                ],
+              ],
+            ],
+          ],
+        ],
+      ])
+      ->save();
+  }
+
+  /**
+   * The update hook removes the duplicate "Add to export list" entry.
+   */
+  public function testUpdateRemovesDuplicateExportListAction(): void {
+    mukurtu_core_update_40102();
+
+    $selected_actions = \Drupal::config('views.view.mukurtu_manage_all_content')
+      ->get('display.default.display_options.fields.views_bulk_operations_bulk_form.selected_actions');
+
+    $export_add_entries = array_filter($selected_actions, function (array $action): bool {
+      return $action['action_id'] === 'mukurtu_export_add_to_list_action';
+    });
+
+    $this->assertCount(1, $export_add_entries, 'Expected exactly one "Add to export list" bulk action entry after update.');
+  }
+
+  /**
+   * The update hook re-syncs the view to match the shipped config exactly.
+   */
+  public function testUpdateMatchesShippedViewConfig(): void {
+    mukurtu_core_update_40102();
+
+    $profile_path = \Drupal::service('extension.list.profile')->getPath('mukurtu');
+    $shipped_config = (new FileStorage($profile_path . '/config/install'))
+      ->read('views.view.mukurtu_manage_all_content');
+
+    $active_selected_actions = \Drupal::config('views.view.mukurtu_manage_all_content')
+      ->get('display.default.display_options.fields.views_bulk_operations_bulk_form.selected_actions');
+    $shipped_selected_actions = $shipped_config['display']['default']['display_options']['fields']['views_bulk_operations_bulk_form']['selected_actions'];
+
+    $this->assertSame($shipped_selected_actions, $active_selected_actions);
+  }
+
+}


### PR DESCRIPTION
Fixes #2027

## Summary
- The `mukurtu_manage_all_content` view's Views Bulk Operations `selected_actions` list had `mukurtu_export_add_to_list_action` listed twice (keys `4` and `40`), so the "Action" dropdown on `/admin/content` rendered "Add to export list" twice.
- Removed the duplicate entry from `config/install/views.view.mukurtu_manage_all_content.yml`.
- Added `mukurtu_core_update_40102()` to re-sync the corrected view config on already-installed sites (following the same wholesale re-import pattern as the prior `mukurtu_core_update_40053()` for this view).
- Added a Kernel test covering the update hook.

## Test plan
- [x] Ran `drush updb` in a local DDEV site; confirmed the duplicate `selected_actions` key disappeared from active config.
- [x] Loaded `/admin/content` and confirmed the Action `<select>` now lists "Add to export list" exactly once (the per-row dropbutton "Add to export list" link is separate and unaffected).
- [x] Ran the new `DuplicateExportActionUpdateTest` Kernel tests locally — both pass.
- [x] Ran the WCAG accessibility check skill — no concerns (config-only dedup, no new markup).
- [x] Checked all currently-open PRs touching `mukurtu_core.install` for update-hook number collisions — none found.

## Pre-merge checklist:

- [x] I have checked for and if required, created update hooks.
- [x] I have run an accessibility check, and resolved any issues.
- [x] I have recompiled SCSS if required. (N/A - no SCSS changes)
- [x] I have updated or created CI/CD tests, if required.
- [x] I have updated from `main` and resolved any merge conflicts.
- [x] If this PR's base branch is not `main`, I understand it needs to be retargeted once that base branch's own PR merges (see docs/stacked-prs.md). (N/A - based on `main`)
- [ ] I have verified that all expected checks pass.
- [x] I have run the pr-expert-review skill and resolved all relevant issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)