### PR TITLE
Fix crash when account menu contains an external URL link

### DIFF
--- a/themes/mukurtu_v4/templates/navigation/menu--account.html.twig
+++ b/themes/mukurtu_v4/templates/navigation/menu--account.html.twig
@@ -37,7 +37,7 @@
       <ul class="menu__account-submenu"{% if submenu_id %} id="{{ submenu_id }}"{% endif %}>
     {% endif %}
     {% for item in items %}
-      {% if item.url.routeName != 'user.edit' %}
+      {% if not item.url.isRouted or item.url.routeName != 'user.edit' %}
       {% set item_classes = [
         'account-menu__menu-item',
         'account-menu__menu-item--level-' ~ (menu_level + 1),


### PR DESCRIPTION
## Summary
- Fixes an `UnexpectedValueException: <url> has no corresponding route.` crash (seen in production dblog) thrown from `Drupal\Core\Url::getRouteName()` when the account menu contains an external/absolute URL link.
- `menu--account.html.twig` called `item.url.routeName` unconditionally on every menu item to hide the `user.edit` link; `getRouteName()` throws for unrouted (external) URLs. Guarded with `isRouted` first, matching the existing pattern already used in `menu--main.html.twig`.

## Test plan
- [ ] On DDEV, add a menu link to the "account" menu (`/admin/structure/menu/manage/account/add`) pointing to an external URL (e.g. `https://mukurtu.org`).
- [ ] Load an authenticated page and confirm it renders without the exception, and the new link appears in the account menu.
- [ ] Confirm the "Edit profile" (`user.edit`) link is still hidden from the account menu (no regression).
- [ ] Confirm `/admin/reports/dblog` shows no new errors from the page load.

## Pre-merge checklist:

- [x] I have checked for and if required, created update hooks. (Not required, no config/schema change.)
- [ ] I have run an accessibility check, and resolved any issues.
- [x] I have recompiled SCSS if required. (Not required, no SCSS change.)
- [x] I have updated or created CI/CD tests, if required. (Not required, single-line Twig logic fix.)
- [x] I have updated from `main` and resolved any merge conflicts.
- [x] If this PR's base branch is not `main`, I understand it needs to be retargeted once that base branch's own PR merges. (N/A, base is `main`.)
- [ ] I have verified that all expected checks pass.
- [ ] I have run the pr-expert-review skill and resolved all relevant issues.
- [x] If I added a content entity bundle... (N/A, no content entity/view changes.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)