### PR TITLE
Ship the language_with_fallback field in config/install too (#1260)

### DIFF
--- a/modules/mukurtu_browse/config/install/search_api.index.mukurtu_default_content_index.yml
+++ b/modules/mukurtu_browse/config/install/search_api.index.mukurtu_default_content_index.yml
@@ -16,6 +16,10 @@ name: 'Mukurtu Default content index'
 description: 'Default Mukurtu content index'
 read_only: false
 field_settings:
+  language_with_fallback:
+    label: 'Language (with fallback)'
+    property_path: language_with_fallback
+    type: string
   changed:
     label: Changed
     datasource_id: 'entity:node'

--- a/modules/mukurtu_collection/config/install/search_api.index.mukurtu_collection_index.yml
+++ b/modules/mukurtu_collection/config/install/search_api.index.mukurtu_collection_index.yml
@@ -10,6 +10,10 @@ name: 'Mukurtu Collection Index'
 description: 'Index for Mukurtu Collections.'
 read_only: false
 field_settings:
+  language_with_fallback:
+    label: 'Language (with fallback)'
+    property_path: language_with_fallback
+    type: string
   changed:
     label: Changed
     datasource_id: 'entity:node'

--- a/modules/mukurtu_dictionary/config/install/search_api.index.mukurtu_dictionary_index.yml
+++ b/modules/mukurtu_dictionary/config/install/search_api.index.mukurtu_dictionary_index.yml
@@ -15,6 +15,10 @@ name: 'Mukurtu Dictionary Index'
 description: 'Index for the Mukurtu dictionary.'
 read_only: false
 field_settings:
+  language_with_fallback:
+    label: 'Language (with fallback)'
+    property_path: language_with_fallback
+    type: string
   changed:
     label: Changed
     datasource_id: 'entity:node'

--- a/modules/mukurtu_multilingual/tests/src/Unit/SearchApiFallbackFieldShippedConfigTest.php
+++ b/modules/mukurtu_multilingual/tests/src/Unit/SearchApiFallbackFieldShippedConfigTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\mukurtu_multilingual\Unit;
+
+use Drupal\Tests\UnitTestCase;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Confirms the language_with_fallback Search API field ships in every
+ * profile-owned index's config/install, not just added via an update
+ * hook.
+ *
+ * mukurtu_multilingual_update_40009() (added in #2049) only converges
+ * *existing* sites - update hooks never run on a fresh install, and this
+ * profile's hook_install() implementations never called that logic
+ * either, so a fresh install got none of the 6 indexes wired at all until
+ * this test's own fix shipped the field directly in each owning module's
+ * config/install/search_api.index.*.yml. That's the same "ship it in
+ * config/install AND provide an update hook for upgraders" pattern
+ * already used for other field/config additions in this codebase.
+ *
+ * A pure filesystem/YAML check - no Drupal bootstrap needed.
+ *
+ * @see mukurtu_multilingual_update_40009()
+ * @group mukurtu_multilingual
+ */
+class SearchApiFallbackFieldShippedConfigTest extends UnitTestCase {
+
+  /**
+   * Every profile-owned index config file, relative to the profile root.
+   */
+  private const INDEX_FILES = [
+    'modules/mukurtu_browse/config/install/search_api.index.mukurtu_default_content_index.yml',
+    'modules/mukurtu_collection/config/install/search_api.index.mukurtu_collection_index.yml',
+    'modules/mukurtu_dictionary/config/install/search_api.index.mukurtu_dictionary_index.yml',
+    'modules/mukurtu_search/config/install/search_api.index.mukurtu_browse_auto_index.yml',
+    'modules/mukurtu_solr/config/install/search_api.index.mukurtu_default_solr_index.yml',
+    'modules/mukurtu_solr/config/install/search_api.index.mukurtu_dictionary_solr_index.yml',
+  ];
+
+  /**
+   * Every index ships the field with the exact shape the update hook also
+   * creates - a plain string field, no datasource (it's a processor-
+   * derived, index-wide property, not per-datasource).
+   */
+  public function testEveryIndexShipsTheFallbackField(): void {
+    $profileRoot = dirname(__DIR__, 5);
+    $this->assertDirectoryExists($profileRoot . '/modules', 'Sanity check: resolved profile root is wrong.');
+
+    foreach (self::INDEX_FILES as $relativePath) {
+      $path = "$profileRoot/$relativePath";
+      $this->assertFileExists($path);
+
+      $index = Yaml::parseFile($path);
+      $field = $index['field_settings']['language_with_fallback'] ?? NULL;
+      $this->assertNotNull($field, "$relativePath does not ship the language_with_fallback field.");
+      $this->assertSame('string', $field['type'], "$relativePath: wrong field type.");
+      $this->assertSame('language_with_fallback', $field['property_path'], "$relativePath: wrong property_path.");
+      $this->assertArrayNotHasKey('datasource_id', $field, "$relativePath: should have no datasource_id - it's an index-wide processor property.");
+
+      // The processor itself must also actually be enabled, or the field
+      // would resolve to nothing at index time.
+      $this->assertArrayHasKey('language_with_fallback', $index['processor_settings'] ?? [], "$relativePath: language_with_fallback processor is not enabled.");
+    }
+  }
+
+}

--- a/modules/mukurtu_search/config/install/search_api.index.mukurtu_browse_auto_index.yml
+++ b/modules/mukurtu_search/config/install/search_api.index.mukurtu_browse_auto_index.yml
@@ -14,6 +14,10 @@ name: 'Mukurtu Browse Auto Content Index'
 description: ''
 read_only: false
 field_settings:
+  language_with_fallback:
+    label: 'Language (with fallback)'
+    property_path: language_with_fallback
+    type: string
   entity_type:
     label: 'Entity type'
     property_path: search_api_entity_type

--- a/modules/mukurtu_solr/config/install/search_api.index.mukurtu_default_solr_index.yml
+++ b/modules/mukurtu_solr/config/install/search_api.index.mukurtu_default_solr_index.yml
@@ -71,6 +71,10 @@ name: 'Mukurtu Default Solr Content Index'
 description: 'The default Mukurtu Solr search index that provides search for most "browse" pages.'
 read_only: false
 field_settings:
+  language_with_fallback:
+    label: 'Language (with fallback)'
+    property_path: language_with_fallback
+    type: string
   node__body:
     label: Body
     datasource_id: 'entity:node'

--- a/modules/mukurtu_solr/config/install/search_api.index.mukurtu_dictionary_solr_index.yml
+++ b/modules/mukurtu_solr/config/install/search_api.index.mukurtu_dictionary_solr_index.yml
@@ -60,6 +60,10 @@ name: 'Mukurtu Dictionary Solr Index'
 description: 'Solr search index for dictionary browse Solr.'
 read_only: false
 field_settings:
+  language_with_fallback:
+    label: 'Language (with fallback)'
+    property_path: language_with_fallback
+    type: string
   changed:
     label: Changed
     datasource_id: 'entity:node'


### PR DESCRIPTION
## Summary

Found while scoping the next batch of Phase 4 view migrations - `mukurtu_multilingual_update_40009()` (#2049) only wires the `language_with_fallback` Search API field for sites **upgrading** from an older schema version. Update hooks never run on a fresh install, and no `hook_install()` in this profile called that logic either (checked `mukurtu_multilingual_install()` directly - it doesn't). A brand-new Mukurtu site therefore never got the field on any of the 6 indexes at all.

This is more than a coverage gap - it's a real functional issue: the 14 remaining Phase 4 views that will filter on this field would ship broken on any fresh install once added, since they'd reference a field that doesn't exist in the index.

**Fix**: ship the field directly in each owning module's `config/install/search_api.index.*.yml` (covers fresh installs, matching how other field/config additions in this codebase already handle both cases), leaving #2049's existing update hook in place unchanged for sites converging from an older version.

## Test plan

- [x] Added `SearchApiFallbackFieldShippedConfigTest` (Unit, no bootstrap): confirms all 6 shipped index configs carry the field with the exact shape the update hook also creates (`type: string`, correct `property_path`, no `datasource_id` since it's a processor-derived index-wide property), and that the `language_with_fallback` processor is actually enabled in each. This is a fresh-install-path check that didn't exist before - the only prior test (`SearchApiLanguageFallbackFieldTest` from #2049) only ever exercised the update-hook path.
- [x] Manually re-verified the same assertions the new test makes directly against the 6 edited files - all pass.
- [x] `php -l` - no syntax errors.
- [ ] Could not run the real Unit test locally - no `web/core` scaffold in this checkout, the same limitation hit throughout this work. CI is the real verification.

## Pre-merge checklist:

- [x] I have checked for and if required, created update hooks. (N/A - this ships the field in `config/install` for fresh installs; #2049's existing update hook already handles upgrading sites, unchanged here.)
- [x] I have run an accessibility check, and resolved any issues. (N/A - no rendered markup/UI change.)
- [x] I have recompiled SCSS if required. (N/A.)
- [x] I have updated or created CI/CD tests, if required. (New Unit test added.)
- [x] I have updated from `main` and resolved any merge conflicts. (Branched directly off current `main`.)
- [ ] I have verified that all expected checks pass.
- [x] I have run the pr-expert-review skill and resolved all relevant issues.
- [x] If I added a content entity bundle... (N/A.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)