### PR TITLE
Bump drupal/genpass to ^3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "drupal/field_group": "^4.0",
         "drupal/flag": "^4.0",
         "drupal/flat_taxonomy": "^2.0",
-        "drupal/genpass": "^2.1",
+        "drupal/genpass": "^3.0",
         "drupal/geocoder": "^4.30",
         "drupal/geofield": "^1.59",
         "drupal/gin": "^5.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a1de3d6e1ccd6695b155bf61ca4b7a04",
+    "content-hash": "0a42c73a4b3ffce6664da80f036a2b44",
     "packages": [
         {
             "name": "altcha-org/altcha",
@@ -3090,26 +3090,26 @@
         },
         {
             "name": "drupal/genpass",
-            "version": "2.3.0",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/genpass.git",
-                "reference": "2.3.0"
+                "reference": "3.0.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/genpass-2.3.0.zip",
-                "reference": "2.3.0",
-                "shasum": "7752d86684cf1fb044dbe7f5e42762d6174a9efb"
+                "url": "https://ftp.drupal.org/files/projects/genpass-3.0.0.zip",
+                "reference": "3.0.0",
+                "shasum": "abd802efff7636739e6676d6fd364322e87cd1d9"
             },
             "require": {
-                "drupal/core": "^10.3 || ^11"
+                "drupal/core": "^11.3 || ^12"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "2.3.0",
-                    "datestamp": "1782101388",
+                    "version": "3.0.0",
+                    "datestamp": "1774620752",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"

--- a/modules/mukurtu_core/mukurtu_core.info.yml
+++ b/modules/mukurtu_core/mukurtu_core.info.yml
@@ -32,6 +32,7 @@ dependencies:
   - 'entity_browser:entity_browser'
   - 'extlink:extlink'
   - 'flag:flag'
+  - 'genpass:genpass'
   - 'geofield:geofield'
   - 'leaflet:leaflet'
   - 'media_entity_soundcloud:media_entity_soundcloud'

--- a/modules/mukurtu_protocol/mukurtu_protocol.info.yml
+++ b/modules/mukurtu_protocol/mukurtu_protocol.info.yml
@@ -23,6 +23,7 @@ dependencies:
   - 'drupal:tagify'
   - 'entity_browser:entity_browser'
   - 'field_group:field_group'
+  - 'genpass:genpass'
   - 'message:message'
   - 'mukurtu_core:mukurtu_core'
   - 'mukurtu_drafts:mukurtu_drafts'


### PR DESCRIPTION
## Summary
- Bumps `drupal/genpass` `2.3.0` -> `3.0.0` (constraint `^2.1` -> `^3.0`), part of the deferred dependency sweep tracked in #2087.
- Genpass is enabled via the install profile itself (`mukurtu.info.yml`), not a custom-module dependency, and Mukurtu ships no override of `genpass.settings.yml` - customization happens only through the admin UI.
- Unlike extlink (#2099), Mukurtu has real, direct code coupling to genpass. Verified via static diff against the vendored 2.3.0 source and the downloaded 3.0.0 release tarball (same testing constraint as #2099: composer install isn't runnable at this repo's root, and the local DDEV sandbox couldn't be started in this environment - see Test plan) that every touch point is unchanged:
  - `modules/mukurtu_core/mukurtu_core.module`'s `hook_form_user_admin_settings_alter()` rebuilds genpass's admin account-settings form into Mukurtu-specific fieldsets (`genpass_config_registration`, `genpass_settings`) and removes two display options via `GenpassInterface::PASSWORD_DISPLAY_USER`/`PASSWORD_DISPLAY_BOTH` - the admin-form-building class (`FormAdminAlter.php`) and `GenpassInterface.php` are byte-identical between 2.3.0 and 3.0.0.
  - `mukurtu_core_user_admin_settings_validate()` cross-validates the `genpass_mode` form value against `user.settings:verify_mail` - the config schema and install defaults for `genpass.settings` (including `genpass_mode`) are unchanged.
  - `modules/mukurtu_core/src/Hook/FormHooks.php:887` reads `\Drupal::config('genpass.settings')->get('genpass_mode')` directly - same config key, unchanged schema.
  - `modules/mukurtu_protocol/mukurtu_protocol.module`'s `hook_action_info_alter()` swaps genpass's `genpass_set_random_password` action plugin for Mukurtu's own `MukurtuUserSetRandomPasswordAction` (adds a password-reset email) - the plugin ID and the shipped `config/optional/system.action.genpass_set_random_password.yml` action config are unchanged in 3.0.0.
  - No `drupal/password_policy` module is present in this codebase, so the password-policy interaction flagged in #2087 doesn't apply here.
- The only real changes in 3.0.0: a core-version bump to `^11.3 || ^12` (already satisfied by this profile's `drupal/core: ~11.4.0`), and removal of a legacy procedural-hook shim (`genpass.module` + manual service registration) now that Drupal's OOP hooks auto-register at that core version. An internal validation-constraint class (`GenpassModeConstraint`) was refactored to use promoted constructor properties, but it's not referenced anywhere in Mukurtu's own code.
- No patches in `extra.patches` target `drupal/genpass`.
- **Also fixed**: neither `mukurtu_core` nor `mukurtu_protocol` formally declared a Drupal module dependency on `genpass` in their `.info.yml`, despite using its interface/config/plugin directly. Added `'genpass:genpass'` to both. This is a metadata-correctness fix only - genpass was already unconditionally enabled via the `mukurtu` install profile itself, so there's no behavior change and no update hook is needed.

## Test plan
- [x] `composer validate --no-check-all --strict` passes (only the same pre-existing "no license specified" warning noted in #2098/#2099).
- [x] `composer audit` reports no security vulnerability advisories.
- [x] `composer.lock` diff confirmed to touch only `drupal/genpass` itself - no other packages moved.
- [x] `scripts/lint/multilingual-guardrails.sh` passes (no UI strings touched).
- [ ] **Not completed**: a live functional check in a running site (account-registration admin settings form at `/admin/config/people/accounts`, self-registration flow with each `genpass_mode` value, and the "Set new random password" bulk action) - the local DDEV sandbox (`~/ddev/multilingual`) could not be started in this environment (Rosetta/ARM64 mismatch, unrelated to this change; same limitation noted in #2099). CI's `testing` job builds a full site via `mukurtu/mukurtu-template:dev-main` and should be checked once it runs; a reviewer with a working local environment should click through the registration settings form and self-registration flow before merging, given the direct code coupling here.

## Pre-merge checklist
- [x] I have checked for and if required, created update hooks. (Not required: `genpass.settings` config schema/defaults are unchanged between 2.3.0 and 3.0.0; the new `.info.yml` dependency declarations don't need one either, since genpass was already always enabled via the install profile.)
- [ ] I have run an accessibility check, and resolved any issues. (No Mukurtu markup/CSS changed by this PR itself; see Test plan for the outstanding live check of the admin settings form.)
- [x] I have recompiled SCSS if required. (Not applicable: no SCSS touched.)
- [ ] I have updated or created CI/CD tests, if required.
- [x] I have updated from `main` and resolved any merge conflicts.
- [x] If this PR's base branch is not `main`, I understand it needs to be retargeted once that base branch's own PR merges. (Base is `main`.)
- [ ] I have verified that all expected checks pass.
- [x] I have run the pr-expert-review skill and resolved all relevant issues.
- [x] If I added a content entity bundle... (Not applicable.)

Part of #2087.

🤖 Generated with [Claude Code](https://claude.com/claude-code)