### PR TITLE
Fix Google Tag container form always failing to save

### DIFF
--- a/modules/mukurtu_core/mukurtu_core.install
+++ b/modules/mukurtu_core/mukurtu_core.install
@@ -3788,3 +3788,27 @@ function mukurtu_core_update_40106(): void {
     }
   }
 }
+
+/**
+ * Removes any saved og_group_type insertion condition from Google Tag
+ * containers.
+ *
+ * That condition's required context-mapping select has no option that
+ * meaningfully resolves on the container admin form, which normally blocks
+ * saving the form entirely (see FormHooks::formGoogleTagContainerFormAlter(),
+ * which now hides the condition from the form going forward). This only
+ * matters for a container that was saved with the condition already
+ * configured before that fix, which would otherwise be stuck permanently
+ * enforcing it with no UI left to remove it.
+ */
+function mukurtu_core_update_40107(): void {
+  $config_factory = \Drupal::configFactory();
+  foreach ($config_factory->listAll('google_tag.container.') as $config_name) {
+    $config = $config_factory->getEditable($config_name);
+    $conditions = $config->get('conditions') ?? [];
+    if (isset($conditions['og_group_type'])) {
+      unset($conditions['og_group_type']);
+      $config->set('conditions', $conditions)->save();
+    }
+  }
+}

--- a/modules/mukurtu_core/src/Hook/FormHooks.php
+++ b/modules/mukurtu_core/src/Hook/FormHooks.php
@@ -1454,6 +1454,20 @@ class FormHooks
      * satisfies it, so it renders with no option pre-selected while still
      * being required, which blocks saving the container entirely regardless
      * of the actual Tag ID(s) entered.
+     *
+     * Scoped to just this one condition plugin (not a general "drop any
+     * condition whose context can't be satisfied" check) since it's the
+     * only one currently reachable here with this problem; other og_*
+     * condition plugins would need the same treatment if they're ever
+     * added to this form and hit the same unsatisfiable-context issue.
+     *
+     * Unconditional removal is safe here (not just for new/unconfigured
+     * containers): mukurtu_core_update_40107() strips any og_group_type
+     * condition that was already saved in an existing container's config
+     * before this fix shipped, so no container can retain one going
+     * forward.
+     *
+     * @see mukurtu_core_update_40107()
      */
     #[Hook("form_google_tag_container_form_alter")]
     public function formGoogleTagContainerFormAlter(

--- a/modules/mukurtu_core/src/Hook/FormHooks.php
+++ b/modules/mukurtu_core/src/Hook/FormHooks.php
@@ -1444,4 +1444,22 @@ class FormHooks
             $form["status"]["#group"] = "publishing_options";
         }
     }
+
+    /**
+     * Implements hook_form_FORM_ID_alter() for 'google_tag_container_form'.
+     *
+     * Removes the Organic Groups "Group type" condition from the Google Tag
+     * container's Insertion conditions tab. That condition's context-mapping
+     * "Group" select has no context on this admin route that meaningfully
+     * satisfies it, so it renders with no option pre-selected while still
+     * being required, which blocks saving the container entirely regardless
+     * of the actual Tag ID(s) entered.
+     */
+    #[Hook("form_google_tag_container_form_alter")]
+    public function formGoogleTagContainerFormAlter(
+        array &$form,
+        FormStateInterface $form_state,
+    ): void {
+        unset($form["conditions"]["og_group_type"]);
+    }
 }

--- a/modules/mukurtu_core/tests/src/Kernel/FormHooksGoogleTagContainerFormAlterTest.php
+++ b/modules/mukurtu_core/tests/src/Kernel/FormHooksGoogleTagContainerFormAlterTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\mukurtu_core\Kernel;
+
+use Drupal\Core\Form\FormState;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\mukurtu_core\Hook\FormHooks;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Tests removal of the broken og_group_type condition from the Google Tag
+ * container form.
+ *
+ * @see \Drupal\mukurtu_core\Hook\FormHooks::formGoogleTagContainerFormAlter()
+ */
+#[Group('mukurtu_core')]
+class FormHooksGoogleTagContainerFormAlterTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'text',
+    'filter',
+    'geofield',
+    'leaflet',
+    'node',
+    'mukurtu_core',
+  ];
+
+  /**
+   * Tests that the og_group_type condition is removed when present.
+   *
+   * The condition's required "Group" context-mapping select has no usable
+   * default on this admin route, which blocks saving the container
+   * entirely; removing the condition's fieldset here also removes it from
+   * $form_state->getValue('conditions') on submit, since
+   * TagContainerForm::validateConditionsForm()/submitConditionsForm() only
+   * iterate submitted values.
+   */
+  public function testOgGroupTypeConditionIsRemoved(): void {
+    $form = [
+      'conditions' => [
+        'og_group_type' => ['#type' => 'details'],
+        'request_path' => ['#type' => 'details'],
+      ],
+    ];
+    $formState = new FormState();
+
+    (new FormHooks())->formGoogleTagContainerFormAlter($form, $formState);
+
+    $this->assertArrayNotHasKey('og_group_type', $form['conditions']);
+    $this->assertArrayHasKey('request_path', $form['conditions']);
+  }
+
+  /**
+   * Tests that a form without the condition is left alone without error.
+   */
+  public function testFormWithoutOgGroupTypeConditionIsLeftAlone(): void {
+    $form = ['conditions' => ['request_path' => ['#type' => 'details']]];
+    $formState = new FormState();
+
+    (new FormHooks())->formGoogleTagContainerFormAlter($form, $formState);
+
+    $this->assertSame(['conditions' => ['request_path' => ['#type' => 'details']]], $form);
+  }
+
+}

--- a/modules/mukurtu_core/tests/src/Kernel/FormHooksGoogleTagContainerFormAlterTest.php
+++ b/modules/mukurtu_core/tests/src/Kernel/FormHooksGoogleTagContainerFormAlterTest.php
@@ -70,4 +70,25 @@ class FormHooksGoogleTagContainerFormAlterTest extends KernelTestBase {
     $this->assertSame(['conditions' => ['request_path' => ['#type' => 'details']]], $form);
   }
 
+  /**
+   * Tests that Drupal's hook system actually discovers and invokes this
+   * alter for the 'google_tag_container_form' form ID, not just that the
+   * method body works when called directly.
+   */
+  public function testHookIsWiredIntoModuleHandlerAlter(): void {
+    $form = [
+      'conditions' => [
+        'og_group_type' => ['#type' => 'details'],
+        'request_path' => ['#type' => 'details'],
+      ],
+    ];
+    $formState = new FormState();
+    $formId = 'google_tag_container_form';
+
+    \Drupal::moduleHandler()->alter('form_google_tag_container_form', $form, $formState, $formId);
+
+    $this->assertArrayNotHasKey('og_group_type', $form['conditions']);
+    $this->assertArrayHasKey('request_path', $form['conditions']);
+  }
+
 }


### PR DESCRIPTION
## Summary

Google Tag containers (`admin/config/services/google-tag`) could never be saved — reported as "Google tags failing to fire," but the real symptom is the container form itself rejecting every save, empty or not, with an empty-looking error message.

**Root cause:** `TagContainerForm` renders a fieldset for every registered "Insertion condition" plugin, not just ones in use. Organic Groups' `og_group_type` condition has a required context-mapping select (labeled just "Group") offering multiple context candidates (Node from URL, Active group, Term from URL, Current user) with none pre-selected. Submitting the form with that field blank fails Drupal core's illegal-value validation — regardless of the actual Tag ID(s) entered. Reproduced on a fresh local install with a brand-new container (no consent/Klaro config involved at all, despite that being the original investigation path).

**Fix:**
- `hook_form_google_tag_container_form_alter()` in `mukurtu_core` removes the `og_group_type` condition from the form's Insertion Conditions tab.
- `mukurtu_core_update_40107()` strips any `og_group_type` condition already saved in existing container config (verified end-to-end via `drush updatedb` against a container seeded with that condition).
- Kernel test covers both the direct method behavior and that Drupal's hook system actually discovers/invokes the `#[Hook]` attribute (`\Drupal::moduleHandler()->alter()`).

## Test plan

- [x] Reproduced the original bug on a fresh local DDEV install (same `drupal/google_tag` 2.0.9 version as the reporting site) with zero prior config — confirmed it's unrelated to Klaro/consent.
- [x] Verified the fix resolves it: same vanilla form submission (just a Tag ID) now saves cleanly with no manual workaround.
- [x] `mukurtu_core_update_40107()` run via real `drush updatedb` against a container pre-seeded with a saved `og_group_type` condition — confirmed it's stripped while an unrelated `request_path` condition is left intact.
- [x] New Kernel test (`FormHooksGoogleTagContainerFormAlterTest`) passes: 3 tests / 5 assertions.

## Pre-merge checklist:

- [x] I have checked for and if required, created update hooks.
- [ ] I have run an accessibility check, and resolved any issues. *(N/A — admin-only form-alter removing a broken element, no new user-facing UI/strings)*
- [ ] I have recompiled SCSS if required. *(N/A — no SCSS changes)*
- [x] I have updated or created CI/CD tests, if required.
- [x] I have updated from `main` and resolved any merge conflicts.
- [ ] If this PR's base branch is not `main`, I understand it needs to be retargeted once that base branch's own PR merges. *(N/A — based on main)*
- [ ] I have verified that all expected checks pass.
- [x] I have run the pr-expert-review skill and resolved all relevant issues.
- [ ] If I added a content entity bundle... *(N/A)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)