### PR TITLE
Add accessibility program docs: process + findings index

### DIFF
--- a/docs/accessibility/README.md
+++ b/docs/accessibility/README.md
@@ -1,0 +1,30 @@
+# Accessibility Program
+
+Mukurtu must be WCAG 2.1 AA compliant (should be WCAG 2.2 AA) and ATAG 2.0 compliant. This directory documents how accessibility findings get filed, triaged, and closed out.
+
+Findings live as GitHub issues under the umbrella issue [#2008](https://github.com/MukurtuCMS/Mukurtu-CMS/issues/2008). See `findings-index.md` in this directory for the current status of every sub-issue.
+
+## Scan tooling
+
+Some early findings issues reference an automated helper (`checkTextZoom` in `tests/playwright/src/helpers/automated-checks.ts`) and a baseline scan file (`findings/2026-07-baseline.md`). **Neither exists in this repo.** They were referenced by issue text but never actually committed — don't assume they exist, and don't spend time looking for them. Confirmed missing during work on issues #1998 and #2003.
+
+`axe-core` isn't vendored in this repo either. Live verification during this program's work has used `axe-core` loaded ad hoc from a CDN (`https://cdn.jsdelivr.net/npm/axe-core@4/axe.min.js`) inside a throwaway Playwright script against a running DDEV instance — not a committed test. If a permanent, CI-integrated a11y test harness gets built, that's a real gap worth closing (raised as a possible follow-up, not yet scoped as its own issue).
+
+## Filing a finding
+
+- Title format: `[WCAG X.Y.Z] Short description` for a specific success criterion, or `[best-practice]` for an axe best-practice rule that isn't a numbered WCAG failure.
+- Link it as a sub-issue of #2008.
+- Include: the axe rule name, severity/impact, affected page(s), and enough markup context to reproduce without re-scanning.
+
+## Triaging a finding
+
+1. **Verify live, don't trust the issue text alone.** Findings can be stale, imprecise (see #2003's "six" vs. the seven actually reproduced), or describe the wrong root cause entirely (see #1998, where the originally-suspected cause turned out not to be the real one — bisecting by hiding page sections and re-measuring found the true source). Reproduce with a real scan or real browser interaction before writing a fix.
+2. **Identify whose code it is.** If the flagged markup comes from Mukurtu's own theme/module code, fix it locally. If it comes from a vendored/contrib dependency (a Composer package, an npm-vendored JS bundle, a contrib theme like Gin), check whether it's already fixed in a newer available version first.
+3. **For vendored/contrib bugs:** search the upstream project's issue queue before filing — it's often already reported (see #2003, where all three findings turned out to already be tracked in Gin's and Drupal core's own queues). Link existing upstream issues rather than duplicating them. Only apply a local override/patch when the bug is genuinely blocking and no upstream fix is imminent (see #2000's ALTCHA fix: a small local CSS/JS patch was applied *and* the bugs were also reported upstream, since the local fix doesn't remove the need to fix the actual source).
+4. **Watch for scope creep discoveries.** Investigating one finding sometimes surfaces a second, unrelated bug (see #1998 → #2051 → the real fix landing back in #1998's own PR once #2051 turned out to be a false lead; see #2003 surfacing three separate but related upstream issues). File what's genuinely separate as its own issue rather than silently expanding the PR in front of you.
+
+## Closing a finding
+
+- If fixed locally: reference the fixing PR, close.
+- If it's a vendored/contrib bug fully resolved by a local override: reference the PR *and* the upstream issue link, close.
+- If it's a vendored/contrib bug with no local fix applied (fix belongs entirely upstream): leave it open as a tracking placeholder with the upstream issue link(s), to be closed once the dependency is updated and the fix is verified. Don't close prematurely just because there's nothing left for Mukurtu to do right now.

--- a/docs/accessibility/findings-index.md
+++ b/docs/accessibility/findings-index.md
@@ -1,0 +1,42 @@
+# Findings Index
+
+Status of every sub-issue under [#2008](https://github.com/MukurtuCMS/Mukurtu-CMS/issues/2008), the accessibility program's umbrella issue. Last updated 2026-08-27.
+
+## Fixed (PR open, pending merge)
+
+| Issue | Title | PR |
+|---|---|---|
+| [#1976](https://github.com/MukurtuCMS/Mukurtu-CMS/issues/1976) | Import mapping table: unlabeled Remove buttons, no focus/live-region | [#1981](https://github.com/MukurtuCMS/Mukurtu-CMS/pull/1981) |
+| [#1977](https://github.com/MukurtuCMS/Mukurtu-CMS/issues/1977) | Generic entity-browser row selection lacks role/aria-checked | [#1984](https://github.com/MukurtuCMS/Mukurtu-CMS/pull/1984) |
+| [#1978](https://github.com/MukurtuCMS/Mukurtu-CMS/issues/1978) | Collection organization form: unlabeled Remove buttons, no AJAX focus/live-region | [#1983](https://github.com/MukurtuCMS/Mukurtu-CMS/pull/1983) |
+| [#1979](https://github.com/MukurtuCMS/Mukurtu-CMS/issues/1979) | Content warnings settings: unlabeled Remove buttons, no AJAX focus/live-region | [#1983](https://github.com/MukurtuCMS/Mukurtu-CMS/pull/1983) |
+| [#1995](https://github.com/MukurtuCMS/Mukurtu-CMS/issues/1995) | PDF thumbnail missing alt text in media carousel | [#2045](https://github.com/MukurtuCMS/Mukurtu-CMS/pull/2045) |
+| [#1997](https://github.com/MukurtuCMS/Mukurtu-CMS/issues/1997) | Horizontal scroll required at 320px width (reflow) | [#2046](https://github.com/MukurtuCMS/Mukurtu-CMS/pull/2046) |
+| [#1998](https://github.com/MukurtuCMS/Mukurtu-CMS/issues/1998) | Dictionary browse overflows at 200% text zoom | [#2050](https://github.com/MukurtuCMS/Mukurtu-CMS/pull/2050) |
+| [#1999](https://github.com/MukurtuCMS/Mukurtu-CMS/issues/1999) | Missing focus indicator on 4 elements, dictionary word page | [#2045](https://github.com/MukurtuCMS/Mukurtu-CMS/pull/2045) |
+| [#1996](https://github.com/MukurtuCMS/Mukurtu-CMS/issues/1996) | Splide carousel slide has ARIA role conflict | [#2061](https://github.com/MukurtuCMS/Mukurtu-CMS/pull/2061) |
+| [#2000](https://github.com/MukurtuCMS/Mukurtu-CMS/issues/2000) | ALTCHA widget: focusable hidden link + contrast failure | [#2062](https://github.com/MukurtuCMS/Mukurtu-CMS/pull/2062) (local fix *and* filed upstream: [altcha-org/altcha#197](https://github.com/altcha-org/altcha/issues/197)) |
+| [#2002](https://github.com/MukurtuCMS/Mukurtu-CMS/issues/2002) | Lightbox zoom-hint text not contained in a landmark | [#2045](https://github.com/MukurtuCMS/Mukurtu-CMS/pull/2045) |
+
+Note: #1998's PR (#2050) also carries the fix for #1996-adjacent glossary overflow found along the way; #1998's *originally suspected* cause (the alphabet glossary bar) turned out not to be the actual cause of the reported number — the real cause (the exposed filter form's CSS Grid) was found by bisecting the page, not by trusting the issue's own hypothesis. See the issue/PR for the full trail.
+
+## Closed — no code fix needed
+
+| Issue | Title | Outcome |
+|---|---|---|
+| [#2001](https://github.com/MukurtuCMS/Mukurtu-CMS/issues/2001) | Decorative card link focusable despite aria-hidden | Investigated in [#2045](https://github.com/MukurtuCMS/Mukurtu-CMS/pull/2045); not reproducible — the correct `tabindex="-1"` pairing was already in place everywhere checked. Regression test added instead of a fix. |
+| [#2051](https://github.com/MukurtuCMS/Mukurtu-CMS/issues/2051) | Main navigation doesn't collapse under text-only zoom | Closed: disproved during #1998 investigation. Hiding the entire `<header>` (nav included) made zero measurable difference to the actual page overflow — the nav wasn't the cause. |
+| [#1913](https://github.com/MukurtuCMS/Mukurtu-CMS/issues/1913) | Map Points (Leaflet draw) widget isn't keyboard/screen-reader accessible | Closed prior to this pass of the program. |
+
+## Tracked upstream — no local fix needed or possible
+
+| Issue | Title | Upstream links |
+|---|---|---|
+| [#2003](https://github.com/MukurtuCMS/Mukurtu-CMS/issues/2003) | Admin toolbar: invalid ARIA attribute + unnamed buttons/links | All three findings are 100% Gin/Drupal core contrib code, already tracked: Gin [#3598613](https://git.drupalcode.org/project/gin/-/work_items/3598613) (aria-toolbar-link__labelledby typo, fix ready/RTBC) + core [#3615331](https://www.drupal.org/project/drupal/issues/3615331) (currently postponed pending confirmation the templates are actually used — which we've now confirmed via live testing); Gin [#3539420](https://git.drupalcode.org/project/gin/-/work_items/3539420) (collapsed-toolbar labels use `display:none` instead of a proper visually-hidden technique, stripping button/link names). Left open as a placeholder until these land in a Gin/core update. |
+
+## Parent/tracking issues (not individual findings)
+
+| Issue | Title |
+|---|---|
+| [#1786](https://github.com/MukurtuCMS/Mukurtu-CMS/issues/1786) | Site-wide accessibility check — the original umbrella issue that spawned this program's baseline scan |
+| [#1975](https://github.com/MukurtuCMS/Mukurtu-CMS/issues/1975) | Accessibility Phase 2: admin/authoring inventory (complementary to #1817) — parent of #1976-#1979, all now fixed above |


### PR DESCRIPTION
## Summary
Several issues under #2008 (e.g. #1998, #2003) reference a `docs/accessibility/` directory — a baseline scan file, an automated `checkTextZoom` test helper — that was never actually committed to the repo. Discovered this gap while investigating those issues.

Adds:
- `docs/accessibility/README.md` — how findings get filed, triaged, and closed, including the pattern established this session for vendored/contrib bugs (check upstream first, link don't duplicate, apply a local override only when genuinely blocking).
- `docs/accessibility/findings-index.md` — current status of every sub-issue under #2008: fixed (with PR links), closed with no code fix, tracked upstream with no local fix possible, and the two parent/tracking issues.

No code changes — documentation only.

## Pre-merge checklist
- [x] Checked for update hooks — none needed (docs only).
- [x] N/A — no code/markup changed, accessibility check doesn't apply.
- [x] N/A — no SCSS changed.
- [x] Updated from `main`, no conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)