### PR TITLE
Make CSV import translation-aware (#1260 Phase 5, import track)

### DIFF
--- a/docs/import-translation.md
+++ b/docs/import-translation.md
@@ -1,0 +1,35 @@
+# Import Translation Support
+
+This documents how `mukurtu_import` (CSV/spreadsheet import) handles targeting a *translation* of existing content, rather than always creating or overwriting the default-language entity (#1260 Phase 5, import track). It's the counterpart to `docs/export-translation.md`'s export track.
+
+Only the CSV import path is covered. `mukurtu_migrate` (legacy Drupal 7 migration) needs nothing here — the profile has no expectation of migrating D7 multilingual content, and will revisit only if that's actually requested (see #2078).
+
+## Turning it on: `destination.translations`
+
+Drupal core's own `entity:$entity_type_id` migrate destination already knows how to target a translation — set `translations: true` on the destination and, for any row whose mapped langcode differs from an existing entity's own language, it calls `addTranslation()`/`getTranslation()` before writing that row's fields, instead of overwriting the base entity. Mukurtu never turned this on; `MukurtuImportStrategy::toDefinition()` now does, **strictly opt-in**, gated on both:
+
+- The strategy's mapping includes a column mapped to the entity type's langcode field (already a normal, listed mapping target — `ImportFormTrait::buildTargetOptions()` labels it "... (langcode)" to disambiguate it from any other field that happens to also be called "Language").
+- The target bundle actually has content translation enabled (`content_translation.manager`'s `isEnabled($entity_type_id, $bundle)`).
+
+Neither condition met → `translations` is never set, and behavior is byte-identical to before this existed. See `MukurtuImportStrategy::isTranslationImport()`.
+
+## The non-translatable-field guard
+
+Drupal core's `EntityContentBase::updateEntity()` writes every field named in `overwrite_properties` through whichever translation object the row resolved to — with **no guard** for fields that aren't marked translatable. Those fields' storage is shared across every translation of an entity, so writing one through a translation object silently overwrites it for every other translation too. `field_cultural_protocols` (sharing settings + protocol assignment) is the concrete example on Mukurtu content — protocol/sharing settings apply to the whole entity, not per-language, so they're deliberately not translatable.
+
+**The fix is a static, strategy-wide exclusion**, not a per-row one: once a strategy is a translation import (per the gating above), `MukurtuImportStrategy::getOverwriteProperties()` drops every non-translatable field from the writable-fields list entirely, for the whole strategy.
+
+**What this does and doesn't affect** — traced against Drupal core's own `Entity::getEntity()`:
+
+- `overwrite_properties` (and therefore this guard) is only consulted on the **update** path — `getEntity()` calls `updateEntity()` only when a matching entity already exists for the row (loaded by ID/UUID/identifier column).
+- A row that creates **brand-new** content never touches `overwrite_properties` at all — `getEntity()` builds it via `$storage->create($row->getDestination())`, which writes every mapped field, including non-translatable ones, exactly as before. So a translation-enabled strategy can still create new content with protocols set, in the same file.
+- The real, narrower limitation: once a strategy is a translation import, it can no longer **update** a non-translatable field on already-existing content through that strategy — regardless of whether the row targeting a translation or the entity's own original language. If you need to change `field_cultural_protocols` (or any other non-translatable field) on existing content, do that through a separate, non-translation-targeting import first.
+
+In practice this matches how translation work tends to happen anyway: content (and its protocol/sharing settings) gets created first, and translations get added later, often as a separate pass.
+
+The correct-but-costlier alternative — a custom per-entity-type destination plugin that only skips non-translatable fields on rows updating an existing entity's *non-original* translation, leaving original-language updates unaffected — was considered and declined: it would mean subclassing every core/contrib migrate destination plugin Mukurtu's ~6 importable entity types use (node, media, taxonomy_term, paragraph, and the custom roundtrip entity types), for a narrower edge case than the static guard already handles reasonably.
+
+## Out of scope
+
+- Legacy D7 migration translation support (`mukurtu_migrate`) — not planned; see #2078.
+- Anything letting one strategy update a non-translatable field on existing content while also being a translation import — use two passes instead (see above).

--- a/modules/mukurtu_import/mukurtu_import.info.yml
+++ b/modules/mukurtu_import/mukurtu_import.info.yml
@@ -4,6 +4,7 @@ description: 'Provides import functionality for Mukurtu.'
 package: 'Mukurtu CMS'
 core_version_requirement: '^10 || ^11'
 dependencies:
+  - 'drupal:content_translation'
   - 'drupal:history'
   - 'drupal:layout_builder'
   - 'drupal:media'

--- a/modules/mukurtu_import/src/Entity/MukurtuImportStrategy.php
+++ b/modules/mukurtu_import/src/Entity/MukurtuImportStrategy.php
@@ -327,6 +327,8 @@ class MukurtuImportStrategy extends ConfigEntityBase implements MukurtuImportStr
     // Get the field definitions for the target.
     $fieldDefs = $this->getFieldDefinitions($entity_type_id, $bundle);
 
+    $isTranslationImport = $this->isTranslationImport($targets);
+
     $writableFields = [];
     foreach ($fieldDefs as $fieldName => $fieldDef) {
       if (in_array($fieldName,['default_langcode'])) {
@@ -338,6 +340,20 @@ class MukurtuImportStrategy extends ConfigEntityBase implements MukurtuImportStr
       // we get around this by only specifying what is absolutely necessary for
       // the given import input.
       if (!$fieldDef->isReadOnly() && in_array($fieldName, $targets)) {
+        // A translation-targeting import updates whichever translation a
+        // row resolves to. Non-translatable fields share one value across
+        // every translation of an entity, so writing one through a
+        // translation object would silently overwrite it for every other
+        // translation too - core has no guard against this. Excluding
+        // them here only affects updates to already-existing entities
+        // (Entity::getEntity() only calls updateEntity(), which reads
+        // overwrite_properties, when a matching entity already exists;
+        // brand-new entities are built via storage->create() with every
+        // mapped field, unaffected by this list). See
+        // docs/import-translation.md.
+        if ($isTranslationImport && !$fieldDef->isTranslatable()) {
+          continue;
+        }
         $writableFields[] = $fieldName;
       }
     }
@@ -354,6 +370,44 @@ class MukurtuImportStrategy extends ConfigEntityBase implements MukurtuImportStr
     }
 
     return $writableFields;
+  }
+
+  /**
+   * Whether this definition targets translations rather than always the
+   * default/original-language entity.
+   *
+   * Gated on both a column being mapped to the entity type's langcode
+   * field AND the target bundle actually supporting content translation -
+   * an unmapped or non-translatable-bundle strategy is completely
+   * unaffected, byte-identical to before this existed.
+   *
+   * @param array|null $targets
+   *   The mapping's target field names (without subfield suffixes), or
+   *   NULL to compute them from the current mapping.
+   *
+   * @return bool
+   *   TRUE if imports using this definition should target translations.
+   */
+  protected function isTranslationImport(?array $targets = NULL): bool {
+    $entity_type_id = $this->getTargetEntityTypeId();
+    $bundle = $this->getTargetBundle();
+    $entity_type = $this->entityTypeManager()->getDefinition($entity_type_id);
+    $langcode_key = $entity_type->getKey('langcode');
+    if (!$langcode_key) {
+      return FALSE;
+    }
+
+    if ($targets === NULL) {
+      $targets = array_map(fn($t) => explode('/', $t, 2)[0], array_column($this->getMapping(), 'target'));
+    }
+    if (!in_array($langcode_key, $targets, TRUE)) {
+      return FALSE;
+    }
+
+    if (!$bundle) {
+      return FALSE;
+    }
+    return \Drupal::service('content_translation.manager')->isEnabled($entity_type_id, $bundle);
   }
 
   /**
@@ -417,6 +471,16 @@ class MukurtuImportStrategy extends ConfigEntityBase implements MukurtuImportStr
       $ids[] = '_record_number';
     }
 
+    $destination = [
+      'plugin' => "entity:$entity_type_id",
+      'default_bundle' => $bundle,
+      'overwrite_properties' => $this->getOverwriteProperties(),
+      'validate' => TRUE,
+    ];
+    if ($this->isTranslationImport()) {
+      $destination['translations'] = TRUE;
+    }
+
     return [
       'id' => $this->getDefinitionId($file),
       'label' => $this->getDefinitionLabel($file),
@@ -432,12 +496,7 @@ class MukurtuImportStrategy extends ConfigEntityBase implements MukurtuImportStr
         'record_number_field' => '_record_number',
       ],
       'process' => $process,
-      'destination' => [
-        'plugin' => "entity:$entity_type_id",
-        'default_bundle' => $bundle,
-        'overwrite_properties' => $this->getOverwriteProperties(),
-        'validate' => TRUE,
-      ],
+      'destination' => $destination,
     ];
   }
 

--- a/modules/mukurtu_import/src/Form/ImportFieldDescriptionListForm.php
+++ b/modules/mukurtu_import/src/Form/ImportFieldDescriptionListForm.php
@@ -26,14 +26,23 @@ class ImportFieldDescriptionListForm extends ImportBaseForm {
 
     $fields = $this->entityFieldManager->getFieldDefinitions($entity_type, $effective_bundle);
 
+    // Applies to every entity type that has a langcode field - mapping a
+    // column to it can target a translation of existing content instead
+    // of creating/overwriting it, once #1260's import track lands (see
+    // docs/import-translation.md).
+    $field_description_overrides = [
+      'langcode' => $this->t("The content's language, encoded (e.g. en, es). On a bundle with translation enabled, mapping a column here targets a translation of matching content instead of creating or overwriting it."),
+    ];
+    $field_format_overrides = [
+      'langcode' => $this->t("A language code, e.g. es. Fields that aren't translatable (like Cultural Protocols) won't be updated when this import targets a translation - update those in a separate, non-translation import."),
+    ];
+
     // Per-entity-type overrides for the Field Description column.
     // Drupal base field descriptions are often missing or too terse for
     // end users; these replace them on import format pages only.
-    $field_description_overrides = [];
     if ($entity_type === 'taxonomy_term') {
-      $field_description_overrides = [
+      $field_description_overrides += [
         'description' => $this->t('The description is not normally shown to end users. It may be used for internal documentation to clarify or define the content that should reference this term, or to provide additional details about the term.'),
-        'langcode'    => $this->t('The encoded language. Used for translation and localization.'),
         'name'        => $this->t('The taxonomy term name.'),
         'tid'         => $this->t('Identifier number assigned by the system.'),
         'parent'      => $this->t('Not currently supported in Mukurtu. Used if a site supports hierarchical taxonomies.'),
@@ -91,7 +100,7 @@ class ImportFieldDescriptionListForm extends ImportBaseForm {
       $option = [
         'label' => $target_label,
         'description' => $field_description_overrides[$field_name] ?? ($fields[$field_name]->getDescription() ?? ''),
-        'format' => $process_plugin->getFormatDescription($fields[$field_name], $field_property),
+        'format' => $field_format_overrides[$field_name] ?? $process_plugin->getFormatDescription($fields[$field_name], $field_property),
       ];
       if ($fields[$field_name]->isRequired()) {
         $required_options[$field_target] = $option;

--- a/modules/mukurtu_import/tests/src/Kernel/ImportTranslationTest.php
+++ b/modules/mukurtu_import/tests/src/Kernel/ImportTranslationTest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\mukurtu_import\Kernel;
+
+use Drupal\language\Entity\ConfigurableLanguage;
+use Drupal\migrate\Plugin\MigrationInterface;
+use Drupal\mukurtu_import\Entity\MukurtuImportStrategy;
+use Drupal\node\Entity\Node;
+
+/**
+ * Tests translation-targeting CSV import (#1260 Phase 5, import track).
+ *
+ * @group mukurtu_import
+ */
+class ImportTranslationTest extends MukurtuImportTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'language',
+    'content_translation',
+  ];
+
+  protected Node $node;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    ConfigurableLanguage::createFromLangcode('en')->save();
+    ConfigurableLanguage::createFromLangcode('es')->save();
+    \Drupal::service('content_translation.manager')->setEnabled('node', 'protocol_aware_content', TRUE);
+
+    $node = Node::create([
+      'title' => 'Before Import',
+      'type' => 'protocol_aware_content',
+      'status' => TRUE,
+      'uid' => $this->currentUser->id(),
+    ]);
+    $node->setSharingSetting('any');
+    $node->setProtocols([$this->protocol]);
+    $node->save();
+    $this->node = $node;
+  }
+
+  /**
+   * Mapping a column to langcode, on a translatable bundle, adds a
+   * translation instead of overwriting the base entity - and doesn't
+   * touch field_cultural_protocols on the new translation, since it
+   * isn't translatable.
+   */
+  public function testLangcodeColumnAddsTranslation(): void {
+    $data = [
+      ['nid', 'title', 'langcode', 'sharing'],
+      [$this->node->id(), 'Después de Importar', 'es', 'none'],
+    ];
+    $import_file = $this->createCsvFile($data);
+
+    $mapping = [
+      ['target' => 'nid', 'source' => 'nid'],
+      ['target' => 'title', 'source' => 'title'],
+      ['target' => 'langcode', 'source' => 'langcode'],
+      ['target' => 'field_cultural_protocols/sharing_setting', 'source' => 'sharing'],
+    ];
+
+    $result = $this->importCsvFile($import_file, $mapping);
+    $this->assertEquals(MigrationInterface::RESULT_COMPLETED, $result);
+
+    $node = $this->entityTypeManager->getStorage('node')->load($this->node->id());
+    $this->assertTrue($node->hasTranslation('es'));
+    $this->assertEquals('Después de Importar', $node->getTranslation('es')->getTitle());
+
+    // The base (original-language) entity is untouched - only a
+    // translation was added, not an overwrite of the default entity.
+    $this->assertEquals('Before Import', $node->getTitle());
+
+    // field_cultural_protocols isn't translatable, so the translation
+    // import must not have written it - the sharing setting mapped in
+    // this row ('none') is nowhere on the entity.
+    $this->assertEquals('any', $node->getSharingSetting());
+  }
+
+  /**
+   * The same langcode-mapped import on a bundle *without* translation
+   * enabled produces a destination definition with no 'translations' key
+   * at all - the opt-in gate, verified directly against toDefinition()'s
+   * output rather than relying on ambiguous runtime behavior.
+   */
+  public function testUngatedWithoutTranslationEnabledBundle(): void {
+    \Drupal::service('content_translation.manager')->setEnabled('node', 'protocol_aware_content', FALSE);
+
+    $data = [
+      ['nid', 'title', 'langcode'],
+      [$this->node->id(), 'Ignored', 'es'],
+    ];
+    $import_file = $this->createCsvFile($data);
+
+    $mapping = [
+      ['target' => 'nid', 'source' => 'nid'],
+      ['target' => 'title', 'source' => 'title'],
+      ['target' => 'langcode', 'source' => 'langcode'],
+    ];
+
+    $import_config = MukurtuImportStrategy::create(['uid' => $this->currentUser->id()]);
+    $import_config->setTargetEntityTypeId('node');
+    $import_config->setTargetBundle('protocol_aware_content');
+    $import_config->setMapping($mapping);
+    $definition = $import_config->toDefinition($import_file);
+
+    $this->assertArrayNotHasKey('translations', $definition['destination']);
+  }
+
+  /**
+   * The same for a strategy with no langcode column mapped at all -
+   * byte-identical to before this feature existed.
+   */
+  public function testUngatedWithoutLangcodeColumn(): void {
+    $data = [
+      ['nid', 'title'],
+      [$this->node->id(), 'Updated Title'],
+    ];
+    $import_file = $this->createCsvFile($data);
+
+    $mapping = [
+      ['target' => 'nid', 'source' => 'nid'],
+      ['target' => 'title', 'source' => 'title'],
+    ];
+
+    $import_config = MukurtuImportStrategy::create(['uid' => $this->currentUser->id()]);
+    $import_config->setTargetEntityTypeId('node');
+    $import_config->setTargetBundle('protocol_aware_content');
+    $import_config->setMapping($mapping);
+    $definition = $import_config->toDefinition($import_file);
+
+    $this->assertArrayNotHasKey('translations', $definition['destination']);
+  }
+
+}


### PR DESCRIPTION
## Summary
- The other half of #1260 Phase 5 (export/import translation roundtrip) - the export track shipped in #2080. Legacy D7 migration (`mukurtu_migrate`) needs no work here (#2078, closed - no D7 multilingual content is expected to be migrated).
- Import always created or overwrote the default-language entity, regardless of a mapped langcode column. Drupal core's own `entity:$entity_type_id` migrate destination already supports targeting a translation (`destination.translations`) - it was just never turned on here.
- `MukurtuImportStrategy::toDefinition()` now sets `destination.translations`, strictly opt-in: gated on both a column being mapped to the langcode field, and the target bundle actually having content translation enabled. Neither condition met → byte-identical to before this shipped.
- `getOverwriteProperties()` excludes non-translatable fields (`field_cultural_protocols` - sharing settings/protocol assignment, entity-wide not per-language - is the concrete example) from the writable-fields list whenever a definition is a translation import. Core's own `EntityContentBase::updateEntity()` writes every `overwrite_properties` field through whichever translation a row resolves to, with **no guard** against clobbering a non-translatable field's shared value across every other translation - this closes that gap.
  - Traced against core's `Entity::getEntity()` to confirm the precise scope: `overwrite_properties` only applies to the **update** path (an existing entity matched by ID/UUID/identifier column). Brand-new content creation goes through `storage->create()` with every mapped field, completely unaffected - so a translation-enabled strategy can still create new content with protocols set. The real, narrower limitation: it can no longer **update** a non-translatable field on already-existing content through that strategy. See `docs/import-translation.md` for the full writeup, including why a per-row custom destination plugin (correct but costlier, ~6 entity types' worth of plugin subclasses) was considered and declined in favor of this simpler static guard.
- `mukurtu_import.info.yml` gains an explicit `drupal:content_translation` dependency (the module used the service without declaring it before).
- `ImportFieldDescriptionListForm`'s langcode field help text (previously `taxonomy_term`-only, and already claimed langcode was "used for translation" before that was actually true) now applies to every entity type and explains the opt-in gating and the field-clobber limitation. Wording approved via AskUserQuestion before implementation.

## Test plan
- [x] New `ImportTranslationTest`: a translation import adds an 'es' title translation without touching the base (original-language) entity's title or its `field_cultural_protocols`
- [x] Two more tests proving the opt-in gate directly against `toDefinition()`'s output: no `translations` key when the bundle isn't translation-enabled, and no `translations` key when no langcode column is mapped
- [x] `php -l` on every changed/new PHP file
- [x] Ran `scripts/lint/multilingual-guardrails.sh` - clean
- [x] Confirmed no update hook needed - `toDefinition()`'s output isn't itself stored config, only `MukurtuImportStrategy`'s own fields are (id/uid/label/description/target_entity_type_id/target_bundle/mapping/configuration), none of which changed shape

## Pre-merge checklist:

- [x] I have checked for and if required, created update hooks. (Not required — see above.)
- [x] I have run an accessibility check, and resolved any issues. (N/A — plain help text in an existing table, no new markup or interactive elements.)
- [x] I have recompiled SCSS if required. (N/A — no SCSS changes.)
- [x] I have updated or created CI/CD tests, if required.
- [x] I have updated from `main` and resolved any merge conflicts. (Branched directly from `main`, includes the merged export track.)
- [x] If this PR's base branch is not `main`, I understand it needs to be retargeted once that base branch's own PR merges. (N/A — based on `main`.)
- [ ] I have verified that all expected checks pass.
- [x] I have run the pr-expert-review skill and resolved all relevant issues.
- [x] If I added a content entity bundle, I added its `language.content_settings` and base field overrides to `mukurtu_multilingual`. If I added or changed a view, I applied the content language policy in that doc. (N/A — no new bundle/view; this is import-pipeline logic, documented separately in `docs/import-translation.md`.)