### PR TITLE
Remove 11 stale view-fallback exemptions PR #2053 already fixed (#1260)

### DIFF
--- a/modules/mukurtu_multilingual/tests/src/Unit/ViewLanguageFallbackCoverageTest.php
+++ b/modules/mukurtu_multilingual/tests/src/Unit/ViewLanguageFallbackCoverageTest.php
@@ -54,26 +54,21 @@ class ViewLanguageFallbackCoverageTest extends UnitTestCase {
     'mukurtu_migrate_results' => 'lists watchdog log entries, not translatable content',
     'og_members_overview' => 'og_membership has no routable display and is not translatable content',
 
-    // Authoring-tool entity_browser pickers (modal widgets used while
-    // editing, not a visitor-facing browse/search surface).
-    'mukurtu_content_browser' => 'entity_browser picker widget used in editing forms, not a public browse page',
-    'multipage_item_browser' => 'entity_browser picker widget used in editing forms, not a public browse page',
-    'mukurtu_community_select' => 'entity_browser picker widget used in editing forms, not a public browse page',
-
     // Genuinely visitor-facing, not yet migrated to the fallback pattern.
     // Tracked under #1159 / #1188 (Phase 4 of the #1260 multilingual
-    // roadmap). Remove each line as its view is migrated.
-    'mukurtu_categories' => 'visitor-facing, not yet migrated - #1159/#1188',
+    // roadmap). Remove each line as its view is migrated. (The 11
+    // plain-entity views - mukurtu_categories, mukurtu_collection_items,
+    // mukurtu_recent_content, browse_by_community, taxonomy_term, the 3
+    // entity_browser pickers, and the 3 audience-resolved views - were
+    // migrated in #2053; the remaining 14 below are Search API-backed and
+    // depend on the language_with_fallback index field from #2049.)
     'mukurtu_browse' => 'visitor-facing, not yet migrated - #1159/#1188',
     'mukurtu_browse_by_map' => 'visitor-facing, not yet migrated - #1159/#1188',
     'mukurtu_browse_collections' => 'visitor-facing, not yet migrated - #1159/#1188',
     'mukurtu_browse_map' => 'visitor-facing, not yet migrated - #1159/#1188',
     'mukurtu_digital_heritage_browse' => 'visitor-facing, not yet migrated - #1159/#1188',
     'mukurtu_dictionary' => 'visitor-facing, not yet migrated - #1159/#1188',
-    'mukurtu_collection_items' => 'visitor-facing, not yet migrated - #1159/#1188',
-    'mukurtu_recent_content' => 'visitor-facing, not yet migrated - #1159/#1188',
     'mukurtu_taxonomy_references' => 'visitor-facing, not yet migrated - #1159/#1188',
-    'taxonomy_term' => 'visitor-facing, not yet migrated - #1159/#1188',
     // The mukurtu_solr module is not installed by default (see mukurtu.install)
     // - these are a dormant alternate-backend copy of the views above.
     'dictionary_browse_solr_new_index' => 'visitor-facing, not yet migrated - #1159/#1188 (mukurtu_solr, not installed by default)',
@@ -83,17 +78,6 @@ class ViewLanguageFallbackCoverageTest extends UnitTestCase {
     'mukurtu_dictionary_solr' => 'visitor-facing, not yet migrated - #1159/#1188 (mukurtu_solr, not installed by default)',
     'mukurtu_digital_heritage_browse_solr' => 'visitor-facing, not yet migrated - #1159/#1188 (mukurtu_solr, not installed by default)',
     'mukurtu_taxonomy_references_solr' => 'visitor-facing, not yet migrated - #1159/#1188 (mukurtu_solr, not installed by default)',
-
-    // Active violation, not just "not yet migrated": its langcode filter
-    // excludes untranslated content instead of falling back to it, which
-    // directly contradicts the "never silently disappear" policy.
-    'browse_by_community' => 'has a langcode filter that HIDES untranslated communities instead of falling back - violates the policy, not just unmigrated - #1159/#1188',
-
-    // Audience resolved by human review (2026-08-26) - all three ruled in
-    // scope for the fallback policy, not yet migrated.
-    'my_personal_collections' => 'visitor-facing (a user\'s own saved items still deserve fallback, not just shared/public content), not yet migrated - #1159/#1188',
-    'mukurtu_message_log' => 'visitor-facing - only the /notifications display is in scope (admin/notifications is legitimately admin-only within the same view); not yet migrated - #1159/#1188',
-    'mukurtu_workflow_overview' => 'staff review-queue at /review-queue - reviewers are ruled in scope (may work in a non-default language too), not just visitors; not yet migrated - #1159/#1188',
   ];
 
   /**


### PR DESCRIPTION
## Summary

PR #2053 migrated 11 plain-entity views to the language-fallback policy and, as part of its diff, removed their `EXEMPTIONS` entries from `ViewLanguageFallbackCoverageTest` (PR #2044's guard test). That specific file's change never actually landed in the squash-merge onto `main` - confirmed:

- `git show 3c81b890c --stat` (the actual #2053 merge commit) lists all 27 other changed files (view YAMLs, 8 new update hooks, 8 new Kernel tests) but **not** `ViewLanguageFallbackCoverageTest.php`.
- `git log -- modules/mukurtu_multilingual/tests/src/Unit/ViewLanguageFallbackCoverageTest.php` on `main` shows only 2 commits ever touched this file - #2044's original add and an earlier audience-scoping resolution - #2053's removal is absent from the history entirely.

The 11 views themselves are genuinely fixed on `main` (verified `views.view.mukurtu_categories.yml` has the `default_langcode` filter, `mukurtu.install` has the new update hook, etc.) - only the guard test's bookkeeping was stale.

**Why this isn't just cosmetic**: while a view's entry stays in `EXEMPTIONS`, the guard test skips checking it entirely. So right now, on `main`, these 11 views have **zero protection** from this test against a future regression - exactly the failure mode PR #2044 was built to catch. This PR closes that gap.

## Test plan

- [x] Re-ran the same standalone verification harness used throughout #2044/#2053's development (real PHPUnit isn't runnable in this bare checkout): 40 views scanned, 29 exemptions (was 40), zero gaps - confirms the 11 already-fixed views are correctly recognized as compliant without needing an exemption.
- [x] `php -l` - no syntax errors.
- [x] Diff is exactly the 11 entries + comment cleanup - no other file needed touching, since the underlying view fixes are already correctly on `main`.

## Pre-merge checklist:

- [x] I have checked for and if required, created update hooks. (N/A - test-only change.)
- [x] I have run an accessibility check, and resolved any issues. (N/A.)
- [x] I have recompiled SCSS if required. (N/A.)
- [x] I have updated or created CI/CD tests, if required. (This *is* a test fix - no new test needed.)
- [x] I have updated from `main` and resolved any merge conflicts. (Branched directly off current `main`.)
- [ ] I have verified that all expected checks pass.
- [x] I have run the pr-expert-review skill and resolved all relevant issues.
- [x] If I added a content entity bundle... (N/A.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)