### PR TITLE
Remove misleading Search API Solr backend option

### DIFF
--- a/modules/mukurtu_search/mukurtu_search.install
+++ b/modules/mukurtu_search/mukurtu_search.install
@@ -95,3 +95,14 @@ function mukurtu_search_update_40005(): void {
     $index->reindex();
   }
 }
+
+/**
+ * Reset the search backend to "db" for sites left on the removed "solr" option.
+ */
+function mukurtu_search_update_40006(): void {
+  $config = \Drupal::configFactory()->getEditable('mukurtu_search.settings');
+  if ($config->get('backend') === 'solr') {
+    $config->set('backend', 'db');
+    $config->save();
+  }
+}

--- a/modules/mukurtu_search/src/Form/SearchSettingsForm.php
+++ b/modules/mukurtu_search/src/Form/SearchSettingsForm.php
@@ -98,7 +98,6 @@ class SearchSettingsForm extends ConfigFormBase {
       '#type'          => 'radios',
       '#options' => [
         'db' => $this->t('Search API Database'),
-        'solr' => $this->t('Search API Solr'),
       ],
       '#default_value' => $backend,
     ];

--- a/modules/mukurtu_search/tests/src/Kernel/SearchBackendUpdateTest.php
+++ b/modules/mukurtu_search/tests/src/Kernel/SearchBackendUpdateTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\mukurtu_search\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Tests mukurtu_search_update_40006().
+ *
+ * The "Search API Solr" option was removed from the Search Backend settings
+ * form because Solr support isn't ready on any site. This update hook resets
+ * any existing config left pointed at the now-unavailable "solr" backend so
+ * no site is left referencing an option the UI no longer offers.
+ *
+ * mukurtu_search itself is not enabled here: its declared dependency chain
+ * (mukurtu_collection, paragraphs, media, search_api_glossary, token) isn't
+ * needed to exercise mukurtu_search_update_40006() directly, mirroring
+ * StaticTaxonomyNameFieldRestoreTest.
+ *
+ * @see mukurtu_search_update_40006()
+ */
+#[Group('mukurtu_search')]
+class SearchBackendUpdateTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $strictConfigSchema = FALSE;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $module_path = \Drupal::service('extension.list.module')->getPath('mukurtu_search');
+    require_once $module_path . '/mukurtu_search.install';
+  }
+
+  /**
+   * Tests the update hook resets a "solr" backend value to "db".
+   */
+  public function testUpdateResetsSolrBackendToDb(): void {
+    \Drupal::configFactory()->getEditable('mukurtu_search.settings')
+      ->set('backend', 'solr')
+      ->save();
+
+    mukurtu_search_update_40006();
+
+    $backend = \Drupal::config('mukurtu_search.settings')->get('backend');
+    $this->assertSame('db', $backend);
+  }
+
+  /**
+   * Tests the update hook leaves an already-"db" backend untouched.
+   */
+  public function testUpdateLeavesDbBackendUntouched(): void {
+    \Drupal::configFactory()->getEditable('mukurtu_search.settings')
+      ->set('backend', 'db')
+      ->save();
+
+    mukurtu_search_update_40006();
+
+    $backend = \Drupal::config('mukurtu_search.settings')->get('backend');
+    $this->assertSame('db', $backend);
+  }
+
+  /**
+   * Tests the update hook is a no-op when the backend key was never set.
+   */
+  public function testUpdateLeavesUnsetBackendUnset(): void {
+    mukurtu_search_update_40006();
+
+    $backend = \Drupal::config('mukurtu_search.settings')->get('backend');
+    $this->assertNull($backend);
+  }
+
+}


### PR DESCRIPTION
## Summary
- Removes the "Search API Solr" radio option from `/admin/config/mukurtu/search/settings` — Solr isn't a supported backend on any site yet. The separate `mukurtu_solr` module ships real Solr server/index config, but it isn't a guaranteed dependency of `mukurtu_search`, and the form never checked for it; picking "Solr" without `mukurtu_solr` enabled silently pointed several browse/collection/taxonomy/dictionary controllers at Solr views/paths that don't exist.
- Adds `mukurtu_search_update_40006()` to reset any site already left on `backend: solr` back to `db`.
- Adds a kernel test (`SearchBackendUpdateTest`) covering the update hook: resets `solr` to `db`, leaves `db` untouched, and no-ops when the key was never set.

## Test plan
- [ ] Run `SearchBackendUpdateTest` in CI (could not run locally here — this machine's DDEV sandbox fails to start under Rosetta, unrelated to this change).
- [ ] Load `/admin/config/mukurtu/search/settings` and confirm only "Search API Database" is shown.
- [ ] Save the form and confirm `mukurtu_search.settings:backend` is `db`.
- [ ] `drush updatedb` against a site with `backend: solr` pre-set and confirm it flips to `db`.

## Pre-merge checklist:

- [x] I have checked for and if required, created update hooks.
- [ ] I have run an accessibility check, and resolved any issues.
- [x] I have recompiled SCSS if required. (N/A — no SCSS touched)
- [x] I have updated or created CI/CD tests, if required.
- [x] I have updated from `main` and resolved any merge conflicts.
- [x] If this PR's base branch is not `main`, I understand it needs to be retargeted once that base branch's own PR merges (see [docs/stacked-prs.md](../docs/stacked-prs.md)). (N/A — based on main)
- [ ] I have verified that all expected checks pass.
- [x] I have run the pr-expert-review skill and resolved all relevant issues.
- [x] If I added a content entity bundle, I added its `language.content_settings` and base field overrides to `mukurtu_multilingual` (see `docs/content-language-policy.md`). If I added or changed a view, I applied the content language policy in that doc. (N/A — no content entity/view changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)