### PR TITLE
Mark search_api_field rewrite-text as non-translatable (#1638)

### DIFF
--- a/docs/content-language-policy.md
+++ b/docs/content-language-policy.md
@@ -43,6 +43,24 @@ Admin-only views that intentionally list content across all languages for editor
 
 `modules/mukurtu_multilingual/tests/src/Unit/ViewLanguageFallbackCoverageTest.php` runs in CI on every PR. It scans every shipped `views.view.*.yml` (`config/install` and `config/optional`, profile-wide) and fails the build if a view implements neither fallback mechanism above **and** has no entry in its `EXEMPTIONS` list. Adding a new view (or editing an existing one's language handling) that doesn't satisfy either condition breaks CI — either implement the fallback pattern, or add a keyed, reasoned entry to `EXEMPTIONS`.
 
+## Known contrib limitation: locale_string_is_safe() false positives (#1901)
+
+Drupal's `locale_string_is_safe()` scans every string in a `translatable`-
+typed config schema value and rejects it if it contains disallowed HTML
+(e.g. a `<div>` wrapping a machine-readable token, not visible text).
+Klaro and Captcha (both contrib, no Mukurtu-owned code in either) ship
+config strings that trip this check - see #1901. That's a contrib
+packaging issue, not something fixable in this profile; it needs a patch
+or an upstream fix in Klaro/Captcha itself.
+
+When the same false positive shows up in **Mukurtu-owned** config
+instead, it usually means a schema type is marked `translatable` for
+content that was never meant to be translated (e.g. a machine-readable
+token, not visible text). See #1638 for a real instance and its fix:
+`mukurtu_multilingual/src/Hook/ViewsSchemaHooks.php` overrides the
+offending schema type via `hook_config_schema_info_alter()` rather than
+patching contrib or silencing the check.
+
 ## Checklist for new views/facets
 
 - [ ] Does this view show content to site visitors (not just admins/editors)? If yes, it needs the fallback policy above.

--- a/modules/mukurtu_multilingual/src/Hook/ViewsSchemaHooks.php
+++ b/modules/mukurtu_multilingual/src/Hook/ViewsSchemaHooks.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\mukurtu_multilingual\Hook;
+
+use Drupal\Core\Hook\Attribute\Hook;
+
+/**
+ * Marks the search_api_field Views field's "rewrite results" text as
+ * non-translatable (issue #1638).
+ *
+ * mukurtu_browse_by_map and its mukurtu_solr equivalent each rewrite two
+ * fields (uuid, nid) to `<div class="uuid visually-hidden">{{ uuid }}
+ * </div>` (and the nid equivalent) - hidden, machine-readable tokens for
+ * JS to read node identity on the map, not visible text. Search API's own
+ * schema (views.field.search_api_field) inherits this "rewrite text"
+ * value from Views' generic views_field type as `type: text`, which core
+ * marks translatable - so Drupal's locale tooling scans it and flags the
+ * <div> tag as disallowed in a translatable string, even though
+ * translating it would never change anything.
+ *
+ * Confirmed (2026-08-28) this is safe to apply profile-wide rather than
+ * scoping to just those 2 views: swept every shipped views.view.*.yml for
+ * a search_api_field-plugin field with alter_text enabled and a non-empty
+ * value - these are the only two non-empty instances anywhere in the
+ * profile, so no other view's use of this plugin's rewrite-text is
+ * losing real translatability here.
+ */
+class ViewsSchemaHooks {
+
+  /**
+   * Implements hook_config_schema_info_alter().
+   */
+  #[Hook('config_schema_info_alter')]
+  public function configSchemaInfoAlter(array &$definitions): void {
+    if (isset($definitions['views.field.search_api_field']['mapping']['alter']['mapping']['text'])) {
+      $definitions['views.field.search_api_field']['mapping']['alter']['mapping']['text']['type'] = 'string';
+    }
+  }
+
+}

--- a/modules/mukurtu_multilingual/src/Hook/ViewsSchemaHooks.php
+++ b/modules/mukurtu_multilingual/src/Hook/ViewsSchemaHooks.php
@@ -26,6 +26,18 @@ use Drupal\Core\Hook\Attribute\Hook;
  * value - these are the only two non-empty instances anywhere in the
  * profile, so no other view's use of this plugin's rewrite-text is
  * losing real translatability here.
+ *
+ * hook_config_schema_info_alter() receives the raw, per-type discovery
+ * array, before TypedConfigManager::getDefinition() walks and deep-merges
+ * a type's parent chain - views.field.search_api_field's own raw entry
+ * never declares 'alter' itself (it only sets 'field_rendering'); the
+ * 'alter.mapping.text' key this needs to override lives several levels up
+ * the chain, on the shared views_field base type. So this always sets the
+ * override on search_api_field's own raw entry (auto-vivifying the path)
+ * rather than gating on isset() - the later deep merge combines it with
+ * the inherited 'alter' tree, overriding only this one leaf. Altering
+ * views_field itself instead would've been correct too, but far too
+ * broad: every Views field type inherits from it.
  */
 class ViewsSchemaHooks {
 
@@ -34,7 +46,13 @@ class ViewsSchemaHooks {
    */
   #[Hook('config_schema_info_alter')]
   public function configSchemaInfoAlter(array &$definitions): void {
-    if (isset($definitions['views.field.search_api_field']['mapping']['alter']['mapping']['text'])) {
+    // Guard on the type existing at all (only true when search_api is
+    // installed) - unconditionally writing the nested path would
+    // auto-vivify a brand new top-level 'views.field.search_api_field'
+    // key on a site without search_api, which TypedConfigManager flags as
+    // an error (hook_config_schema_info_alter() must not add/remove
+    // top-level type definitions, only modify existing ones).
+    if (isset($definitions['views.field.search_api_field'])) {
       $definitions['views.field.search_api_field']['mapping']['alter']['mapping']['text']['type'] = 'string';
     }
   }

--- a/modules/mukurtu_multilingual/tests/src/Kernel/ViewsSchemaHooksTest.php
+++ b/modules/mukurtu_multilingual/tests/src/Kernel/ViewsSchemaHooksTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\mukurtu_multilingual\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+
+/**
+ * Tests ViewsSchemaHooks::configSchemaInfoAlter() (issue #1638).
+ *
+ * @see \Drupal\mukurtu_multilingual\Hook\ViewsSchemaHooks
+ * @group mukurtu_multilingual
+ */
+class ViewsSchemaHooksTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = ['system', 'views', 'search_api'];
+
+  /**
+   * The search_api_field Views field's rewrite-results text is marked
+   * non-translatable, not core's default translatable "text" type - so
+   * Drupal's locale tooling stops flagging the uuid/nid <div> markup as
+   * a disallowed-HTML translatable string.
+   */
+  public function testRewriteTextIsNotTranslatable(): void {
+    $definition = \Drupal::service('config.typed')->getDefinition('views.field.search_api_field');
+
+    $this->assertSame(
+      'string',
+      $definition['mapping']['alter']['mapping']['text']['type'],
+      'The search_api_field rewrite-results text should be typed as a plain (non-translatable) string.'
+    );
+  }
+
+}

--- a/modules/mukurtu_multilingual/tests/src/Kernel/ViewsSchemaHooksTest.php
+++ b/modules/mukurtu_multilingual/tests/src/Kernel/ViewsSchemaHooksTest.php
@@ -17,7 +17,7 @@ class ViewsSchemaHooksTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  protected static $modules = ['system', 'views', 'search_api'];
+  protected static $modules = ['system', 'views', 'search_api', 'mukurtu_multilingual'];
 
   /**
    * The search_api_field Views field's rewrite-results text is marked


### PR DESCRIPTION
## Summary
- Fixes #1638: `locale_string_is_safe()` was flagging the hidden `uuid`/`nid` `<div>` tokens in `mukurtu_browse_by_map` and `mukurtu_browse_by_map_solr` as disallowed HTML in a translatable string. These tokens are machine-readable hooks for JS to read node identity on the map, never visible text.
- Root cause: Search API's `views.field.search_api_field` schema inherits Views' generic `views_field` type's `alter.text` as `type: text` (translatable). Adds `ViewsSchemaHooks::configSchemaInfoAlter()` (`#[Hook('config_schema_info_alter')]`) to override that mapping to `string`, the same pattern `ctools_views_config_schema_info_alter()` uses for an existing Views schema type.
- Confirmed this is scoped correctly: swept every shipped `views.view.*.yml` in the profile for a `search_api_field`-plugin field with non-empty `alter.text` — these two uuid/nid fields are the only instances, so no other view loses real translatability from this override.
- Documents #1901 (Klaro/Captcha) in `docs/content-language-policy.md` as the same symptom class but contrib-owned — not fixable in this profile — and points at this fix as the pattern for a future Mukurtu-owned string hitting the same restriction.
- Closes out Phase 6 items 1 and 2 of the #1260 multilingual roadmap.

## Test plan
- [x] `php -l` on the new Hook class and Kernel test
- [x] Added `ViewsSchemaHooksTest::testRewriteTextIsNotTranslatable()`, a Kernel test asserting `\Drupal::service('config.typed')->getDefinition('views.field.search_api_field')`'s `mapping.alter.mapping.text.type` is `string`
- [x] No update hook needed — this only changes how locale/translation tooling scans config schema, not any stored config value, so there is nothing for an existing site to converge

## Pre-merge checklist:

- [x] I have checked for and if required, created update hooks. (Not required — see above.)
- [x] I have run an accessibility check, and resolved any issues. (N/A — schema/doc-only change, no rendered markup.)
- [x] I have recompiled SCSS if required. (N/A — no SCSS changes.)
- [x] I have updated or created CI/CD tests, if required.
- [x] I have updated from `main` and resolved any merge conflicts.
- [x] If this PR's base branch is not `main`, I understand it needs to be retargeted once that base branch's own PR merges. (N/A — based on `main`.)
- [ ] I have verified that all expected checks pass.
- [x] I have run the pr-expert-review skill and resolved all relevant issues.
- [x] If I added a content entity bundle, I added its `language.content_settings` and base field overrides to `mukurtu_multilingual`. If I added or changed a view, I applied the content language policy in that doc. (N/A — no new bundle/view; this documents a related contrib-vs-Mukurtu-owned distinction in that same policy doc.)