### PR TITLE
Document locale_string_is_safe() .po-import false positives (#1901)

### DIFF
--- a/docs/content-language-policy.md
+++ b/docs/content-language-policy.md
@@ -45,13 +45,47 @@ Admin-only views that intentionally list content across all languages for editor
 
 ## Known contrib limitation: locale_string_is_safe() false positives (#1901)
 
-Drupal's `locale_string_is_safe()` scans every string in a `translatable`-
-typed config schema value and rejects it if it contains disallowed HTML
-(e.g. a `<div>` wrapping a machine-readable token, not visible text).
-Klaro and Captcha (both contrib, no Mukurtu-owned code in either) ship
-config strings that trip this check - see #1901. That's a contrib
-packaging issue, not something fixable in this profile; it needs a patch
-or an upstream fix in Klaro/Captcha itself.
+Drupal core's `locale_string_is_safe()` (`core/includes/locale.inc`) runs
+every translatable string through an HTML allowlist and rejects any that
+contains markup it can't verify as safe. It has no hook, no allowed-tags
+setting, and no alter, so it can't be reconfigured or bypassed from a
+module without patching core.
+
+It fires in two places:
+
+- **config-schema scanning**, when a `translatable`-typed schema leaf
+  wraps a machine token in markup (e.g. a hidden `<div>`), and
+- **`.po` file import**, when adding a language, running
+  `drush locale:update`, or the cron translation-update job pulls a
+  contrib module's interface translations.
+
+The `.po`-import case produces the admin warning "N translation strings
+were skipped because of disallowed or malformed HTML" plus a `locale`
+dblog entry naming the files. It is admin-only, shown once per language
+import, and never seen by site visitors; the only user-visible effect is
+that those specific strings render untranslated for that language.
+
+Two modules Mukurtu ships (via `mukurtu_bot_protection`) trip this on
+import. Both are genuine upstream false positives, tracked upstream,
+neither fixable in this profile:
+
+- **Klaro** - the privacy-policy URL config string `internal:/<front>`
+  (`<front>` reads as an unknown HTML tag). drupal.org/project/klaro
+  issue #3538882 (open at time of writing).
+- **CAPTCHA** (`image_captcha` submodule) - a font-preview string
+  embedding `<img src="@font_preview_url" alt="@title" title="@title">`.
+  drupal.org/project/captcha issue #3398914 (open at time of writing).
+
+Do not suppress the warning by intercepting the messenger/logger, or by
+removing these modules from the translation-update project list via
+`hook_locale_translation_projects_alter()`: the first hides a real signal
+for every future import in every language, the second drops all
+translations for those modules in all languages. Track the upstream
+issues instead.
+
+To see which strings were skipped on a given site, run
+`drush watchdog:show --type=locale`, or open Reports > Recent log
+messages filtered to type "locale".
 
 When the same false positive shows up in **Mukurtu-owned** config
 instead, it usually means a schema type is marked `translatable` for


### PR DESCRIPTION
## Summary

Docs-only. Expands the "#1901" section of [docs/content-language-policy.md](../docs/content-language-policy.md) to cover the `.po` **file import** path of `locale_string_is_safe()`, not just config-schema scanning.

### Why

Enabling `mukurtu_multilingual` (which force-enables core `locale` + translation infrastructure) and then adding a language runs core's `locale_string_is_safe()` over every imported translation string. Adding French produced:

- Admin status: "2 translation strings were skipped because of disallowed or malformed HTML."
- `locale` dblog warning: "2 disallowed HTML string(s) in files: translations://captcha-2.0.10.fr.po, translations://klaro-3.1.1.fr.po."

This is expected contrib behavior, not a Mukurtu bug. Two strings out of ~13,000 were skipped; the import otherwise succeeded. Klaro and CAPTCHA are pulled in by `mukurtu_bot_protection`. Both skipped strings are genuine upstream false positives:

- **Klaro** - translatable privacy-policy URL config string `internal:/<front>` (`<front>` reads as an unknown HTML tag). [drupal.org/project/klaro #3538882](https://www.drupal.org/project/klaro/issues/3538882) (open).
- **CAPTCHA** (`image_captcha` submodule) - a font-preview string embedding `<img src="@font_preview_url" alt="@title" title="@title">`. [drupal.org/project/captcha #3398914](https://www.drupal.org/project/captcha/issues/3398914) (open).

The warning is admin-only, shown once per language import, and never visitor-facing; the only effect is those two strings rendering untranslated for that language.

### What changed

The updated section now:

- Notes the check has no hook / config / alter and fires in **two** places (config-schema scanning **and** `.po` import).
- Explains the `.po`-import warning is admin-only, once per language import, not visitor-facing.
- Names the two contrib offenders with their exact strings and links the open upstream issues.
- Records why neither suppression route is acceptable: intercepting the messenger/logger hides a real signal for every future import in every language; `hook_locale_translation_projects_alter()` to drop the modules loses all their translations in all languages.
- Adds how to inspect skipped strings on a site (`drush watchdog:show --type=locale`, or Reports > Recent log messages filtered to type "locale").

## Pre-merge checklist:

- [x] I have checked for and if required, created update hooks. (N/A - docs only)
- [x] I have run an accessibility check, and resolved any issues. (N/A - docs only)
- [x] I have recompiled SCSS if required. (N/A)
- [x] I have updated or created CI/CD tests, if required. (N/A - docs only)
- [x] I have updated from `main` and resolved any merge conflicts.
- [x] If this PR's base branch is not `main`, I understand it needs to be retargeted once that base branch's own PR merges. (Base is `main`.)
- [ ] I have verified that all expected checks pass.
- [x] I have run the pr-expert-review skill and resolved all relevant issues. (N/A - docs-only prose change)
- [x] If I added a content entity bundle... / added or changed a view... (N/A - no bundle or view change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)