### PR TITLE
Suppress Klaro consent toggle button inside entity browser modals

### DIFF
--- a/modules/mukurtu_core/src/Hook/ThemeHooks.php
+++ b/modules/mukurtu_core/src/Hook/ThemeHooks.php
@@ -52,4 +52,23 @@ class ThemeHooks {
     }
   }
 
+  /**
+   * Implements hook_page_attachments_alter().
+   *
+   * Entity browser modals (mukurtu_content_browser, etc.) render as a
+   * separate full page inside an iframe, so Klaro's hook_page_attachments()
+   * attaches its floating "Manage consents" toggle button there too,
+   * duplicating the one already on the parent page. Suppress just the
+   * button for these routes; leave Klaro's consent enforcement itself
+   * untouched, since browser results can still surface consent-gated
+   * external content.
+   */
+  #[Hook('page_attachments_alter')]
+  public function pageAttachmentsAlter(array &$attachments): void {
+    $route_name = \Drupal::routeMatch()->getRouteName();
+    if ($route_name !== NULL && str_starts_with($route_name, 'entity_browser.') && isset($attachments['#attached']['drupalSettings']['klaro'])) {
+      $attachments['#attached']['drupalSettings']['klaro']['show_toggle_button'] = FALSE;
+    }
+  }
+
 }

--- a/modules/mukurtu_core/tests/src/Kernel/ThemeHooksPageAttachmentsAlterTest.php
+++ b/modules/mukurtu_core/tests/src/Kernel/ThemeHooksPageAttachmentsAlterTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\mukurtu_core\Kernel;
+
+use Drupal\Core\Routing\RouteObjectInterface;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\mukurtu_core\Hook\ThemeHooks;
+use PHPUnit\Framework\Attributes\Group;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+use Symfony\Component\Routing\Route;
+
+/**
+ * Tests suppressing Klaro's toggle button inside entity browser modals.
+ *
+ * @see \Drupal\mukurtu_core\Hook\ThemeHooks::pageAttachmentsAlter()
+ */
+#[Group('mukurtu_core')]
+class ThemeHooksPageAttachmentsAlterTest extends KernelTestBase {
+
+  /**
+   * Pushes a request matched to the given route name onto the stack.
+   */
+  protected function setCurrentRoute(string $routeName): void {
+    $request = Request::create('/entity-browser/modal/' . $routeName);
+    $request->attributes->set(RouteObjectInterface::ROUTE_NAME, $routeName);
+    $request->attributes->set(RouteObjectInterface::ROUTE_OBJECT, new Route('/entity-browser/modal/' . $routeName));
+    $request->setSession(new Session(new MockArraySessionStorage()));
+    $this->container->get('request_stack')->push($request);
+  }
+
+  /**
+   * The toggle button is suppressed on entity browser modal routes.
+   */
+  public function testToggleButtonSuppressedOnEntityBrowserRoute(): void {
+    $this->setCurrentRoute('entity_browser.mukurtu_content_browser');
+
+    $attachments = [
+      '#attached' => [
+        'drupalSettings' => [
+          'klaro' => ['show_toggle_button' => TRUE],
+        ],
+      ],
+    ];
+    (new ThemeHooks())->pageAttachmentsAlter($attachments);
+
+    $this->assertFalse($attachments['#attached']['drupalSettings']['klaro']['show_toggle_button']);
+  }
+
+  /**
+   * The toggle button is left alone on a normal page route.
+   */
+  public function testToggleButtonUntouchedOnNormalRoute(): void {
+    $this->setCurrentRoute('entity.node.canonical');
+
+    $attachments = [
+      '#attached' => [
+        'drupalSettings' => [
+          'klaro' => ['show_toggle_button' => TRUE],
+        ],
+      ],
+    ];
+    (new ThemeHooks())->pageAttachmentsAlter($attachments);
+
+    $this->assertTrue($attachments['#attached']['drupalSettings']['klaro']['show_toggle_button']);
+  }
+
+  /**
+   * Nothing errors when Klaro hasn't attached its settings at all.
+   */
+  public function testNoErrorWhenKlaroSettingsAbsent(): void {
+    $this->setCurrentRoute('entity_browser.mukurtu_content_browser');
+
+    $attachments = ['#attached' => []];
+    (new ThemeHooks())->pageAttachmentsAlter($attachments);
+
+    $this->assertArrayNotHasKey('drupalSettings', $attachments['#attached']);
+  }
+
+}


### PR DESCRIPTION
## Summary
- Entity browser modals (content browser, collection browser, etc.) render as a full separate page inside an iframe, so Klaro's `hook_page_attachments()` was duplicating the floating "Manage consents" toggle button inside the modal alongside the one already on the parent page.
- Added `ThemeHooks::pageAttachmentsAlter()` to suppress just the toggle button (`drupalSettings.klaro.show_toggle_button`) on `entity_browser.*` routes, leaving Klaro's consent enforcement/blocking of external resources fully intact everywhere.
- Scoped generically by route-name prefix, so it covers all 9 of Mukurtu's entity browser modals, not just the content browser.

## Test plan
- [x] New kernel test (`ThemeHooksPageAttachmentsAlterTest`, 3 cases: suppressed on an entity browser route, untouched on a normal page route, no error when Klaro's settings aren't attached) — passing.
- [x] Full `mukurtu_core` kernel suite (66 tests) run in a scratch DDEV sandbox — no regressions.
- [ ] Manual check: open "Add content" → "Select Content" (or any entity browser modal) and confirm the floating consent button no longer appears inside the modal iframe, while it still shows on the parent page.

## Pre-merge checklist:

- [x] I have checked for and if required, created update hooks. (Not required — pure per-request render-time override, no config/schema change.)
- [x] I have run an accessibility check, and resolved any issues. (Button is gated before DOM insertion, not hidden after the fact; no focus/keyboard regression; contextual "Manage privacy settings" links elsewhere in Klaro remain unaffected.)
- [x] I have recompiled SCSS if required. (Not required — no SCSS touched.)
- [x] I have updated or created CI/CD tests, if required.
- [x] I have updated from `main` and resolved any merge conflicts. (Branch is up to date with `main`, no conflicts.)
- [ ] If this PR's base branch is not `main`, I understand it needs to be retargeted once that base branch's own PR merges (see [docs/stacked-prs.md](../docs/stacked-prs.md)). (N/A — base is `main`.)
- [ ] I have verified that all expected checks pass.
- [x] I have run the pr-expert-review skill and resolved all relevant issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)