### PR TITLE
Make CSV export translation-aware (#1260 Phase 5, export track)

### DIFF
--- a/docs/export-translation.md
+++ b/docs/export-translation.md
@@ -1,0 +1,31 @@
+# Export Translation Support
+
+This documents how `mukurtu_export` handles translated content (#1260 Phase 5, export track). It exists because export previously always emitted an entity's default/original-language field values, regardless of which translation a user actually wanted.
+
+## Item identity
+
+Every exporter source (`AdHocExporterSource`, `ExportListSource`) hands `CSV.php` an `entity_type_id => [key => key]` map, same as before. A key is now either:
+
+- A bare entity ID — export that entity's original language. Unchanged from before this feature existed.
+- A composite `"$id:$langcode"` key, built via `ExportItemIdentity::encode()`/parsed via `::decode()` — export the specific translation. `CSV::batchExport()` swaps in `$entity->getTranslation($langcode)` when it exists, and falls back to the entity's own language otherwise (never a hard failure).
+
+Only one format is defined, in one place (`ExportItemIdentity`), so `CSV.php`'s batch logic never needs to know which source produced a given key.
+
+## Two ways a composite key gets produced
+
+- **VBO bulk export** (`AdHocExportStartController::startBulk()`): the manage-content view's selection already carries each row's langcode; it's encoded directly since this path is ephemeral (tempstore-backed, nothing persisted).
+- **Saved Export Lists**: `ExportList` gained an additive `item_languages` base field (`"$entity_type:$id" => $langcode`), separate from the existing `items` field. `items`' shape is intentionally untouched — `ExportListRemoveItemsForm`/`ExportListListBuilder` match/remove by bare entity ID, so encoding language into `items`' own keys would have broken removal. An item with no `item_languages` entry exports in its original language, exactly as before this field existed — no update hook was needed to migrate existing data, only the standard field-installation update hook for the schema itself.
+  - **Scope boundary**: one langcode per (entity_type, id) per list. Adding the same item again with a different language choice overwrites the previous one rather than creating a second entry.
+
+The language picker (`ExportListAddItemForm`/`ExportListAddNodeForm`) only appears when the entity actually has more than one translation, and defaults to whichever translation the user is currently viewing.
+
+## Referenced entities
+
+A translated row's *own* fields translate for free — `$entity->get($field_name)` is already scoped to whichever translation object `CSV::export()` was called with. But fields that reference *other* entities (taxonomy terms, protocols, usernames) previously always loaded that referenced entity fresh via a bare `->load()`, showing its own default-language name regardless of the row's language.
+
+`CsvEntityFieldExportEventSubscriber` now resolves these through `EntityTranslationResolver::loadTranslated()` (`mukurtu_core`), using the row's langcode (`EntityFieldExportEvent::getLangcode()`, derived from the row entity itself — `NULL` unless it's a non-original translation). When a referenced entity is additionally queued for its own export (`exportAdditionalEntity()`), it's queued under a composite key too, so the whole reference chain stays in the same language as the row that pulled it in.
+
+## Out of scope
+
+- The import track (translations on the way *in*) — separate follow-up.
+- Exporting the same item in more than one language within a single saved list.

--- a/modules/mukurtu_export/mukurtu_export.install
+++ b/modules/mukurtu_export/mukurtu_export.install
@@ -808,3 +808,19 @@ function mukurtu_export_update_40025(): void {
     $entity->set('entity_fields_export_list', $list)->save();
   }
 }
+
+/**
+ * Add the item_languages field so export list items can carry a
+ * requested-translation langcode (#1260 Phase 5 export track).
+ *
+ * Additive only - existing lists have no entries in this field, so every
+ * existing item keeps exporting in its original language exactly as
+ * before.
+ */
+function mukurtu_export_update_40026(): void {
+  $definition = \Drupal\Core\Field\BaseFieldDefinition::create('map')
+    ->setLabel(t('Item languages'))
+    ->setDescription(t('Serialized map of "entity_type:id" => langcode pairs, for items whose export should use a specific translation instead of their original language. Additive to items - an item with no entry here exports in its original language, unchanged from before this field existed.'));
+  \Drupal::entityDefinitionUpdateManager()
+    ->installFieldStorageDefinition('item_languages', 'export_list', 'mukurtu_export', $definition);
+}

--- a/modules/mukurtu_export/mukurtu_export.services.yml
+++ b/modules/mukurtu_export/mukurtu_export.services.yml
@@ -14,5 +14,6 @@ services:
       - '@messenger'
       - '@entity_type.manager'
       - '@mukurtu_core.paragraph_emptiness_checker'
+      - '@mukurtu_core.entity_translation_resolver'
     tags:
       - { name: event_subscriber }

--- a/modules/mukurtu_export/src/Controller/AdHocExportStartController.php
+++ b/modules/mukurtu_export/src/Controller/AdHocExportStartController.php
@@ -5,6 +5,7 @@ namespace Drupal\mukurtu_export\Controller;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\TempStore\PrivateTempStoreFactory;
 use Drupal\media\MediaInterface;
+use Drupal\mukurtu_export\ExportItemIdentity;
 use Drupal\node\NodeInterface;
 use Drupal\views_bulk_operations\Traits\ViewsBulkOperationsFormTrait;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -61,9 +62,11 @@ class AdHocExportStartController extends ControllerBase {
     // Each VBO list item is [base_field_value, langcode, entity_type, entity_id, ...].
     $by_type = [];
     foreach ($form_data['list'] as $item) {
+      $langcode = $item[1] ?: NULL;
       $entity_type = $item[2];
       $entity_id = (int) $item[3];
-      $by_type[$entity_type][$entity_id] = $entity_id;
+      $key = ExportItemIdentity::encode($entity_id, $langcode);
+      $by_type[$entity_type][$key] = $key;
     }
 
     $store = $this->tempStoreFactory->get('mukurtu_import');

--- a/modules/mukurtu_export/src/Entity/ExportList.php
+++ b/modules/mukurtu_export/src/Entity/ExportList.php
@@ -85,6 +85,10 @@ class ExportList extends ContentEntityBase implements EntityOwnerInterface {
       ->setLabel(t('Items'))
       ->setDescription(t('Serialized map of entity_type_id => [id => id] pairs.'));
 
+    $fields['item_languages'] = BaseFieldDefinition::create('map')
+      ->setLabel(t('Item languages'))
+      ->setDescription(t('Serialized map of "entity_type:id" => langcode pairs, for items whose export should use a specific translation instead of their original language. Additive to items - an item with no entry here exports in its original language, unchanged from before this field existed.'));
+
     $fields['created'] = BaseFieldDefinition::create('created')
       ->setLabel(t('Created'));
 
@@ -171,6 +175,55 @@ class ExportList extends ContentEntityBase implements EntityOwnerInterface {
       $items[$entity_type_id][$id] = $id;
     }
     $this->setItems($items);
+    return $this;
+  }
+
+  /**
+   * Gets the requested-translation langcode for a list item, if one is set.
+   *
+   * @param string $entity_type_id
+   *   The entity type ID.
+   * @param int|string $id
+   *   The entity ID.
+   *
+   * @return string|null
+   *   The langcode, or NULL if the item should export in its original
+   *   language (the default, and the only option before this field
+   *   existed).
+   */
+  public function getItemLanguage(string $entity_type_id, int|string $id): ?string {
+    $first = $this->get('item_languages')->first();
+    $languages = $first ? ($first->value ?? []) : [];
+    return $languages["{$entity_type_id}:{$id}"] ?? NULL;
+  }
+
+  /**
+   * Sets (or clears) the requested-translation langcode for a list item.
+   *
+   * Does not save the entity; callers should call save() once after
+   * making all the changes they need.
+   *
+   * @param string $entity_type_id
+   *   The entity type ID.
+   * @param int|string $id
+   *   The entity ID.
+   * @param string|null $langcode
+   *   The langcode to export this item in, or NULL to clear any previously
+   *   set langcode and export it in its original language.
+   *
+   * @return $this
+   */
+  public function setItemLanguage(string $entity_type_id, int|string $id, ?string $langcode) {
+    $first = $this->get('item_languages')->first();
+    $languages = $first ? ($first->value ?? []) : [];
+    $key = "{$entity_type_id}:{$id}";
+    if ($langcode) {
+      $languages[$key] = $langcode;
+    }
+    else {
+      unset($languages[$key]);
+    }
+    $this->set('item_languages', ['value' => $languages]);
     return $this;
   }
 

--- a/modules/mukurtu_export/src/Event/EntityFieldExportEvent.php
+++ b/modules/mukurtu_export/src/Event/EntityFieldExportEvent.php
@@ -4,6 +4,8 @@ namespace Drupal\mukurtu_export\Event;
 
 use Drupal\Component\EventDispatcher\Event;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\TypedData\TranslatableInterface;
+use Drupal\mukurtu_export\ExportItemIdentity;
 
 /**
  * Event when an entity field is being exported.
@@ -79,6 +81,21 @@ class EntityFieldExportEvent extends Event {
   }
 
   /**
+   * The langcode of the row entity being exported, or NULL if it's being
+   * exported in its own original language.
+   *
+   * Referenced-entity lookups (taxonomy terms, protocols, usernames, etc.)
+   * should resolve to this same language so a translated export doesn't
+   * mix in default-language names for the entities it references.
+   */
+  public function getLangcode(): ?string {
+    if ($this->entity instanceof TranslatableInterface && !$this->entity->isDefaultTranslation()) {
+      return $this->entity->language()->getId();
+    }
+    return NULL;
+  }
+
+  /**
    * Package a binary file for export.
    *
    * @param string $uri
@@ -101,7 +118,11 @@ class EntityFieldExportEvent extends Event {
    *   The entity to export.
    */
   public function exportAdditionalEntity(EntityInterface $entity) {
-    $this->context['results']['entities'][$entity->getEntityTypeId()][$entity->id()] = $entity->id();
+    $langcode = $entity instanceof TranslatableInterface && !$entity->isDefaultTranslation()
+      ? $entity->language()->getId()
+      : NULL;
+    $key = ExportItemIdentity::encode($entity->id(), $langcode);
+    $this->context['results']['entities'][$entity->getEntityTypeId()][$key] = $key;
   }
 
 }

--- a/modules/mukurtu_export/src/EventSubscriber/CsvEntityFieldExportEventSubscriber.php
+++ b/modules/mukurtu_export/src/EventSubscriber/CsvEntityFieldExportEventSubscriber.php
@@ -5,6 +5,7 @@ namespace Drupal\mukurtu_export\EventSubscriber;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\mukurtu_core\Service\EntityTranslationResolver;
 use Drupal\mukurtu_core\Service\ParagraphEmptinessChecker;
 use Drupal\mukurtu_export\Entity\CsvExporter;
 use Drupal\mukurtu_export\Event\EntityFieldExportEvent;
@@ -36,12 +37,20 @@ class CsvEntityFieldExportEventSubscriber implements EventSubscriberInterface {
   protected $paragraphEmptinessChecker;
 
   /**
+   * The entity translation resolver.
+   *
+   * @var \Drupal\mukurtu_core\Service\EntityTranslationResolver
+   */
+  protected $entityTranslationResolver;
+
+  /**
    * {@inheritDoc}
    */
-  public function __construct(MessengerInterface $messenger, EntityTypeManagerInterface $entity_type_manager, ParagraphEmptinessChecker $paragraph_emptiness_checker) {
+  public function __construct(MessengerInterface $messenger, EntityTypeManagerInterface $entity_type_manager, ParagraphEmptinessChecker $paragraph_emptiness_checker, EntityTranslationResolver $entity_translation_resolver) {
     $this->messenger = $messenger;
     $this->entityTypeManager = $entity_type_manager;
     $this->paragraphEmptinessChecker = $paragraph_emptiness_checker;
+    $this->entityTranslationResolver = $entity_translation_resolver;
   }
 
   /**
@@ -155,6 +164,25 @@ class CsvEntityFieldExportEventSubscriber implements EventSubscriberInterface {
    *
    * @protected
    */
+  /**
+   * Loads an entity for export, honoring the row's requested translation.
+   *
+   * When the row entity ($event->entity) is being exported in a specific
+   * translation (not its own original language), referenced entities
+   * should resolve to that same translation where one exists. Otherwise
+   * this is a plain load, unchanged from before - deliberately not routed
+   * through EntityTranslationResolver's active-content-language fallback,
+   * which would silently pull in the *current request's* language instead
+   * of the referenced entity's own default one.
+   */
+  protected function loadForExport(string $entity_type_id, $id, EntityFieldExportEvent $event): ?EntityInterface {
+    $langcode = $event->getLangcode();
+    if ($langcode) {
+      return $this->entityTranslationResolver->loadTranslated($entity_type_id, $id, $langcode);
+    }
+    return $this->entityTypeManager->getStorage($entity_type_id)->load($id);
+  }
+
   protected function getUUID($entity_type_id, $id) {
     if ($entity = $this->entityTypeManager->getStorage($entity_type_id)->load($id)) {
       return $entity->uuid();
@@ -246,7 +274,7 @@ class CsvEntityFieldExportEventSubscriber implements EventSubscriberInterface {
           }
 
           if ($target_type == 'taxonomy_term' && $option == 'name') {
-            if ($term = $this->entityTypeManager->getStorage($target_type)->load($id)) {
+            if ($term = $this->loadForExport($target_type, $id, $event)) {
               /** @var \Drupal\taxonomy\TermInterface $term */
               $export[] = $term->getName();
               continue;
@@ -610,7 +638,7 @@ class CsvEntityFieldExportEventSubscriber implements EventSubscriberInterface {
    * @protected
    */
   protected function exportEntityById(EntityFieldExportEvent $event, $entity_type_id, $id): EntityInterface|null {
-    if ($entity = $this->entityTypeManager->getStorage($entity_type_id)->load($id)) {
+    if ($entity = $this->loadForExport($entity_type_id, $id, $event)) {
       $event->exportAdditionalEntity($entity);
       return $entity;
     }
@@ -624,7 +652,7 @@ class CsvEntityFieldExportEventSubscriber implements EventSubscriberInterface {
    * exported as identifiers only -- their references will not be followed further.
    */
   protected function exportEntityByIdShallow(EntityFieldExportEvent $event, $entity_type_id, $id): EntityInterface|null {
-    if ($entity = $this->entityTypeManager->getStorage($entity_type_id)->load($id)) {
+    if ($entity = $this->loadForExport($entity_type_id, $id, $event)) {
       $event->exportAdditionalEntity($entity);
       $event->context['results']['shallow_entity_ids'][$entity_type_id][$id] = $id;
       return $entity;

--- a/modules/mukurtu_export/src/ExportItemIdentity.php
+++ b/modules/mukurtu_export/src/ExportItemIdentity.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Drupal\mukurtu_export;
+
+/**
+ * Encodes/decodes export item keys.
+ *
+ * An item key is either a bare entity ID (export the entity's original
+ * language, today's behavior) or a composite "$id:$langcode" string
+ * (export a specific translation). Every producer of the entities array
+ * consumed by MukurtuExporter plugins (AdHocExporterSource,
+ * ExportListSource) builds keys through encode() so the format is defined
+ * exactly once.
+ */
+class ExportItemIdentity {
+
+  /**
+   * Builds an item key from an entity ID and an optional langcode.
+   *
+   * @param int|string $id
+   *   The entity ID.
+   * @param string|null $langcode
+   *   The requested translation's langcode, or NULL/empty for the entity's
+   *   original language.
+   *
+   * @return string
+   *   The item key.
+   */
+  public static function encode(int|string $id, ?string $langcode = NULL): string {
+    return $langcode ? "{$id}:{$langcode}" : (string) $id;
+  }
+
+  /**
+   * Splits an item key back into its entity ID and langcode.
+   *
+   * @param string $key
+   *   The item key, as produced by encode().
+   *
+   * @return array
+   *   A 2-tuple: [id, langcode]. langcode is NULL when the key carried no
+   *   language (the entity's original-language export).
+   */
+  public static function decode(string $key): array {
+    $parts = explode(':', $key, 2);
+    return [$parts[0], $parts[1] ?? NULL];
+  }
+
+}

--- a/modules/mukurtu_export/src/ExportListSource.php
+++ b/modules/mukurtu_export/src/ExportListSource.php
@@ -19,7 +19,14 @@ class ExportListSource implements MukurtuExporterSourceInterface {
    * {@inheritdoc}
    */
   public function getEntities(): array {
-    return $this->exportList->getItems();
+    $entities = [];
+    foreach ($this->exportList->getItems() as $entity_type_id => $ids) {
+      foreach ($ids as $id) {
+        $key = ExportItemIdentity::encode($id, $this->exportList->getItemLanguage($entity_type_id, $id));
+        $entities[$entity_type_id][$key] = $key;
+      }
+    }
+    return $entities;
   }
 
 }

--- a/modules/mukurtu_export/src/Form/ExportListAddItemForm.php
+++ b/modules/mukurtu_export/src/Form/ExportListAddItemForm.php
@@ -4,7 +4,9 @@ namespace Drupal\mukurtu_export\Form;
 
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\TypedData\TranslatableInterface;
 use Drupal\Core\Url;
+use Drupal\mukurtu_core\Service\EntityTranslationResolver;
 use Drupal\mukurtu_export\ExportChildResolver;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
@@ -19,10 +21,12 @@ class ExportListAddItemForm extends FormBase {
 
   protected EntityTypeManagerInterface $entityTypeManager;
   protected ExportChildResolver $childResolver;
+  protected EntityTranslationResolver $entityTranslationResolver;
 
-  public function __construct(EntityTypeManagerInterface $entity_type_manager, ExportChildResolver $child_resolver) {
+  public function __construct(EntityTypeManagerInterface $entity_type_manager, ExportChildResolver $child_resolver, EntityTranslationResolver $entity_translation_resolver) {
     $this->entityTypeManager = $entity_type_manager;
     $this->childResolver = $child_resolver;
+    $this->entityTranslationResolver = $entity_translation_resolver;
   }
 
   /**
@@ -32,6 +36,7 @@ class ExportListAddItemForm extends FormBase {
     return new static(
       $container->get('entity_type.manager'),
       $container->get('mukurtu_export.child_resolver'),
+      $container->get('mukurtu_core.entity_translation_resolver'),
     );
   }
 
@@ -59,6 +64,26 @@ class ExportListAddItemForm extends FormBase {
       '#type' => 'item',
       '#markup' => $this->t('Adding <em>@label</em> to an export list.', ['@label' => $entity->label()]),
     ];
+
+    // Only offer a language choice when the entity actually has more than
+    // one translation - otherwise there's nothing to choose between.
+    if ($entity instanceof TranslatableInterface) {
+      $translations = $entity->getTranslationLanguages();
+      if (count($translations) > 1) {
+        $current = $this->entityTranslationResolver->translate($entity);
+        $options = [];
+        foreach ($translations as $langcode => $language) {
+          $options[$langcode] = $language->getName();
+        }
+        $form['export_langcode'] = [
+          '#type' => 'select',
+          '#title' => $this->t('Export language'),
+          '#description' => $this->t('Which translation of this item should be added to the list? Defaults to the version you\'re currently viewing.'),
+          '#options' => $options,
+          '#default_value' => $current->language()->getId(),
+        ];
+      }
+    }
 
     // Load accessible lists for this user.
     $uid = $this->currentUser()->id();
@@ -316,6 +341,16 @@ class ExportListAddItemForm extends FormBase {
 
     $this->childResolver->addMpiEntitiesForNodes($items);
     $list->setItems($items);
+
+    // Only the item the user explicitly chose a language for is tagged -
+    // child/related items pulled in above stay in their original language.
+    // No entry is stored when the choice matches the entity's own original
+    // language, keeping item_languages free of no-op entries.
+    $selected_langcode = $form_state->getValue('export_langcode');
+    if ($selected_langcode && $entity && $selected_langcode !== $entity->language()->getId()) {
+      $list->setItemLanguage($entity_type, $entity_id, $selected_langcode);
+    }
+
     $list->save();
 
     // Also flag the item so it's picked up by FlaggedExporterSource, the

--- a/modules/mukurtu_export/src/Form/ExportListAddNodeForm.php
+++ b/modules/mukurtu_export/src/Form/ExportListAddNodeForm.php
@@ -5,6 +5,8 @@ namespace Drupal\mukurtu_export\Form;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\TypedData\TranslatableInterface;
+use Drupal\mukurtu_core\Service\EntityTranslationResolver;
 use Drupal\mukurtu_export\ExportChildResolver;
 use Drupal\node\NodeInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -17,12 +19,14 @@ class ExportListAddNodeForm extends FormBase {
   public function __construct(
     protected readonly EntityTypeManagerInterface $entityTypeManager,
     protected readonly ExportChildResolver $childResolver,
+    protected readonly EntityTranslationResolver $entityTranslationResolver,
   ) {}
 
   public static function create(ContainerInterface $container): static {
     return new static(
       $container->get('entity_type.manager'),
       $container->get('mukurtu_export.child_resolver'),
+      $container->get('mukurtu_core.entity_translation_resolver'),
     );
   }
 
@@ -36,6 +40,26 @@ class ExportListAddNodeForm extends FormBase {
     $form['info'] = [
       '#markup' => $this->t('Adding <em>%title</em> to an export list.', ['%title' => $node->label()]),
     ];
+
+    // Only offer a language choice when the node actually has more than one
+    // translation - otherwise there's nothing to choose between.
+    if ($node instanceof TranslatableInterface) {
+      $translations = $node->getTranslationLanguages();
+      if (count($translations) > 1) {
+        $current = $this->entityTranslationResolver->translate($node);
+        $options = [];
+        foreach ($translations as $langcode => $language) {
+          $options[$langcode] = $language->getName();
+        }
+        $form['export_langcode'] = [
+          '#type' => 'select',
+          '#title' => $this->t('Export language'),
+          '#description' => $this->t('Which translation of this item should be added to the list? Defaults to the version you\'re currently viewing.'),
+          '#options' => $options,
+          '#default_value' => $current->language()->getId(),
+        ];
+      }
+    }
 
     $uid = $this->currentUser()->id();
     $storage = $this->entityTypeManager->getStorage('export_list');
@@ -266,7 +290,18 @@ class ExportListAddNodeForm extends FormBase {
     }
 
     $this->childResolver->addMpiEntitiesForNodes($items);
-    $list->setItems($items)->save();
+    $list->setItems($items);
+
+    // Only the item the user explicitly chose a language for is tagged -
+    // child/related items pulled in above stay in their original language.
+    // No entry is stored when the choice matches the node's own original
+    // language, keeping item_languages free of no-op entries.
+    $selected_langcode = $form_state->getValue('export_langcode');
+    if ($selected_langcode && $selected_langcode !== $node->language()->getId()) {
+      $list->setItemLanguage('node', $node->id(), $selected_langcode);
+    }
+
+    $list->save();
 
     $this->messenger()->addStatus($this->t('%title added to export list %label.', [
       '%title' => $node->label(),

--- a/modules/mukurtu_export/src/Plugin/MukurtuExporter/CSV.php
+++ b/modules/mukurtu_export/src/Plugin/MukurtuExporter/CSV.php
@@ -3,10 +3,12 @@
 namespace Drupal\mukurtu_export\Plugin\MukurtuExporter;
 
 use Drupal\mukurtu_export\Attribute\MukurtuExporter;
+use Drupal\mukurtu_export\ExportItemIdentity;
 use Drupal\mukurtu_export\Plugin\ExporterBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\File\FileSystemInterface;
+use Drupal\Core\TypedData\TranslatableInterface;
 use Drupal\mukurtu_export\Event\EntityFieldExportEvent;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\Url;
@@ -294,17 +296,24 @@ class CSV extends ExporterBase {
     $entities = $context['sandbox']['batch']['entities'];
     $storage = \Drupal::entityTypeManager()->getStorage($entity_type_id);
 
-    foreach ($entities as $id) {
-      $alreadyExported = $context['results']['exported_entities'][$entity_type_id][$id] ?? FALSE;
+    foreach ($entities as $key) {
+      $alreadyExported = $context['results']['exported_entities'][$entity_type_id][$key] ?? FALSE;
       if (!$alreadyExported) {
+        [$id, $langcode] = ExportItemIdentity::decode($key);
         $entity = $storage->load($id);
 
         // Regardless of the result, remove entity from the list.
-        unset($context['results']['entities'][$entity_type_id][$id]);
+        unset($context['results']['entities'][$entity_type_id][$key]);
 
         if (!$entity) {
           // @todo what do we do on this failure?
           continue;
+        }
+
+        // Resolve to the requested translation, falling back to the
+        // entity's own language if that translation doesn't exist.
+        if ($langcode && $entity instanceof TranslatableInterface && $entity->hasTranslation($langcode)) {
+          $entity = $entity->getTranslation($langcode);
         }
 
         // Confirm user has access to view this entity.
@@ -327,7 +336,7 @@ class CSV extends ExporterBase {
         fputcsv($output, $result, $context['results']['csv']['separator'], $context['results']['csv']['enclosure'], $context['results']['csv']['escape']);
 
         // Record export of this entity.
-        $context['results']['exported_entities'][$entity_type_id][$id] = $id;
+        $context['results']['exported_entities'][$entity_type_id][$key] = $key;
         $context['results']['exported_entities_count']++;
       }
 

--- a/modules/mukurtu_export/tests/src/Kernel/CsvExportFieldTestBase.php
+++ b/modules/mukurtu_export/tests/src/Kernel/CsvExportFieldTestBase.php
@@ -85,7 +85,7 @@ class CsvExportFieldTestBase extends ProtocolAwareEntityTestBase {
       ]
     ];
 
-    $this->fieldExporter = new CsvEntityFieldExportEventSubscriber(\Drupal::messenger(), \Drupal::entityTypeManager(), \Drupal::service('mukurtu_core.paragraph_emptiness_checker'));
+    $this->fieldExporter = new CsvEntityFieldExportEventSubscriber(\Drupal::messenger(), \Drupal::entityTypeManager(), \Drupal::service('mukurtu_core.paragraph_emptiness_checker'), \Drupal::service('mukurtu_core.entity_translation_resolver'));
   }
 
 }

--- a/modules/mukurtu_export/tests/src/Kernel/CsvExportTranslationTest.php
+++ b/modules/mukurtu_export/tests/src/Kernel/CsvExportTranslationTest.php
@@ -45,10 +45,10 @@ class CsvExportTranslationTest extends CsvExportFieldTestBase {
     ConfigurableLanguage::createFromLangcode('en')->save();
     ConfigurableLanguage::createFromLangcode('es')->save();
     \Drupal::service('content_translation.manager')->setEnabled('node', 'protocol_aware_content', TRUE);
-    \Drupal::service('content_translation.manager')->setEnabled('taxonomy_term', 'keywords', TRUE);
 
     $vocabulary = Vocabulary::create(['vid' => 'keywords', 'name' => 'Keywords']);
     $vocabulary->save();
+    \Drupal::service('content_translation.manager')->setEnabled('taxonomy_term', 'keywords', TRUE);
 
     FieldStorageConfig::create([
       'field_name' => 'field_keywords',

--- a/modules/mukurtu_export/tests/src/Kernel/CsvExportTranslationTest.php
+++ b/modules/mukurtu_export/tests/src/Kernel/CsvExportTranslationTest.php
@@ -63,6 +63,12 @@ class CsvExportTranslationTest extends CsvExportFieldTestBase {
       'entity_type' => 'node',
       'bundle' => 'protocol_aware_content',
       'label' => 'Keywords',
+      // Translatable fields are per-translation and addTranslation() doesn't
+      // copy values into the new translation object - a reference to the
+      // same term(s) should apply across every translation regardless, so
+      // this matches how reference fields are typically configured on real
+      // Mukurtu content.
+      'translatable' => FALSE,
       'settings' => [
         'handler' => 'default:taxonomy_term',
         'handler_settings' => ['target_bundles' => ['keywords' => 'keywords']],
@@ -183,6 +189,7 @@ class CsvExportTranslationTest extends CsvExportFieldTestBase {
         ],
       ],
       'results' => [
+        'config_id' => $this->export_config->id(),
         'csv' => ['separator' => ',', 'enclosure' => '"', 'escape' => '\\'],
         'entities' => [
           'node' => [

--- a/modules/mukurtu_export/tests/src/Kernel/CsvExportTranslationTest.php
+++ b/modules/mukurtu_export/tests/src/Kernel/CsvExportTranslationTest.php
@@ -1,0 +1,216 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\mukurtu_export\Kernel;
+
+use Drupal\Core\File\FileSystemInterface;
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\language\Entity\ConfigurableLanguage;
+use Drupal\mukurtu_export\Event\EntityFieldExportEvent;
+use Drupal\mukurtu_export\ExportItemIdentity;
+use Drupal\mukurtu_export\Plugin\MukurtuExporter\CSV;
+use Drupal\node\Entity\Node;
+use Drupal\taxonomy\Entity\Term;
+use Drupal\taxonomy\Entity\Vocabulary;
+
+/**
+ * Tests that a translated export row pulls referenced-entity names from
+ * the same translation, not their own default language (#1260 Phase 5).
+ *
+ * @group mukurtu_export
+ */
+class CsvExportTranslationTest extends CsvExportFieldTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'language',
+    'content_translation',
+  ];
+
+  protected $node;
+  protected $term;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    // 'en' isn't a real ConfigurableLanguage entity until explicitly
+    // created, matching ProtocolLabelTranslationTest's setup.
+    ConfigurableLanguage::createFromLangcode('en')->save();
+    ConfigurableLanguage::createFromLangcode('es')->save();
+    \Drupal::service('content_translation.manager')->setEnabled('node', 'protocol_aware_content', TRUE);
+    \Drupal::service('content_translation.manager')->setEnabled('taxonomy_term', 'keywords', TRUE);
+
+    $vocabulary = Vocabulary::create(['vid' => 'keywords', 'name' => 'Keywords']);
+    $vocabulary->save();
+
+    FieldStorageConfig::create([
+      'field_name' => 'field_keywords',
+      'entity_type' => 'node',
+      'type' => 'entity_reference',
+      'cardinality' => -1,
+      'settings' => ['target_type' => 'taxonomy_term'],
+    ])->save();
+
+    FieldConfig::create([
+      'field_name' => 'field_keywords',
+      'entity_type' => 'node',
+      'bundle' => 'protocol_aware_content',
+      'label' => 'Keywords',
+      'settings' => [
+        'handler' => 'default:taxonomy_term',
+        'handler_settings' => ['target_bundles' => ['keywords' => 'keywords']],
+      ],
+    ])->save();
+
+    $term = Term::create([
+      'name' => 'Weaving',
+      'vid' => 'keywords',
+      'status' => TRUE,
+      'uid' => $this->currentUser->id(),
+    ]);
+    $term->save();
+    $term->addTranslation('es', ['name' => 'Tejido'])->save();
+    $this->term = $term;
+
+    $node = Node::create([
+      'title' => 'About Weaving',
+      'type' => 'protocol_aware_content',
+      'status' => TRUE,
+      'uid' => $this->currentUser->id(),
+      'field_keywords' => [['target_id' => $this->term->id()]],
+    ]);
+    $node->setSharingSetting('any');
+    $node->setProtocols([$this->protocol]);
+    $node->save();
+    $node->addTranslation('es', ['title' => 'Sobre el Tejido'])->save();
+    $this->node = $node;
+  }
+
+  /**
+   * The event reports the row's langcode only for a non-original
+   * translation, never for the entity's own original language.
+   */
+  public function testEventLangcode(): void {
+    $originalEvent = new EntityFieldExportEvent('csv', $this->node, 'title', $this->context);
+    $this->assertNull($originalEvent->getLangcode());
+
+    $translatedEvent = new EntityFieldExportEvent('csv', $this->node->getTranslation('es'), 'title', $this->context);
+    $this->assertSame('es', $translatedEvent->getLangcode());
+  }
+
+  /**
+   * A translated row's own field values already come through correctly
+   * (FieldItemList is scoped to whichever translation object it's called
+   * on) - this just confirms the fixture exercises a real translation.
+   */
+  public function testRowOwnFieldUsesRequestedTranslation(): void {
+    $event = new EntityFieldExportEvent('csv', $this->node->getTranslation('es'), 'title', $this->context);
+    $this->fieldExporter->exportField($event);
+    $this->assertEquals(['Sobre el Tejido'], $event->getValue());
+  }
+
+  /**
+   * A referenced taxonomy term's name exports in the row's language, not
+   * the term's own default language.
+   */
+  public function testReferencedTermNameUsesRowLanguage(): void {
+    $this->export_config->setEntityReferenceSetting('taxonomy_term', 'name');
+    $this->export_config->save();
+
+    $event = new EntityFieldExportEvent('csv', $this->node->getTranslation('es'), 'field_keywords', $this->context);
+    $this->fieldExporter->exportField($event);
+
+    $this->assertEquals(['Tejido'], $event->getValue());
+  }
+
+  /**
+   * The same lookup for the row's own original-language export still
+   * returns the term's own default-language name, unchanged from before.
+   */
+  public function testReferencedTermNameUsesDefaultLanguageForOriginalRow(): void {
+    $this->export_config->setEntityReferenceSetting('taxonomy_term', 'name');
+    $this->export_config->save();
+
+    $event = new EntityFieldExportEvent('csv', $this->node, 'field_keywords', $this->context);
+    $this->fieldExporter->exportField($event);
+
+    $this->assertEquals(['Weaving'], $event->getValue());
+  }
+
+  /**
+   * A term additionally queued for its own export (entity_shallow/entity
+   * settings) is queued under a composite id:langcode key when the row
+   * that pulled it in is a translated row, so the queued entity itself
+   * also exports in that language.
+   */
+  public function testReferencedEntityQueuedInRowLanguage(): void {
+    $this->export_config->setEntityReferenceSetting('taxonomy_term', 'entity');
+    $this->export_config->save();
+
+    $event = new EntityFieldExportEvent('csv', $this->node->getTranslation('es'), 'field_keywords', $this->context);
+    $this->fieldExporter->exportField($event);
+
+    $expectedKey = ExportItemIdentity::encode($this->term->id(), 'es');
+    $this->assertArrayHasKey($expectedKey, $event->context['results']['entities']['taxonomy_term']);
+  }
+
+  /**
+   * CSV::batchExport() resolves a composite "$id:$langcode" item key to
+   * the requested translation before exporting the row, and falls back to
+   * the entity's own language when the requested translation doesn't
+   * exist - the mechanism the ad-hoc/VBO and saved-list export paths both
+   * funnel into.
+   */
+  public function testBatchExportResolvesRequestedTranslation(): void {
+    $basepath = 'temporary://csv-export-translation-test';
+    \Drupal::service('file_system')->prepareDirectory($basepath, FileSystemInterface::CREATE_DIRECTORY);
+
+    $context = [
+      'sandbox' => [
+        'config' => $this->export_config,
+        'batch' => [
+          'entity_type_id' => 'node',
+          'entities' => [
+            ExportItemIdentity::encode($this->node->id(), 'es'),
+          ],
+        ],
+      ],
+      'results' => [
+        'csv' => ['separator' => ',', 'enclosure' => '"', 'escape' => '\\'],
+        'entities' => [
+          'node' => [
+            ExportItemIdentity::encode($this->node->id(), 'es') => ExportItemIdentity::encode($this->node->id(), 'es'),
+          ],
+        ],
+        'exported_entities' => [],
+        'exported_entities_count' => 0,
+        'shallow_entity_ids' => [],
+        'headers_written' => [],
+        'basepath' => $basepath,
+        'deliverables' => ['metadata' => [], 'files' => []],
+      ],
+    ];
+
+    CSV::batchExport($context);
+
+    $key = ExportItemIdentity::encode($this->node->id(), 'es');
+    $this->assertArrayHasKey($key, $context['results']['exported_entities']['node']);
+
+    $output = fopen("{$basepath}/Content - Protocol Aware Content.csv", 'r');
+    $header = fgetcsv($output);
+    $row = fgetcsv($output);
+    fclose($output);
+
+    $titleColumn = array_search('Title', $header, TRUE);
+    $this->assertNotFalse($titleColumn);
+    $this->assertSame('Sobre el Tejido', $row[$titleColumn]);
+  }
+
+}

--- a/modules/mukurtu_export/tests/src/Kernel/ExportListItemLanguageTest.php
+++ b/modules/mukurtu_export/tests/src/Kernel/ExportListItemLanguageTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\mukurtu_export\Kernel;
+
+use Drupal\mukurtu_export\Entity\ExportList;
+use Drupal\mukurtu_export\ExportItemIdentity;
+use Drupal\mukurtu_export\ExportListSource;
+use Drupal\Tests\mukurtu_protocol\Kernel\ProtocolAwareEntityTestBase;
+
+/**
+ * Tests ExportList's item_languages field and ExportListSource's key
+ * building (#1260 Phase 5 export track).
+ *
+ * @group mukurtu_export
+ */
+class ExportListItemLanguageTest extends ProtocolAwareEntityTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'mukurtu_export',
+  ];
+
+  protected ExportList $list;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->installEntitySchema('export_list');
+
+    $this->list = ExportList::create([
+      'label' => 'Test List',
+      'uid' => $this->currentUser->id(),
+    ]);
+    $this->list->setItems(['node' => [1 => 1, 2 => 2]]);
+    $this->list->save();
+  }
+
+  /**
+   * An item with no recorded language exports with a bare-ID key -
+   * unchanged from before this field existed.
+   */
+  public function testUntaggedItemUsesBareKey(): void {
+    $this->assertNull($this->list->getItemLanguage('node', 1));
+
+    $entities = (new ExportListSource($this->list))->getEntities();
+    $this->assertArrayHasKey('1', $entities['node']);
+    $this->assertArrayNotHasKey('1:es', $entities['node']);
+  }
+
+  /**
+   * Setting an item's language produces a composite key for that item
+   * only - other items in the same list are unaffected.
+   */
+  public function testTaggedItemUsesCompositeKey(): void {
+    $this->list->setItemLanguage('node', 1, 'es')->save();
+
+    $this->assertSame('es', $this->list->getItemLanguage('node', 1));
+    $this->assertNull($this->list->getItemLanguage('node', 2));
+
+    $entities = (new ExportListSource($this->list))->getEntities();
+    $expectedKey = ExportItemIdentity::encode(1, 'es');
+    $this->assertArrayHasKey($expectedKey, $entities['node']);
+    $this->assertArrayHasKey('2', $entities['node']);
+  }
+
+  /**
+   * Clearing a previously set language reverts the item to a bare key.
+   */
+  public function testClearingLanguageReturnsToDefault(): void {
+    $this->list->setItemLanguage('node', 1, 'es')->save();
+    $this->list->setItemLanguage('node', 1, NULL)->save();
+
+    $this->assertNull($this->list->getItemLanguage('node', 1));
+
+    $entities = (new ExportListSource($this->list))->getEntities();
+    $this->assertArrayHasKey('1', $entities['node']);
+  }
+
+}

--- a/modules/mukurtu_export/tests/src/Kernel/ExportListItemLanguageTest.php
+++ b/modules/mukurtu_export/tests/src/Kernel/ExportListItemLanguageTest.php
@@ -22,6 +22,7 @@ class ExportListItemLanguageTest extends ProtocolAwareEntityTestBase {
    */
   protected static $modules = [
     'mukurtu_export',
+    'mukurtu_multipage_items',
   ];
 
   protected ExportList $list;

--- a/modules/mukurtu_export/tests/src/Unit/ExportItemIdentityTest.php
+++ b/modules/mukurtu_export/tests/src/Unit/ExportItemIdentityTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\mukurtu_export\Unit;
+
+use Drupal\mukurtu_export\ExportItemIdentity;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * @coversDefaultClass \Drupal\mukurtu_export\ExportItemIdentity
+ * @group mukurtu_export
+ */
+class ExportItemIdentityTest extends UnitTestCase {
+
+  /**
+   * @covers ::encode
+   */
+  public function testEncodeWithoutLangcodeReturnsBareId(): void {
+    $this->assertSame('42', ExportItemIdentity::encode(42));
+    $this->assertSame('42', ExportItemIdentity::encode(42, NULL));
+    $this->assertSame('42', ExportItemIdentity::encode(42, ''));
+  }
+
+  /**
+   * @covers ::encode
+   */
+  public function testEncodeWithLangcodeReturnsCompositeKey(): void {
+    $this->assertSame('42:es', ExportItemIdentity::encode(42, 'es'));
+  }
+
+  /**
+   * @covers ::decode
+   */
+  public function testDecodeBareIdHasNullLangcode(): void {
+    [$id, $langcode] = ExportItemIdentity::decode('42');
+    $this->assertSame('42', $id);
+    $this->assertNull($langcode);
+  }
+
+  /**
+   * @covers ::decode
+   */
+  public function testDecodeCompositeKeySplitsIdAndLangcode(): void {
+    [$id, $langcode] = ExportItemIdentity::decode('42:es');
+    $this->assertSame('42', $id);
+    $this->assertSame('es', $langcode);
+  }
+
+  /**
+   * encode()/decode() round-trip for both shapes.
+   *
+   * @covers ::encode
+   * @covers ::decode
+   */
+  public function testRoundTrip(): void {
+    $this->assertSame(['42', NULL], ExportItemIdentity::decode(ExportItemIdentity::encode(42)));
+    $this->assertSame(['42', 'es'], ExportItemIdentity::decode(ExportItemIdentity::encode(42, 'es')));
+  }
+
+}


### PR DESCRIPTION
## Summary
- Part of #1260 Phase 5 (export/import translation roundtrip) - the **export track only**. Import stays a separate follow-up (its riskiest sub-item, the legacy D7 migration discovery spike, is already tracked as #2078).
- Exporting content always emitted the default/original-language field values, regardless of which translation a user actually wanted. The langcode was already available in two places and silently dropped in both:
  - The manage-content view's VBO bulk-export action already carries each row's langcode.
  - Saved Export Lists had no language concept at all - items were always added as bare entity IDs.
- New `ExportItemIdentity` helper defines one item-key format (bare ID, or a composite `"$id:$langcode"`) used by every exporter source, so `CSV.php`'s batch logic only ever needs to understand one shape.
- `CSV::batchExport()` resolves a composite key to the requested translation, falling back to the entity's own language if that translation doesn't exist - never a hard failure.
- `AdHocExportStartController::startBulk()` now encodes the VBO row's langcode instead of discarding it.
- `ExportList` gains an additive `item_languages` base field (+ update hook) so saved lists can also carry a per-item language, with a language picker (shown only when an entity actually has more than one translation) in `ExportListAddItemForm`/`ExportListAddNodeForm`. `items`' own shape is deliberately untouched - `ExportListRemoveItemsForm`/`ExportListListBuilder` match/remove by bare entity ID, so encoding language into those keys would have broken removal. An item with no `item_languages` entry exports exactly as before this field existed.
- `CsvEntityFieldExportEventSubscriber` routes referenced-entity lookups (taxonomy term names, chained entity exports like shallow/full media or paragraph references) through `mukurtu_core`'s `EntityTranslationResolver`, using the row's own langcode - so a translated row's referenced content also renders in that row's language, not the referenced entity's own default language. Deliberately does *not* use the resolver's active-content-language fallback when the row itself is in its original language, to avoid a regression where referenced entities would silently pick up the current request's language instead of their own default.
- Scope boundary: one langcode per (entity_type, id) per saved list - re-adding the same item with a different language choice overwrites the previous one rather than creating two entries.
- See `docs/export-translation.md` for the full design writeup.

## Test plan
- [x] New Unit test (`ExportItemIdentityTest`) for the key encode/decode helper
- [x] New Kernel test (`ExportListItemLanguageTest`) covering the new field's set/get round-trip and `ExportListSource`'s key building, including that untouched items still export with a bare key (zero behavior change for existing lists)
- [x] New Kernel test suite (`CsvExportTranslationTest`) covering `EntityFieldExportEvent::getLangcode()`, a translated row's own fields, a referenced taxonomy term's name resolving to the row's language (and to the term's own default language for a non-translated row), a referenced entity being queued under a composite key, and an end-to-end `CSV::batchExport()` test proving a composite-key item exports the requested translation's field values
- [x] Ran the WCAG accessibility check skill on the new language-picker form element (standard Drupal Form API `select`, confirmed compliant, no custom markup)
- [x] `php -l` on every changed/new PHP file

## Pre-merge checklist:

- [x] I have checked for and if required, created update hooks. (`mukurtu_export_update_40026()` installs the new `item_languages` base field for existing sites; fresh installs get it automatically via `ExportList::baseFieldDefinitions()`.)
- [x] I have run an accessibility check, and resolved any issues.
- [x] I have recompiled SCSS if required. (N/A - no SCSS changes.)
- [x] I have updated or created CI/CD tests, if required.
- [x] I have updated from `main` and resolved any merge conflicts. (Branched directly from `main`.)
- [x] If this PR's base branch is not `main`, I understand it needs to be retargeted once that base branch's own PR merges. (N/A - based on `main`.)
- [ ] I have verified that all expected checks pass.
- [x] I have run the pr-expert-review skill and resolved all relevant issues.
- [x] If I added a content entity bundle, I added its `language.content_settings` and base field overrides to `mukurtu_multilingual`. If I added or changed a view, I applied the content language policy in that doc. (N/A - no new bundle/view; this is export-pipeline logic, documented separately in `docs/export-translation.md`.)