### PR TITLE
Migrate PHPUnit doc-comment metadata to attributes, fix stray deprecations

### DIFF
--- a/modules/mukurtu_browse/tests/src/Kernel/BrowseLinkBuilderTest.php
+++ b/modules/mukurtu_browse/tests/src/Kernel/BrowseLinkBuilderTest.php
@@ -6,16 +6,16 @@ namespace Drupal\Tests\mukurtu_browse\Kernel;
 
 use Drupal\Core\Url;
 use Drupal\KernelTests\KernelTestBase;
-use Drupal\mukurtu_browse\Service\BrowseLinkBuilder;
 use Drupal\facets\Entity\Facet;
+use Drupal\mukurtu_browse\Service\BrowseLinkBuilder;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\Yaml\Yaml;
 
 /**
  * Tests BrowseLinkBuilder, which links to /browse and /digital-heritage
  * pre-filtered by community, category or cultural protocol.
- *
- * @group mukurtu_browse
  */
+#[Group('mukurtu_browse')]
 class BrowseLinkBuilderTest extends KernelTestBase {
 
   /**

--- a/modules/mukurtu_browse/tests/src/Kernel/BrowseViewsLanguageFallbackTest.php
+++ b/modules/mukurtu_browse/tests/src/Kernel/BrowseViewsLanguageFallbackTest.php
@@ -6,6 +6,7 @@ namespace Drupal\Tests\mukurtu_browse\Kernel;
 
 use Drupal\Core\Config\FileStorage;
 use Drupal\KernelTests\KernelTestBase;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests mukurtu_browse_update_40020().
@@ -17,8 +18,8 @@ use Drupal\KernelTests\KernelTestBase;
  * and that running it twice is a no-op.
  *
  * @see \mukurtu_browse_update_40020()
- * @group mukurtu_browse
  */
+#[Group('mukurtu_browse')]
 class BrowseViewsLanguageFallbackTest extends KernelTestBase {
 
   /**

--- a/modules/mukurtu_collection/tests/src/Kernel/CollectionFieldLabelTest.php
+++ b/modules/mukurtu_collection/tests/src/Kernel/CollectionFieldLabelTest.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace Drupal\Tests\mukurtu_collection\Kernel;
 
 use Drupal\Core\StringTranslation\TranslatableMarkup;
-use Drupal\mukurtu_collection\Entity\Collection;
 use Drupal\Tests\mukurtu_protocol\Kernel\ProtocolAwareEntityTestBase;
+use Drupal\mukurtu_collection\Entity\Collection;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests that Collection field labels are translatable.
@@ -19,9 +20,8 @@ use Drupal\Tests\mukurtu_protocol\Kernel\ProtocolAwareEntityTestBase;
  * transitive dependencies - disproportionate kernel test setup for a
  * mechanical one-line string wrap that's otherwise identical in shape and
  * risk to the covered fixes in this same PR.
- *
- * @group mukurtu_collection
  */
+#[Group('mukurtu_collection')]
 class CollectionFieldLabelTest extends ProtocolAwareEntityTestBase {
 
   public function testCollectionFieldLabelsAreTranslatable(): void {

--- a/modules/mukurtu_collection/tests/src/Kernel/CollectionMapEditFormDefaultsUpdateTest.php
+++ b/modules/mukurtu_collection/tests/src/Kernel/CollectionMapEditFormDefaultsUpdateTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\Tests\mukurtu_collection\Kernel;
 
 use Drupal\KernelTests\KernelTestBase;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests mukurtu_collection_update_40018(), which moves the collection edit
@@ -12,8 +13,8 @@ use Drupal\KernelTests\KernelTestBase;
  * editing a single already-saved point (#1453).
  *
  * @see mukurtu_collection_update_40018()
- * @group mukurtu_collection
  */
+#[Group('mukurtu_collection')]
 class CollectionMapEditFormDefaultsUpdateTest extends KernelTestBase {
 
   /**

--- a/modules/mukurtu_collection/tests/src/Kernel/CollectionViewsLanguageFallbackTest.php
+++ b/modules/mukurtu_collection/tests/src/Kernel/CollectionViewsLanguageFallbackTest.php
@@ -6,6 +6,7 @@ namespace Drupal\Tests\mukurtu_collection\Kernel;
 
 use Drupal\Core\Config\FileStorage;
 use Drupal\KernelTests\KernelTestBase;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests mukurtu_collection_update_40027().
@@ -15,8 +16,8 @@ use Drupal\KernelTests\KernelTestBase;
  * confirms it fills them back in - and that running it twice is a no-op.
  *
  * @see \mukurtu_collection_update_40027()
- * @group mukurtu_collection
  */
+#[Group('mukurtu_collection')]
 class CollectionViewsLanguageFallbackTest extends KernelTestBase {
 
   /**

--- a/modules/mukurtu_core/tests/src/Kernel/CategoriesViewLanguageFallbackTest.php
+++ b/modules/mukurtu_core/tests/src/Kernel/CategoriesViewLanguageFallbackTest.php
@@ -6,6 +6,7 @@ namespace Drupal\Tests\mukurtu_core\Kernel;
 
 use Drupal\Core\Config\FileStorage;
 use Drupal\KernelTests\KernelTestBase;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests mukurtu_update_40029().
@@ -15,8 +16,8 @@ use Drupal\KernelTests\KernelTestBase;
  * confirms it fills them back in - and that running it twice is a no-op.
  *
  * @see \mukurtu_update_40029()
- * @group mukurtu_core
  */
+#[Group('mukurtu_core')]
 class CategoriesViewLanguageFallbackTest extends KernelTestBase {
 
   /**

--- a/modules/mukurtu_core/tests/src/Kernel/ContentBrowserViewLanguageFallbackTest.php
+++ b/modules/mukurtu_core/tests/src/Kernel/ContentBrowserViewLanguageFallbackTest.php
@@ -6,6 +6,7 @@ namespace Drupal\Tests\mukurtu_core\Kernel;
 
 use Drupal\Core\Config\FileStorage;
 use Drupal\KernelTests\KernelTestBase;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests mukurtu_core_update_40106().
@@ -15,8 +16,8 @@ use Drupal\KernelTests\KernelTestBase;
  * confirms it fills them back in - and that running it twice is a no-op.
  *
  * @see \mukurtu_core_update_40106()
- * @group mukurtu_core
  */
+#[Group('mukurtu_core')]
 class ContentBrowserViewLanguageFallbackTest extends KernelTestBase {
 
   /**

--- a/modules/mukurtu_core/tests/src/Kernel/DrawCircleDefaultUpdateTest.php
+++ b/modules/mukurtu_core/tests/src/Kernel/DrawCircleDefaultUpdateTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace Drupal\Tests\mukurtu_core\Kernel;
 
 use Drupal\Core\Entity\Entity\EntityFormDisplay;
+use Drupal\KernelTests\KernelTestBase;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;
-use Drupal\KernelTests\KernelTestBase;
 use Drupal\node\Entity\NodeType;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests mukurtu_core_update_40100(), which enables drawCircle by default.
@@ -19,8 +20,8 @@ use Drupal\node\Entity\NodeType;
  * field_coverage field rather than installing mukurtu_place itself.
  *
  * @see mukurtu_core_update_40100()
- * @group mukurtu_core
  */
+#[Group('mukurtu_core')]
 class DrawCircleDefaultUpdateTest extends KernelTestBase {
 
   /**

--- a/modules/mukurtu_core/tests/src/Kernel/FormattedTextWithTitleFieldLabelTest.php
+++ b/modules/mukurtu_core/tests/src/Kernel/FormattedTextWithTitleFieldLabelTest.php
@@ -7,14 +7,14 @@ namespace Drupal\Tests\mukurtu_core\Kernel;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\mukurtu_core\Entity\FormattedTextWithTitle;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests that FormattedTextWithTitle's field label/description are
  * translatable. Every setLabel()/setDescription() call in this file was
  * previously a plain string - 100% untranslated.
- *
- * @group mukurtu_core
  */
+#[Group('mukurtu_core')]
 class FormattedTextWithTitleFieldLabelTest extends KernelTestBase {
 
   /**

--- a/modules/mukurtu_core/tests/src/Kernel/GeofieldMukurtuCircleTest.php
+++ b/modules/mukurtu_core/tests/src/Kernel/GeofieldMukurtuCircleTest.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\mukurtu_core\Kernel;
 
+use Drupal\Core\Entity\Entity\EntityFormDisplay;
 use Drupal\Core\Form\FormState;
+use Drupal\KernelTests\KernelTestBase;
 use Drupal\entity_test\Entity\EntityTest;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;
-use Drupal\Core\Entity\Entity\EntityFormDisplay;
-use Drupal\KernelTests\KernelTestBase;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests circle support in the Mukurtu Leaflet geofield widget.
@@ -22,8 +23,8 @@ use Drupal\KernelTests\KernelTestBase;
  * setting is actually enable-able (contrib force-disables it).
  *
  * @see \Drupal\mukurtu_core\Plugin\Field\FieldWidget\GeofieldMukurtuWidget
- * @group mukurtu_core
  */
+#[Group('mukurtu_core')]
 class GeofieldMukurtuCircleTest extends KernelTestBase {
 
   /**

--- a/modules/mukurtu_core/tests/src/Kernel/GeofieldMukurtuLatLonWidgetTest.php
+++ b/modules/mukurtu_core/tests/src/Kernel/GeofieldMukurtuLatLonWidgetTest.php
@@ -8,6 +8,7 @@ use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Form\FormState;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\mukurtu_core\Plugin\Field\FieldWidget\GeofieldMukurtuLatLonWidget;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests GeofieldMukurtuLatLonWidget's GeoJSON FeatureCollection round trip.
@@ -20,8 +21,8 @@ use Drupal\mukurtu_core\Plugin\Field\FieldWidget\GeofieldMukurtuLatLonWidget;
  * holes, legacy WKT).
  *
  * @see \Drupal\mukurtu_core\Plugin\Field\FieldWidget\GeofieldMukurtuLatLonWidget
- * @group mukurtu_core
  */
+#[Group('mukurtu_core')]
 class GeofieldMukurtuLatLonWidgetTest extends KernelTestBase {
 
   /**

--- a/modules/mukurtu_core/tests/src/Kernel/GeofieldMukurtuWidgetSinglePointZoomTest.php
+++ b/modules/mukurtu_core/tests/src/Kernel/GeofieldMukurtuWidgetSinglePointZoomTest.php
@@ -6,6 +6,7 @@ namespace Drupal\Tests\mukurtu_core\Kernel;
 
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\mukurtu_core\Plugin\Field\FieldWidget\GeofieldMukurtuWidget;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests the Map Points widget's dedicated single-point zoom setting (#1453).
@@ -15,9 +16,8 @@ use Drupal\mukurtu_core\Plugin\Field\FieldWidget\GeofieldMukurtuWidget;
  * deliberately zoomed out to avoid world-map tiling on add forms). See
  * modules/mukurtu_core/js/mukurtu-leaflet-widget.js for the client-side
  * half of this fix.
- *
- * @group mukurtu_core
  */
+#[Group('mukurtu_core')]
 class GeofieldMukurtuWidgetSinglePointZoomTest extends KernelTestBase {
 
   /**

--- a/modules/mukurtu_core/tests/src/Kernel/LeafletHooksPathFillTest.php
+++ b/modules/mukurtu_core/tests/src/Kernel/LeafletHooksPathFillTest.php
@@ -6,13 +6,15 @@ namespace Drupal\Tests\mukurtu_core\Kernel;
 
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\mukurtu_core\Hook\LeafletHooks;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests removal of path fill for line geometries on Leaflet maps.
  *
  * @see \Drupal\mukurtu_core\Hook\LeafletHooks
- * @group mukurtu_core
  */
+#[Group('mukurtu_core')]
 class LeafletHooksPathFillTest extends KernelTestBase {
 
   /**
@@ -32,9 +34,8 @@ class LeafletHooksPathFillTest extends KernelTestBase {
 
   /**
    * Tests that fill is disabled only for line-type features.
-   *
-   * @dataProvider featureProvider
    */
+  #[DataProvider('featureProvider')]
   public function testFillRemovedForLinesOnly(string $type, ?string $path, ?bool $expectedFill): void {
     $feature = ['type' => $type];
     if ($path !== NULL) {

--- a/modules/mukurtu_core/tests/src/Kernel/LocalTaskVisibilityHooksTest.php
+++ b/modules/mukurtu_core/tests/src/Kernel/LocalTaskVisibilityHooksTest.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\mukurtu_core\Kernel;
 
-use PHPUnit\Framework\Attributes\Group;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\mukurtu_core\Hook\LocalTaskVisibilityHooks;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests node Visitors/Devel/Revisions local task visibility.
@@ -41,9 +42,8 @@ class LocalTaskVisibilityHooksTest extends KernelTestBase {
 
   /**
    * The Visitors tab is hidden on both the node view and edit pages.
-   *
-   * @dataProvider visitorsHiddenRouteProvider
    */
+  #[DataProvider('visitorsHiddenRouteProvider')]
   public function testVisitorsTabHidden(string $routeName): void {
     $data = $this->tabsWithEverythingPresent();
     (new LocalTaskVisibilityHooks())->menuLocalTasksAlter($data, $routeName);
@@ -91,9 +91,8 @@ class LocalTaskVisibilityHooksTest extends KernelTestBase {
    * Guards against scope creep: that job now belongs to
    * HideCommunityProtocolLocalTasksOutsideEditView, which (unlike this
    * class) preserves the uid-1-only restriction on their Revisions tab.
-   *
-   * @dataProvider communityProtocolRouteProvider
    */
+  #[DataProvider('communityProtocolRouteProvider')]
   public function testCommunityAndProtocolTabsUntouched(string $routeName, string $entityTypeId): void {
     $data = [
       'tabs' => [

--- a/modules/mukurtu_core/tests/src/Kernel/MukurtuLeafletFormatterTest.php
+++ b/modules/mukurtu_core/tests/src/Kernel/MukurtuLeafletFormatterTest.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\mukurtu_core\Kernel;
 
+use Drupal\KernelTests\KernelTestBase;
 use Drupal\entity_test\Entity\EntityTest;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;
-use Drupal\KernelTests\KernelTestBase;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests that rendering a mukurtu_leaflet_formatter field never mutates the
@@ -23,9 +24,8 @@ use Drupal\KernelTests\KernelTestBase;
  * multi-delta) entity object were later reloaded from Drupal's per-request
  * entity cache and saved, everything past delta 0 would be silently
  * truncated on save.
- *
- * @group mukurtu_core
  */
+#[Group('mukurtu_core')]
 class MukurtuLeafletFormatterTest extends KernelTestBase {
 
   /**

--- a/modules/mukurtu_core/tests/src/Kernel/MukurtuLeafletServiceTest.php
+++ b/modules/mukurtu_core/tests/src/Kernel/MukurtuLeafletServiceTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\Tests\mukurtu_core\Kernel;
 
 use Drupal\KernelTests\KernelTestBase;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests that leaflet.service restores circle_center/circle_radius on display.
@@ -18,8 +19,8 @@ use Drupal\KernelTests\KernelTestBase;
  * leaflet.service to restore them as a 'circle' typed feature instead.
  *
  * @see \Drupal\mukurtu_core\Service\MukurtuLeafletService
- * @group mukurtu_core
  */
+#[Group('mukurtu_core')]
 class MukurtuLeafletServiceTest extends KernelTestBase {
 
   /**

--- a/modules/mukurtu_core/tests/src/Kernel/NotYetTranslatedIndicatorTest.php
+++ b/modules/mukurtu_core/tests/src/Kernel/NotYetTranslatedIndicatorTest.php
@@ -11,13 +11,14 @@ use Drupal\language\Entity\ConfigurableLanguage;
 use Drupal\mukurtu_core\Hook\NotYetTranslatedIndicatorHooks;
 use Drupal\node\Entity\Node;
 use Drupal\node\Entity\NodeType;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests NotYetTranslatedIndicatorHooks::preprocessNode().
  *
  * @see \Drupal\mukurtu_core\Hook\NotYetTranslatedIndicatorHooks
- * @group mukurtu_core
  */
+#[Group('mukurtu_core')]
 class NotYetTranslatedIndicatorTest extends EntityKernelTestBase {
 
   /**

--- a/modules/mukurtu_core/tests/src/Kernel/RoundtripEntityTypeRegistryTest.php
+++ b/modules/mukurtu_core/tests/src/Kernel/RoundtripEntityTypeRegistryTest.php
@@ -5,14 +5,15 @@ declare(strict_types=1);
 namespace Drupal\Tests\mukurtu_core\Kernel;
 
 use Drupal\Tests\mukurtu_protocol\Kernel\ProtocolAwareEntityTestBase;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests RoundtripEntityTypeRegistry discovers custom entity types by interface.
  *
  * @see \Drupal\mukurtu_core\Service\RoundtripEntityTypeRegistry
  * @see \Drupal\mukurtu_core\Entity\RoundtripEntityInterface
- * @group mukurtu_core
  */
+#[Group('mukurtu_core')]
 class RoundtripEntityTypeRegistryTest extends ProtocolAwareEntityTestBase {
 
   /**

--- a/modules/mukurtu_core/tests/src/Kernel/SiteReportsPermissionUpdateTest.php
+++ b/modules/mukurtu_core/tests/src/Kernel/SiteReportsPermissionUpdateTest.php
@@ -6,14 +6,15 @@ namespace Drupal\Tests\mukurtu_core\Kernel;
 
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\user\Entity\Role;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests mukurtu_core_update_40105(), which grants the Mukurtu Manager role
  * permission to view site reports.
  *
  * @see mukurtu_core_update_40105()
- * @group mukurtu_core
  */
+#[Group('mukurtu_core')]
 class SiteReportsPermissionUpdateTest extends KernelTestBase {
 
   /**

--- a/modules/mukurtu_core/tests/src/Unit/MukurtuFormattedAddressTest.php
+++ b/modules/mukurtu_core/tests/src/Unit/MukurtuFormattedAddressTest.php
@@ -4,16 +4,17 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\mukurtu_core\Unit;
 
-use Drupal\mukurtu_core\Plugin\Geocoder\Formatter\MukurtuFormattedAddress;
 use Drupal\Tests\UnitTestCase;
+use Drupal\mukurtu_core\Plugin\Geocoder\Formatter\MukurtuFormattedAddress;
 use Geocoder\Model\Address;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests the address search result formatting (issue #1453).
  *
  * @see https://github.com/MukurtuCMS/Mukurtu-CMS/issues/1453
- * @group mukurtu_core
  */
+#[Group('mukurtu_core')]
 class MukurtuFormattedAddressTest extends UnitTestCase {
 
   /**

--- a/modules/mukurtu_core/tests/src/Unit/RouteSubscriberMessageSubscribeAccessTest.php
+++ b/modules/mukurtu_core/tests/src/Unit/RouteSubscriberMessageSubscribeAccessTest.php
@@ -4,8 +4,9 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\mukurtu_core\Unit;
 
-use Drupal\mukurtu_core\Routing\RouteSubscriber;
 use Drupal\Tests\UnitTestCase;
+use Drupal\mukurtu_core\Routing\RouteSubscriber;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
@@ -38,9 +39,8 @@ class RouteSubscriberMessageSubscribeAccessTest extends UnitTestCase {
 
   /**
    * Both routes end up permission-gated with the custom access check gone.
-   *
-   * @dataProvider routeNameProvider
    */
+  #[DataProvider('routeNameProvider')]
   public function testRouteRequiresPermission(string $routeName): void {
     $collection = $this->messageSubscribeRouteCollection();
 
@@ -55,9 +55,8 @@ class RouteSubscriberMessageSubscribeAccessTest extends UnitTestCase {
 
   /**
    * Both routes are marked as admin routes, so Gin renders them.
-   *
-   * @dataProvider routeNameProvider
    */
+  #[DataProvider('routeNameProvider')]
   public function testRouteUsesAdminTheme(string $routeName): void {
     $collection = $this->messageSubscribeRouteCollection();
 

--- a/modules/mukurtu_design/tests/src/Kernel/DesignPaletteThemeTest.php
+++ b/modules/mukurtu_design/tests/src/Kernel/DesignPaletteThemeTest.php
@@ -7,6 +7,7 @@ namespace Drupal\Tests\mukurtu_design\Kernel;
 use Drupal\Core\Theme\ActiveTheme;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\mukurtu_design\DesignPalette;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests that DesignPalette::enablePalette() attaches the palette library
@@ -16,9 +17,8 @@ use Drupal\mukurtu_design\DesignPalette;
  * renders with this site's default front-end theme for anonymous/most
  * authenticated visitors (they lack "view the administration theme"), so
  * a route-based check alone would incorrectly skip it.
- *
- * @group mukurtu_design
  */
+#[Group('mukurtu_design')]
 class DesignPaletteThemeTest extends KernelTestBase {
 
   /**

--- a/modules/mukurtu_dictionary/tests/src/Kernel/DictionaryFieldLabelTest.php
+++ b/modules/mukurtu_dictionary/tests/src/Kernel/DictionaryFieldLabelTest.php
@@ -5,18 +5,19 @@ declare(strict_types=1);
 namespace Drupal\Tests\mukurtu_dictionary\Kernel;
 
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\Tests\mukurtu_protocol\Kernel\ProtocolAwareEntityTestBase;
 use Drupal\mukurtu_dictionary\Entity\DictionaryWord;
 use Drupal\mukurtu_dictionary\Entity\DictionaryWordEntry;
 use Drupal\mukurtu_dictionary\Entity\SampleSentence;
 use Drupal\mukurtu_dictionary\Entity\WordList;
-use Drupal\Tests\mukurtu_protocol\Kernel\ProtocolAwareEntityTestBase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests that mukurtu_dictionary field labels and descriptions are
  * translatable.
- *
- * @group mukurtu_dictionary
  */
+#[Group('mukurtu_dictionary')]
 class DictionaryFieldLabelTest extends ProtocolAwareEntityTestBase {
 
   /**
@@ -28,8 +29,8 @@ class DictionaryFieldLabelTest extends ProtocolAwareEntityTestBase {
   ];
 
   /**
-   * @dataProvider dictionaryWordFieldProvider
    */
+  #[DataProvider('dictionaryWordFieldProvider')]
   public function testDictionaryWordFieldIsTranslatable(string $fieldName, string $property): void {
     $entityType = \Drupal::entityTypeManager()->getDefinition('node');
     $definitions = DictionaryWord::bundleFieldDefinitions($entityType, '', []);
@@ -50,8 +51,8 @@ class DictionaryFieldLabelTest extends ProtocolAwareEntityTestBase {
   }
 
   /**
-   * @dataProvider wordListFieldProvider
    */
+  #[DataProvider('wordListFieldProvider')]
   public function testWordListFieldLabelIsTranslatable(string $fieldName): void {
     $entityType = \Drupal::entityTypeManager()->getDefinition('node');
     $definitions = WordList::bundleFieldDefinitions($entityType, '', []);
@@ -68,8 +69,8 @@ class DictionaryFieldLabelTest extends ProtocolAwareEntityTestBase {
   }
 
   /**
-   * @dataProvider dictionaryWordEntryFieldProvider
    */
+  #[DataProvider('dictionaryWordEntryFieldProvider')]
   public function testDictionaryWordEntryFieldDescriptionIsTranslatable(string $fieldName): void {
     $entityType = \Drupal::entityTypeManager()->getDefinition('paragraph');
     $definitions = DictionaryWordEntry::bundleFieldDefinitions($entityType, '', []);

--- a/modules/mukurtu_dictionary/tests/src/Kernel/DictionaryMapEditFormDefaultsUpdateTest.php
+++ b/modules/mukurtu_dictionary/tests/src/Kernel/DictionaryMapEditFormDefaultsUpdateTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\Tests\mukurtu_dictionary\Kernel;
 
 use Drupal\KernelTests\KernelTestBase;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests mukurtu_dictionary_update_40041(), which moves the dictionary word
@@ -12,8 +13,8 @@ use Drupal\KernelTests\KernelTestBase;
  * dedicated zoom for editing a single already-saved point (#1453).
  *
  * @see mukurtu_dictionary_update_40041()
- * @group mukurtu_dictionary
  */
+#[Group('mukurtu_dictionary')]
 class DictionaryMapEditFormDefaultsUpdateTest extends KernelTestBase {
 
   /**

--- a/modules/mukurtu_dictionary/tests/src/Kernel/DictionaryViewLanguageFallbackTest.php
+++ b/modules/mukurtu_dictionary/tests/src/Kernel/DictionaryViewLanguageFallbackTest.php
@@ -6,6 +6,7 @@ namespace Drupal\Tests\mukurtu_dictionary\Kernel;
 
 use Drupal\Core\Config\FileStorage;
 use Drupal\KernelTests\KernelTestBase;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests mukurtu_dictionary_update_40043().
@@ -17,8 +18,8 @@ use Drupal\KernelTests\KernelTestBase;
  * and that running it twice is a no-op.
  *
  * @see \mukurtu_dictionary_update_40043()
- * @group mukurtu_dictionary
  */
+#[Group('mukurtu_dictionary')]
 class DictionaryViewLanguageFallbackTest extends KernelTestBase {
 
   /**

--- a/modules/mukurtu_dictionary/tests/src/Kernel/SampleSentenceRecordingDisplayUpdateTest.php
+++ b/modules/mukurtu_dictionary/tests/src/Kernel/SampleSentenceRecordingDisplayUpdateTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\Tests\mukurtu_dictionary\Kernel;
 
 use Drupal\KernelTests\KernelTestBase;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests mukurtu_dictionary_update_40042(), which points the sample sentence
@@ -13,8 +14,8 @@ use Drupal\KernelTests\KernelTestBase;
  * button instead of a plain download icon (#2019).
  *
  * @see mukurtu_dictionary_update_40042()
- * @group mukurtu_dictionary
  */
+#[Group('mukurtu_dictionary')]
 class SampleSentenceRecordingDisplayUpdateTest extends KernelTestBase {
 
   /**

--- a/modules/mukurtu_digital_heritage/tests/src/Kernel/DigitalHeritageFieldLabelTest.php
+++ b/modules/mukurtu_digital_heritage/tests/src/Kernel/DigitalHeritageFieldLabelTest.php
@@ -5,16 +5,17 @@ declare(strict_types=1);
 namespace Drupal\Tests\mukurtu_digital_heritage\Kernel;
 
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\Tests\mukurtu_protocol\Kernel\ProtocolAwareEntityTestBase;
 use Drupal\mukurtu_digital_heritage\Entity\DigitalHeritage;
 use Drupal\mukurtu_digital_heritage\Entity\IndigenousKnowledgeKeepers;
-use Drupal\Tests\mukurtu_protocol\Kernel\ProtocolAwareEntityTestBase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests that DigitalHeritage/IndigenousKnowledgeKeepers field labels and
  * descriptions are translatable.
- *
- * @group mukurtu_digital_heritage
  */
+#[Group('mukurtu_digital_heritage')]
 class DigitalHeritageFieldLabelTest extends ProtocolAwareEntityTestBase {
 
   /**
@@ -26,8 +27,8 @@ class DigitalHeritageFieldLabelTest extends ProtocolAwareEntityTestBase {
   ];
 
   /**
-   * @dataProvider digitalHeritageFieldProvider
    */
+  #[DataProvider('digitalHeritageFieldProvider')]
   public function testDigitalHeritageFieldLabelIsTranslatable(string $fieldName, string $expectedLabel): void {
     $entityType = \Drupal::entityTypeManager()->getDefinition('node');
     $definitions = DigitalHeritage::bundleFieldDefinitions($entityType, '', []);
@@ -54,8 +55,8 @@ class DigitalHeritageFieldLabelTest extends ProtocolAwareEntityTestBase {
   }
 
   /**
-   * @dataProvider knowledgeKeeperDescriptionProvider
    */
+  #[DataProvider('knowledgeKeeperDescriptionProvider')]
   public function testKnowledgeKeeperDescriptionIsTranslatable(string $fieldName): void {
     $entityType = \Drupal::entityTypeManager()->getDefinition('paragraph');
     $definitions = IndigenousKnowledgeKeepers::bundleFieldDefinitions($entityType, '', []);

--- a/modules/mukurtu_digital_heritage/tests/src/Kernel/DigitalHeritageMapEditFormDefaultsUpdateTest.php
+++ b/modules/mukurtu_digital_heritage/tests/src/Kernel/DigitalHeritageMapEditFormDefaultsUpdateTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\Tests\mukurtu_digital_heritage\Kernel;
 
 use Drupal\KernelTests\KernelTestBase;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests mukurtu_digital_heritage_update_40009(), which moves the digital
@@ -12,8 +13,8 @@ use Drupal\KernelTests\KernelTestBase;
  * dedicated zoom for editing a single already-saved point (#1453).
  *
  * @see mukurtu_digital_heritage_update_40009()
- * @group mukurtu_digital_heritage
  */
+#[Group('mukurtu_digital_heritage')]
 class DigitalHeritageMapEditFormDefaultsUpdateTest extends KernelTestBase {
 
   /**

--- a/modules/mukurtu_export/tests/src/Kernel/CsvExportTranslationTest.php
+++ b/modules/mukurtu_export/tests/src/Kernel/CsvExportTranslationTest.php
@@ -14,13 +14,13 @@ use Drupal\mukurtu_export\Plugin\MukurtuExporter\CSV;
 use Drupal\node\Entity\Node;
 use Drupal\taxonomy\Entity\Term;
 use Drupal\taxonomy\Entity\Vocabulary;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests that a translated export row pulls referenced-entity names from
  * the same translation, not their own default language (#1260 Phase 5).
- *
- * @group mukurtu_export
  */
+#[Group('mukurtu_export')]
 class CsvExportTranslationTest extends CsvExportFieldTestBase {
 
   /**
@@ -211,8 +211,8 @@ class CsvExportTranslationTest extends CsvExportFieldTestBase {
     $this->assertArrayHasKey($key, $context['results']['exported_entities']['node']);
 
     $output = fopen("{$basepath}/Content - Protocol Aware Content.csv", 'r');
-    $header = fgetcsv($output);
-    $row = fgetcsv($output);
+    $header = fgetcsv($output, NULL, ',', '"', '\\');
+    $row = fgetcsv($output, NULL, ',', '"', '\\');
     fclose($output);
 
     $titleColumn = array_search('Title', $header, TRUE);

--- a/modules/mukurtu_export/tests/src/Kernel/ExportListItemLanguageTest.php
+++ b/modules/mukurtu_export/tests/src/Kernel/ExportListItemLanguageTest.php
@@ -4,17 +4,17 @@ declare(strict_types = 1);
 
 namespace Drupal\Tests\mukurtu_export\Kernel;
 
+use Drupal\Tests\mukurtu_protocol\Kernel\ProtocolAwareEntityTestBase;
 use Drupal\mukurtu_export\Entity\ExportList;
 use Drupal\mukurtu_export\ExportItemIdentity;
 use Drupal\mukurtu_export\ExportListSource;
-use Drupal\Tests\mukurtu_protocol\Kernel\ProtocolAwareEntityTestBase;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests ExportList's item_languages field and ExportListSource's key
  * building (#1260 Phase 5 export track).
- *
- * @group mukurtu_export
  */
+#[Group('mukurtu_export')]
 class ExportListItemLanguageTest extends ProtocolAwareEntityTestBase {
 
   /**

--- a/modules/mukurtu_export/tests/src/Unit/ExportItemIdentityTest.php
+++ b/modules/mukurtu_export/tests/src/Unit/ExportItemIdentityTest.php
@@ -4,17 +4,21 @@ declare(strict_types = 1);
 
 namespace Drupal\Tests\mukurtu_export\Unit;
 
-use Drupal\mukurtu_export\ExportItemIdentity;
 use Drupal\Tests\UnitTestCase;
+use Drupal\mukurtu_export\ExportItemIdentity;
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
- * @coversDefaultClass \Drupal\mukurtu_export\ExportItemIdentity
- * @group mukurtu_export
+ * Tests ExportItemIdentity.
  */
+#[CoversMethod(ExportItemIdentity::class, 'encode')]
+#[CoversMethod(ExportItemIdentity::class, 'decode')]
+#[Group('mukurtu_export')]
 class ExportItemIdentityTest extends UnitTestCase {
 
   /**
-   * @covers ::encode
+   * Tests encode() without a langcode returns the bare id.
    */
   public function testEncodeWithoutLangcodeReturnsBareId(): void {
     $this->assertSame('42', ExportItemIdentity::encode(42));
@@ -23,14 +27,14 @@ class ExportItemIdentityTest extends UnitTestCase {
   }
 
   /**
-   * @covers ::encode
+   * Tests encode() with a langcode returns a composite key.
    */
   public function testEncodeWithLangcodeReturnsCompositeKey(): void {
     $this->assertSame('42:es', ExportItemIdentity::encode(42, 'es'));
   }
 
   /**
-   * @covers ::decode
+   * Tests decode() of a bare id has a null langcode.
    */
   public function testDecodeBareIdHasNullLangcode(): void {
     [$id, $langcode] = ExportItemIdentity::decode('42');
@@ -39,7 +43,7 @@ class ExportItemIdentityTest extends UnitTestCase {
   }
 
   /**
-   * @covers ::decode
+   * Tests decode() of a composite key splits id and langcode.
    */
   public function testDecodeCompositeKeySplitsIdAndLangcode(): void {
     [$id, $langcode] = ExportItemIdentity::decode('42:es');
@@ -49,9 +53,6 @@ class ExportItemIdentityTest extends UnitTestCase {
 
   /**
    * encode()/decode() round-trip for both shapes.
-   *
-   * @covers ::encode
-   * @covers ::decode
    */
   public function testRoundTrip(): void {
     $this->assertSame(['42', NULL], ExportItemIdentity::decode(ExportItemIdentity::encode(42)));

--- a/modules/mukurtu_import/src/Form/ImportFieldDescriptionListForm.php
+++ b/modules/mukurtu_import/src/Form/ImportFieldDescriptionListForm.php
@@ -218,7 +218,7 @@ class ImportFieldDescriptionListForm extends ImportBaseForm {
 
     // Convert to CSV format.
     $handle = fopen('php://memory', 'r+');
-    fputcsv($handle, $headers);
+    fputcsv($handle, $headers, ',', '"', '\\');
     rewind($handle);
     $csv = stream_get_contents($handle);
     fclose($handle);

--- a/modules/mukurtu_import/tests/src/Kernel/ImportFieldDescriptionListFormTest.php
+++ b/modules/mukurtu_import/tests/src/Kernel/ImportFieldDescriptionListFormTest.php
@@ -154,7 +154,7 @@ class ImportFieldDescriptionListFormTest extends MukurtuImportTestBase {
 
     $response = $form_state->getResponse();
     $this->assertNotNull($response, 'Submitting the form produces a downloadable response.');
-    $headers = str_getcsv(rtrim($response->getContent(), "\r\n"));
+    $headers = str_getcsv(rtrim($response->getContent(), "\r\n"), ',', '"', '\\');
     $this->assertSame(array_values($expected_headers), $headers, 'The downloaded CSV contains a header for every field in both sections.');
   }
 

--- a/modules/mukurtu_import/tests/src/Kernel/ImportTranslationTest.php
+++ b/modules/mukurtu_import/tests/src/Kernel/ImportTranslationTest.php
@@ -8,12 +8,12 @@ use Drupal\language\Entity\ConfigurableLanguage;
 use Drupal\migrate\Plugin\MigrationInterface;
 use Drupal\mukurtu_import\Entity\MukurtuImportStrategy;
 use Drupal\node\Entity\Node;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests translation-targeting CSV import (#1260 Phase 5, import track).
- *
- * @group mukurtu_import
  */
+#[Group('mukurtu_import')]
 class ImportTranslationTest extends MukurtuImportTestBase {
 
   /**

--- a/modules/mukurtu_landing_page/tests/src/Kernel/DefaultLandingPageTest.php
+++ b/modules/mukurtu_landing_page/tests/src/Kernel/DefaultLandingPageTest.php
@@ -6,12 +6,12 @@ namespace Drupal\Tests\mukurtu_landing_page\Kernel;
 
 use Drupal\Core\Config\FileStorage;
 use Drupal\KernelTests\KernelTestBase;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests DefaultLandingPage::createDefaultLandingPage() block reuse.
- *
- * @group mukurtu_landing_page
  */
+#[Group('mukurtu_landing_page')]
 class DefaultLandingPageTest extends KernelTestBase {
 
   protected static $modules = [

--- a/modules/mukurtu_local_contexts/tests/src/Kernel/FormHooksProjectLabelOverlapTest.php
+++ b/modules/mukurtu_local_contexts/tests/src/Kernel/FormHooksProjectLabelOverlapTest.php
@@ -8,13 +8,14 @@ use Drupal\Core\Entity\ContentEntityFormInterface;
 use Drupal\Core\Form\FormState;
 use Drupal\mukurtu_local_contexts\Hook\FormHooks;
 use Drupal\node\Entity\Node;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests the project/label overlap validation added by FormHooks.
  *
  * @see \Drupal\mukurtu_local_contexts\Hook\FormHooks::validateNoProjectLabelOverlap()
- * @group mukurtu_local_contexts
  */
+#[Group('mukurtu_local_contexts')]
 class FormHooksProjectLabelOverlapTest extends LocalContextsTestBase {
 
   /**

--- a/modules/mukurtu_local_contexts/tests/src/Kernel/LegacyLabelRemovalBatchTest.php
+++ b/modules/mukurtu_local_contexts/tests/src/Kernel/LegacyLabelRemovalBatchTest.php
@@ -4,12 +4,12 @@ namespace Drupal\Tests\mukurtu_local_contexts\Kernel;
 
 use Drupal\mukurtu_local_contexts\Batch\LegacyLabelRemovalBatch;
 use Drupal\node\Entity\Node;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests LegacyLabelRemovalBatch::run().
- *
- * @group mukurtu_local_contexts
  */
+#[Group('mukurtu_local_contexts')]
 class LegacyLabelRemovalBatchTest extends LocalContextsTestBase {
 
   /**

--- a/modules/mukurtu_local_contexts/tests/src/Kernel/LegacyLabelRemovalConfirmFormTest.php
+++ b/modules/mukurtu_local_contexts/tests/src/Kernel/LegacyLabelRemovalConfirmFormTest.php
@@ -5,12 +5,12 @@ namespace Drupal\Tests\mukurtu_local_contexts\Kernel;
 use Drupal\Core\Form\FormState;
 use Drupal\mukurtu_local_contexts\Form\LegacyLabelRemovalConfirmForm;
 use Drupal\node\Entity\Node;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests LegacyLabelRemovalConfirmForm.
- *
- * @group mukurtu_local_contexts
  */
+#[Group('mukurtu_local_contexts')]
 class LegacyLabelRemovalConfirmFormTest extends LocalContextsTestBase {
 
   /**

--- a/modules/mukurtu_local_contexts/tests/src/Kernel/LegacyLabelRemovalReviewFormTest.php
+++ b/modules/mukurtu_local_contexts/tests/src/Kernel/LegacyLabelRemovalReviewFormTest.php
@@ -5,12 +5,12 @@ namespace Drupal\Tests\mukurtu_local_contexts\Kernel;
 use Drupal\Core\Form\FormState;
 use Drupal\mukurtu_local_contexts\Form\LegacyLabelRemovalReviewForm;
 use Drupal\node\Entity\Node;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests LegacyLabelRemovalReviewForm.
- *
- * @group mukurtu_local_contexts
  */
+#[Group('mukurtu_local_contexts')]
 class LegacyLabelRemovalReviewFormTest extends LocalContextsTestBase {
 
   /**

--- a/modules/mukurtu_media/tests/src/Kernel/MediaFieldLabelTest.php
+++ b/modules/mukurtu_media/tests/src/Kernel/MediaFieldLabelTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\Tests\mukurtu_media\Kernel;
 
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\Tests\mukurtu_protocol\Kernel\ProtocolAwareEntityTestBase;
 use Drupal\mukurtu_media\Entity\Audio;
 use Drupal\mukurtu_media\Entity\Document;
 use Drupal\mukurtu_media\Entity\ExternalEmbed;
@@ -12,19 +13,19 @@ use Drupal\mukurtu_media\Entity\Image;
 use Drupal\mukurtu_media\Entity\RemoteVideo;
 use Drupal\mukurtu_media\Entity\SoundCloud;
 use Drupal\mukurtu_media\Entity\Video;
-use Drupal\Tests\mukurtu_protocol\Kernel\ProtocolAwareEntityTestBase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests that the "Identifier" field label is translatable across the 7
  * media bundle classes that duplicated it as a plain string.
- *
- * @group mukurtu_media
  */
+#[Group('mukurtu_media')]
 class MediaFieldLabelTest extends ProtocolAwareEntityTestBase {
 
   /**
-   * @dataProvider mediaBundleClassProvider
    */
+  #[DataProvider('mediaBundleClassProvider')]
   public function testIdentifierFieldLabelIsTranslatable(string $class): void {
     $entityType = \Drupal::entityTypeManager()->getDefinition('media');
     $definitions = $class::bundleFieldDefinitions($entityType, '', []);

--- a/modules/mukurtu_media/tests/src/Kernel/MediaOverviewPermissionUpdateTest.php
+++ b/modules/mukurtu_media/tests/src/Kernel/MediaOverviewPermissionUpdateTest.php
@@ -6,13 +6,14 @@ namespace Drupal\Tests\mukurtu_media\Kernel;
 
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\user\Entity\Role;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests mukurtu_media_update_40021(), which grants a media permission.
  *
  * @see mukurtu_media_update_40021()
- * @group mukurtu_media
  */
+#[Group('mukurtu_media')]
 class MediaOverviewPermissionUpdateTest extends KernelTestBase {
 
   /**

--- a/modules/mukurtu_multilingual/tests/src/Kernel/BaseFieldOverrideLabelTranslationTest.php
+++ b/modules/mukurtu_multilingual/tests/src/Kernel/BaseFieldOverrideLabelTranslationTest.php
@@ -7,6 +7,7 @@ namespace Drupal\Tests\mukurtu_multilingual\Kernel;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\language\Entity\ConfigurableLanguage;
 use Drupal\locale\SourceString;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Confirms that Drupal core's own locale config-sync mechanism, not any
@@ -40,9 +41,8 @@ use Drupal\locale\SourceString;
  * rather than mukurtu_multilingual itself, whose real base field
  * overrides all live behind a heavy dependency chain (mukurtu_protocol,
  * mukurtu_collection, mukurtu_multipage_items).
- *
- * @group mukurtu_multilingual
  */
+#[Group('mukurtu_multilingual')]
 class BaseFieldOverrideLabelTranslationTest extends KernelTestBase {
 
   /**

--- a/modules/mukurtu_multilingual/tests/src/Kernel/BundleTranslationEnablementTest.php
+++ b/modules/mukurtu_multilingual/tests/src/Kernel/BundleTranslationEnablementTest.php
@@ -6,6 +6,7 @@ namespace Drupal\Tests\mukurtu_multilingual\Kernel;
 
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\media\Entity\MediaType;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests mukurtu_multilingual_update_40008(), which closes the 12 bundle
@@ -21,8 +22,8 @@ use Drupal\media\Entity\MediaType;
  *
  * @see mukurtu_multilingual_update_40008()
  * @see ConfigTranslationCoverageTest
- * @group mukurtu_multilingual
  */
+#[Group('mukurtu_multilingual')]
 class BundleTranslationEnablementTest extends KernelTestBase {
 
   /**

--- a/modules/mukurtu_multilingual/tests/src/Kernel/LanguageNegotiationDefaultsTest.php
+++ b/modules/mukurtu_multilingual/tests/src/Kernel/LanguageNegotiationDefaultsTest.php
@@ -5,13 +5,14 @@ declare(strict_types=1);
 namespace Drupal\Tests\mukurtu_multilingual\Kernel;
 
 use Drupal\KernelTests\KernelTestBase;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests _mukurtu_multilingual_apply_language_negotiation_defaults().
  *
  * @see _mukurtu_multilingual_apply_language_negotiation_defaults()
- * @group mukurtu_multilingual
  */
+#[Group('mukurtu_multilingual')]
 class LanguageNegotiationDefaultsTest extends KernelTestBase {
 
   /**

--- a/modules/mukurtu_multilingual/tests/src/Kernel/SearchApiLanguageFallbackFieldTest.php
+++ b/modules/mukurtu_multilingual/tests/src/Kernel/SearchApiLanguageFallbackFieldTest.php
@@ -7,6 +7,7 @@ namespace Drupal\Tests\mukurtu_multilingual\Kernel;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\search_api\Entity\Index;
 use Drupal\search_api\Entity\Server;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests mukurtu_multilingual_update_40009().
@@ -16,8 +17,8 @@ use Drupal\search_api\Entity\Server;
  * filter on it (docs/content-language-policy.md).
  *
  * @see mukurtu_multilingual_update_40009()
- * @group mukurtu_multilingual
  */
+#[Group('mukurtu_multilingual')]
 class SearchApiLanguageFallbackFieldTest extends KernelTestBase {
 
   /**

--- a/modules/mukurtu_multilingual/tests/src/Kernel/TranslationOverridesTest.php
+++ b/modules/mukurtu_multilingual/tests/src/Kernel/TranslationOverridesTest.php
@@ -8,6 +8,7 @@ use Drupal\Core\Field\Entity\BaseFieldOverride;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\language\Entity\ContentLanguageSettings;
 use Drupal\node\Entity\NodeType;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests _mukurtu_multilingual_apply_translation_overrides().
@@ -25,8 +26,8 @@ use Drupal\node\Entity\NodeType;
  * instead.
  *
  * @see _mukurtu_multilingual_apply_translation_overrides()
- * @group mukurtu_multilingual
  */
+#[Group('mukurtu_multilingual')]
 class TranslationOverridesTest extends KernelTestBase {
 
   /**

--- a/modules/mukurtu_multilingual/tests/src/Kernel/ViewsSchemaHooksTest.php
+++ b/modules/mukurtu_multilingual/tests/src/Kernel/ViewsSchemaHooksTest.php
@@ -5,13 +5,14 @@ declare(strict_types=1);
 namespace Drupal\Tests\mukurtu_multilingual\Kernel;
 
 use Drupal\KernelTests\KernelTestBase;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests ViewsSchemaHooks::configSchemaInfoAlter() (issue #1638).
  *
  * @see \Drupal\mukurtu_multilingual\Hook\ViewsSchemaHooks
- * @group mukurtu_multilingual
  */
+#[Group('mukurtu_multilingual')]
 class ViewsSchemaHooksTest extends KernelTestBase {
 
   /**

--- a/modules/mukurtu_multilingual/tests/src/Unit/ConfigTranslationCoverageTest.php
+++ b/modules/mukurtu_multilingual/tests/src/Unit/ConfigTranslationCoverageTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\Tests\mukurtu_multilingual\Unit;
 
 use Drupal\Tests\UnitTestCase;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Guards against a bundle silently shipping with no translation support.
@@ -19,9 +20,8 @@ use Drupal\Tests\UnitTestCase;
  * translation support fails CI instead of shipping silently.
  *
  * A pure filesystem check - no Drupal bootstrap needed.
- *
- * @group mukurtu_multilingual
  */
+#[Group('mukurtu_multilingual')]
 class ConfigTranslationCoverageTest extends UnitTestCase {
 
   /**

--- a/modules/mukurtu_multilingual/tests/src/Unit/SearchApiFallbackFieldShippedConfigTest.php
+++ b/modules/mukurtu_multilingual/tests/src/Unit/SearchApiFallbackFieldShippedConfigTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\Tests\mukurtu_multilingual\Unit;
 
 use Drupal\Tests\UnitTestCase;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\Yaml\Yaml;
 
 /**
@@ -24,8 +25,8 @@ use Symfony\Component\Yaml\Yaml;
  * A pure filesystem/YAML check - no Drupal bootstrap needed.
  *
  * @see mukurtu_multilingual_update_40009()
- * @group mukurtu_multilingual
  */
+#[Group('mukurtu_multilingual')]
 class SearchApiFallbackFieldShippedConfigTest extends UnitTestCase {
 
   /**

--- a/modules/mukurtu_multilingual/tests/src/Unit/ViewLanguageFallbackCoverageTest.php
+++ b/modules/mukurtu_multilingual/tests/src/Unit/ViewLanguageFallbackCoverageTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\Tests\mukurtu_multilingual\Unit;
 
 use Drupal\Tests\UnitTestCase;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\Yaml\Yaml;
 
 /**
@@ -23,9 +24,8 @@ use Symfony\Component\Yaml\Yaml;
  * of scope.
  *
  * A pure filesystem/YAML check - no Drupal bootstrap needed.
- *
- * @group mukurtu_multilingual
  */
+#[Group('mukurtu_multilingual')]
 class ViewLanguageFallbackCoverageTest extends UnitTestCase {
 
   /**

--- a/modules/mukurtu_multipage_items/tests/src/Kernel/MultipageItemBrowserViewLanguageFallbackTest.php
+++ b/modules/mukurtu_multipage_items/tests/src/Kernel/MultipageItemBrowserViewLanguageFallbackTest.php
@@ -6,6 +6,7 @@ namespace Drupal\Tests\mukurtu_multipage_items\Kernel;
 
 use Drupal\Core\Config\FileStorage;
 use Drupal\KernelTests\KernelTestBase;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests mukurtu_multipage_items_update_40011().
@@ -15,8 +16,8 @@ use Drupal\KernelTests\KernelTestBase;
  * confirms it fills them back in - and that running it twice is a no-op.
  *
  * @see \mukurtu_multipage_items_update_40011()
- * @group mukurtu_multipage_items
  */
+#[Group('mukurtu_multipage_items')]
 class MultipageItemBrowserViewLanguageFallbackTest extends KernelTestBase {
 
   /**

--- a/modules/mukurtu_notifications/tests/src/Kernel/NewAccountCreatedRecipientsTest.php
+++ b/modules/mukurtu_notifications/tests/src/Kernel/NewAccountCreatedRecipientsTest.php
@@ -4,13 +4,14 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\mukurtu_notifications\Kernel;
 
+use Drupal\KernelTests\KernelTestBase;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;
-use Drupal\KernelTests\KernelTestBase;
 use Drupal\message\Entity\Message;
 use Drupal\message\Entity\MessageTemplate;
 use Drupal\user\Entity\Role;
 use Drupal\user\Entity\User;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests mukurtu_notifications_notify_new_account_created()'s recipient list.
@@ -19,9 +20,8 @@ use Drupal\user\Entity\User;
  * qualified as a recipient of their own "new account created" notification,
  * since the manager-role lookup runs after the account is saved. See
  * mukurtu_notifications_notify_new_account_created().
- *
- * @group mukurtu_notifications
  */
+#[Group('mukurtu_notifications')]
 class NewAccountCreatedRecipientsTest extends KernelTestBase {
 
   /**

--- a/modules/mukurtu_notifications/tests/src/Kernel/NotificationsFeedAccessTest.php
+++ b/modules/mukurtu_notifications/tests/src/Kernel/NotificationsFeedAccessTest.php
@@ -9,6 +9,7 @@ use Drupal\message\Entity\Message;
 use Drupal\user\Entity\Role;
 use Drupal\user\Entity\User;
 use Drupal\views\Views;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests that the personal notifications feed cannot leak another user's
@@ -18,9 +19,8 @@ use Drupal\views\Views;
  * had no validation, so /notifications/<uid> would use whatever uid was
  * supplied in the URL instead of the current user -- see
  * mukurtu_notifications_views_pre_view().
- *
- * @group mukurtu_notifications
  */
+#[Group('mukurtu_notifications')]
 class NotificationsFeedAccessTest extends KernelTestBase {
 
   /**

--- a/modules/mukurtu_notifications/tests/src/Kernel/NotificationsViewsLanguageFallbackTest.php
+++ b/modules/mukurtu_notifications/tests/src/Kernel/NotificationsViewsLanguageFallbackTest.php
@@ -6,6 +6,7 @@ namespace Drupal\Tests\mukurtu_notifications\Kernel;
 
 use Drupal\Core\Config\FileStorage;
 use Drupal\KernelTests\KernelTestBase;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests mukurtu_notifications_update_40056().
@@ -15,8 +16,8 @@ use Drupal\KernelTests\KernelTestBase;
  * confirms it fills them back in - and that running it twice is a no-op.
  *
  * @see \mukurtu_notifications_update_40056()
- * @group mukurtu_notifications
  */
+#[Group('mukurtu_notifications')]
 class NotificationsViewsLanguageFallbackTest extends KernelTestBase {
 
   /**

--- a/modules/mukurtu_notifications/tests/src/Kernel/NotifyFrequencyTest.php
+++ b/modules/mukurtu_notifications/tests/src/Kernel/NotifyFrequencyTest.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\mukurtu_notifications\Kernel;
 
+use Drupal\KernelTests\KernelTestBase;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;
-use Drupal\KernelTests\KernelTestBase;
 use Drupal\user\Entity\User;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests the field_notify_frequency 'none' option and its update hook.
@@ -21,8 +22,8 @@ use Drupal\user\Entity\User;
  * @see mukurtu_notifications_notification_frequency_allowed_values()
  * @see _mukurtu_notifications_user_wants_email()
  * @see mukurtu_notifications_update_40057()
- * @group mukurtu_notifications
  */
+#[Group('mukurtu_notifications')]
 class NotifyFrequencyTest extends KernelTestBase {
 
   /**

--- a/modules/mukurtu_notifications/tests/src/Kernel/Uid1EmailCategoryUpdateTest.php
+++ b/modules/mukurtu_notifications/tests/src/Kernel/Uid1EmailCategoryUpdateTest.php
@@ -6,14 +6,15 @@ namespace Drupal\Tests\mukurtu_notifications\Kernel;
 
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\user\Entity\User;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests mukurtu_notifications_update_40055(), which opts uid 1 in to
  * "User account" category emails.
  *
  * @see mukurtu_notifications_update_40055()
- * @group mukurtu_notifications
  */
+#[Group('mukurtu_notifications')]
 class Uid1EmailCategoryUpdateTest extends KernelTestBase {
 
   /**

--- a/modules/mukurtu_person/tests/src/Kernel/PersonFieldLabelTest.php
+++ b/modules/mukurtu_person/tests/src/Kernel/PersonFieldLabelTest.php
@@ -5,16 +5,16 @@ declare(strict_types=1);
 namespace Drupal\Tests\mukurtu_person\Kernel;
 
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\Tests\mukurtu_protocol\Kernel\ProtocolAwareEntityTestBase;
 use Drupal\mukurtu_person\Entity\Person;
 use Drupal\mukurtu_person\Entity\RelatedPerson;
-use Drupal\Tests\mukurtu_protocol\Kernel\ProtocolAwareEntityTestBase;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests that Person/RelatedPerson field labels and descriptions are
  * translatable.
- *
- * @group mukurtu_person
  */
+#[Group('mukurtu_person')]
 class PersonFieldLabelTest extends ProtocolAwareEntityTestBase {
 
   /**

--- a/modules/mukurtu_person/tests/src/Kernel/PersonMapEditFormDefaultsUpdateTest.php
+++ b/modules/mukurtu_person/tests/src/Kernel/PersonMapEditFormDefaultsUpdateTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\Tests\mukurtu_person\Kernel;
 
 use Drupal\KernelTests\KernelTestBase;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests mukurtu_person_update_40009(), which moves the person edit form
@@ -12,8 +13,8 @@ use Drupal\KernelTests\KernelTestBase;
  * editing a single already-saved point (#1453).
  *
  * @see mukurtu_person_update_40009()
- * @group mukurtu_person
  */
+#[Group('mukurtu_person')]
 class PersonMapEditFormDefaultsUpdateTest extends KernelTestBase {
 
   /**

--- a/modules/mukurtu_place/tests/src/Kernel/PlaceFieldLabelTest.php
+++ b/modules/mukurtu_place/tests/src/Kernel/PlaceFieldLabelTest.php
@@ -5,14 +5,14 @@ declare(strict_types=1);
 namespace Drupal\Tests\mukurtu_place\Kernel;
 
 use Drupal\Core\StringTranslation\TranslatableMarkup;
-use Drupal\mukurtu_place\Entity\Place;
 use Drupal\Tests\mukurtu_protocol\Kernel\ProtocolAwareEntityTestBase;
+use Drupal\mukurtu_place\Entity\Place;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests that Place's "Location Description" field label is translatable.
- *
- * @group mukurtu_place
  */
+#[Group('mukurtu_place')]
 class PlaceFieldLabelTest extends ProtocolAwareEntityTestBase {
 
   public function testCoverageDescriptionFieldLabelIsTranslatable(): void {

--- a/modules/mukurtu_place/tests/src/Kernel/PlaceMapEditFormDefaultsUpdateTest.php
+++ b/modules/mukurtu_place/tests/src/Kernel/PlaceMapEditFormDefaultsUpdateTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\Tests\mukurtu_place\Kernel;
 
 use Drupal\KernelTests\KernelTestBase;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests mukurtu_place_update_40009(), which moves the place edit form map's
@@ -12,8 +13,8 @@ use Drupal\KernelTests\KernelTestBase;
  * single already-saved point (#1453).
  *
  * @see mukurtu_place_update_40009()
- * @group mukurtu_place
  */
+#[Group('mukurtu_place')]
 class PlaceMapEditFormDefaultsUpdateTest extends KernelTestBase {
 
   /**

--- a/modules/mukurtu_protocol/tests/src/Kernel/Access/MukurtuMediaAccessTest.php
+++ b/modules/mukurtu_protocol/tests/src/Kernel/Access/MukurtuMediaAccessTest.php
@@ -12,6 +12,7 @@ use Drupal\og\Entity\OgRole;
 use Drupal\og\Og;
 use Drupal\user\Entity\Role;
 use Drupal\user\Entity\User;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests the permission string that gates /admin/media (issue #972).
@@ -22,9 +23,8 @@ use Drupal\user\Entity\User;
  * permission string ('site:access media overview+protocol:view media', OR
  * conjunction), so exercising that shared method here covers both entry
  * points.
- *
- * @group mukurtu_protocol
  */
+#[Group('mukurtu_protocol')]
 class MukurtuMediaAccessTest extends KernelTestBase {
 
   /**

--- a/modules/mukurtu_protocol/tests/src/Kernel/AdminSurfaceLabelTranslationTest.php
+++ b/modules/mukurtu_protocol/tests/src/Kernel/AdminSurfaceLabelTranslationTest.php
@@ -12,14 +12,14 @@ use Drupal\mukurtu_protocol\Entity\Protocol;
 use Drupal\mukurtu_protocol\Form\AddMemberToCommunityForm;
 use Drupal\mukurtu_protocol\Form\AddUserToCommunityForm;
 use Drupal\mukurtu_protocol\ProtocolListBuilder;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests that admin/editor-facing surfaces show protocol/community names in
  * the active content language, covering the same anti-pattern fixed for
  * visitor-facing surfaces in #1671 (see ProtocolLabelTranslationTest).
- *
- * @group mukurtu_protocol
  */
+#[Group('mukurtu_protocol')]
 class AdminSurfaceLabelTranslationTest extends ProtocolAwareEntityTestBase {
 
   /**

--- a/modules/mukurtu_protocol/tests/src/Kernel/CommunityViewsLanguageFallbackTest.php
+++ b/modules/mukurtu_protocol/tests/src/Kernel/CommunityViewsLanguageFallbackTest.php
@@ -6,6 +6,7 @@ namespace Drupal\Tests\mukurtu_protocol\Kernel;
 
 use Drupal\Core\Config\FileStorage;
 use Drupal\KernelTests\KernelTestBase;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests mukurtu_protocol_update_40043().
@@ -15,8 +16,8 @@ use Drupal\KernelTests\KernelTestBase;
  * confirms it fills them back in - and that running it twice is a no-op.
  *
  * @see \mukurtu_protocol_update_40043()
- * @group mukurtu_protocol
  */
+#[Group('mukurtu_protocol')]
 class CommunityViewsLanguageFallbackTest extends KernelTestBase {
 
   /**

--- a/modules/mukurtu_protocol/tests/src/Kernel/CulturalProtocolFieldLabelTest.php
+++ b/modules/mukurtu_protocol/tests/src/Kernel/CulturalProtocolFieldLabelTest.php
@@ -6,13 +6,14 @@ namespace Drupal\Tests\mukurtu_protocol\Kernel;
 
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\mukurtu_protocol\Entity\MukurtuNode;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests that the "Cultural Protocols" field label is translatable.
  *
  * @see \Drupal\mukurtu_protocol\CulturalProtocolControlledTrait::getProtocolFieldDefinitions()
- * @group mukurtu_protocol
  */
+#[Group('mukurtu_protocol')]
 class CulturalProtocolFieldLabelTest extends ProtocolAwareEntityTestBase {
 
   /**

--- a/modules/mukurtu_protocol/tests/src/Kernel/ProtocolCommunityFieldDescriptionTest.php
+++ b/modules/mukurtu_protocol/tests/src/Kernel/ProtocolCommunityFieldDescriptionTest.php
@@ -7,12 +7,13 @@ namespace Drupal\Tests\mukurtu_protocol\Kernel;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\mukurtu_protocol\Entity\Community;
 use Drupal\mukurtu_protocol\Entity\Protocol;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests that Protocol/Community field descriptions are translatable.
- *
- * @group mukurtu_protocol
  */
+#[Group('mukurtu_protocol')]
 class ProtocolCommunityFieldDescriptionTest extends ProtocolAwareEntityTestBase {
 
   public function testProtocolAccessModeDescriptionIsTranslatable(): void {
@@ -23,8 +24,8 @@ class ProtocolCommunityFieldDescriptionTest extends ProtocolAwareEntityTestBase 
   }
 
   /**
-   * @dataProvider communityFieldProvider
    */
+  #[DataProvider('communityFieldProvider')]
   public function testCommunityFieldDescriptionIsTranslatable(string $fieldName): void {
     $entityType = \Drupal::entityTypeManager()->getDefinition('community');
     $fields = Community::baseFieldDefinitions($entityType);

--- a/modules/mukurtu_protocol/tests/src/Kernel/ProtocolLabelTranslationTest.php
+++ b/modules/mukurtu_protocol/tests/src/Kernel/ProtocolLabelTranslationTest.php
@@ -11,6 +11,7 @@ use Drupal\facets\Result\Result;
 use Drupal\language\Entity\ConfigurableLanguage;
 use Drupal\mukurtu_protocol\Entity\Protocol;
 use Drupal\mukurtu_protocol\Plugin\facets\processor\CulturalProtocolFacetLabelProcessor;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests that protocol names shown to visitors respect the active content
@@ -22,9 +23,8 @@ use Drupal\mukurtu_protocol\Plugin\facets\processor\CulturalProtocolFacetLabelPr
  * bypassing entity.repository's translation context. The same anti-pattern
  * existed in MediaProtocolFilter/NodeProtocolFilter's exposed-filter option
  * lists.
- *
- * @group mukurtu_protocol
  */
+#[Group('mukurtu_protocol')]
 class ProtocolLabelTranslationTest extends ProtocolAwareEntityTestBase {
 
   /**

--- a/modules/mukurtu_protocol/tests/src/Kernel/ViewMediaPermissionUpdateTest.php
+++ b/modules/mukurtu_protocol/tests/src/Kernel/ViewMediaPermissionUpdateTest.php
@@ -6,6 +6,7 @@ namespace Drupal\Tests\mukurtu_protocol\Kernel;
 
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\og\Entity\OgRole;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests mukurtu_protocol_update_40041(), which grants 'view media' to
@@ -13,8 +14,8 @@ use Drupal\og\Entity\OgRole;
  * /admin/media access.
  *
  * @see mukurtu_protocol_update_40041()
- * @group mukurtu_protocol
  */
+#[Group('mukurtu_protocol')]
 class ViewMediaPermissionUpdateTest extends KernelTestBase {
 
   /**

--- a/modules/mukurtu_protocol_sync/tests/src/Kernel/SampleSentenceProtocolSyncTest.php
+++ b/modules/mukurtu_protocol_sync/tests/src/Kernel/SampleSentenceProtocolSyncTest.php
@@ -14,6 +14,7 @@ use Drupal\mukurtu_protocol\Entity\Protocol;
 use Drupal\node\Entity\Node;
 use Drupal\paragraphs\Entity\Paragraph;
 use Drupal\paragraphs\Entity\ParagraphsType;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests that media attached only through a sample-sentence recording
@@ -26,9 +27,8 @@ use Drupal\paragraphs\Entity\ParagraphsType;
  * checked a fixed list of top-level node fields, so a dictionary word's
  * sample-sentence recording never got a protocol-parent claim or protocol
  * sync at all, regardless of its own "sync protocols" setting.
- *
- * @group mukurtu_protocol_sync
  */
+#[Group('mukurtu_protocol_sync')]
 class SampleSentenceProtocolSyncTest extends ProtocolAwareEntityTestBase {
 
   /**

--- a/modules/mukurtu_solr/tests/src/Kernel/SolrViewsLanguageFallbackTest.php
+++ b/modules/mukurtu_solr/tests/src/Kernel/SolrViewsLanguageFallbackTest.php
@@ -6,6 +6,7 @@ namespace Drupal\Tests\mukurtu_solr\Kernel;
 
 use Drupal\Core\Config\FileStorage;
 use Drupal\KernelTests\KernelTestBase;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests mukurtu_solr_update_40005().
@@ -17,8 +18,8 @@ use Drupal\KernelTests\KernelTestBase;
  * and that running it twice is a no-op.
  *
  * @see \mukurtu_solr_update_40005()
- * @group mukurtu_solr
  */
+#[Group('mukurtu_solr')]
 class SolrViewsLanguageFallbackTest extends KernelTestBase {
 
   /**

--- a/modules/mukurtu_submissions/mukurtu_submissions.module
+++ b/modules/mukurtu_submissions/mukurtu_submissions.module
@@ -167,9 +167,11 @@ function mukurtu_submissions_send_email_notifications(Message $message, array $e
   // The rendered view mode output carries theme-wrapper whitespace
   // (newlines/indentation around the actual text) - harmless in the body,
   // but a subject line should always collapse to one line.
-  $subject_render = (string) $renderer->renderInIsolation($view_builder->view($message, 'mail_subject'));
+  $subject_build = $view_builder->view($message, 'mail_subject');
+  $subject_render = (string) $renderer->renderInIsolation($subject_build);
   $subject = trim(preg_replace('/\s+/', ' ', $subject_render));
-  $body = trim((string) $renderer->renderInIsolation($view_builder->view($message, 'mail_body')));
+  $body_build = $view_builder->view($message, 'mail_body');
+  $body = trim((string) $renderer->renderInIsolation($body_build));
   $mail_manager = \Drupal::service('plugin.manager.mail');
   $langcode = \Drupal::languageManager()->getDefaultLanguage()->getId();
 

--- a/modules/mukurtu_submissions/tests/src/Kernel/DefaultFormCreationTest.php
+++ b/modules/mukurtu_submissions/tests/src/Kernel/DefaultFormCreationTest.php
@@ -10,14 +10,14 @@ use Drupal\mukurtu_submissions\Commands\MukurtuSubmissionsCommands;
 use Drupal\mukurtu_submissions\Entity\SubmissionSettings;
 use Drupal\node\Entity\NodeType;
 use Drush\Log\DrushLoggerManager;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests the "create-default-forms" Drush command: bulk-creates a disabled,
  * all-fields-included settings entity for every bundle lacking one, and
  * leaves already-configured bundles untouched.
- *
- * @group mukurtu_submissions
  */
+#[Group('mukurtu_submissions')]
 class DefaultFormCreationTest extends MukurtuSubmissionsKernelTestBase {
 
   protected function createCommand(): MukurtuSubmissionsCommands {

--- a/modules/mukurtu_submissions/tests/src/Kernel/DefaultFormCreationUpdateHookTest.php
+++ b/modules/mukurtu_submissions/tests/src/Kernel/DefaultFormCreationUpdateHookTest.php
@@ -6,6 +6,7 @@ namespace Drupal\Tests\mukurtu_submissions\Kernel;
 
 use Drupal\mukurtu_submissions\Entity\SubmissionSettings;
 use Drupal\node\Entity\NodeType;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests mukurtu_submissions_update_40007(): backfills a disabled default
@@ -14,9 +15,8 @@ use Drupal\node\Entity\NodeType;
  * "drush mukurtu-submissions:create-default-forms" command, which nothing
  * in hook_install()/the update path ever invoked, so an upgrading site's
  * other content types never got a form at all.
- *
- * @group mukurtu_submissions
  */
+#[Group('mukurtu_submissions')]
 class DefaultFormCreationUpdateHookTest extends MukurtuSubmissionsKernelTestBase {
 
   /**

--- a/modules/mukurtu_submissions/tests/src/Kernel/EntityBrowserPermissionSyncTest.php
+++ b/modules/mukurtu_submissions/tests/src/Kernel/EntityBrowserPermissionSyncTest.php
@@ -8,6 +8,7 @@ use Drupal\entity_browser\Entity\EntityBrowser;
 use Drupal\mukurtu_submissions\Entity\SubmissionSettings;
 use Drupal\node\Entity\NodeType;
 use Drupal\user\Entity\Role;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests that access to whichever entity browser(s) a bundle's submission
@@ -17,9 +18,8 @@ use Drupal\user\Entity\Role;
  * permission()'s own logic exactly, since Entity Browser gates each
  * browser's modal route behind a distinct "access {id} entity browser
  * pages" permission separate from the field's own rendering.
- *
- * @group mukurtu_submissions
  */
+#[Group('mukurtu_submissions')]
 class EntityBrowserPermissionSyncTest extends MukurtuSubmissionsKernelTestBase {
 
   /**

--- a/modules/mukurtu_submissions/tests/src/Kernel/FieldGroupSeedTest.php
+++ b/modules/mukurtu_submissions/tests/src/Kernel/FieldGroupSeedTest.php
@@ -7,14 +7,14 @@ namespace Drupal\Tests\mukurtu_submissions\Kernel;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\mukurtu_submissions\Entity\SubmissionSettings;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests SubmissionFormDisplayManager::seedFieldGroupsFromDefaultForm():
  * converts a bundle's regular "default" form's field_group arrangement
  * into this module's simpler field_groups/field_group_assignments schema.
- *
- * @group mukurtu_submissions
  */
+#[Group('mukurtu_submissions')]
 class FieldGroupSeedTest extends MukurtuSubmissionsKernelTestBase {
 
   protected function setUp(): void {

--- a/modules/mukurtu_submissions/tests/src/Kernel/NotifyEmailNotificationTest.php
+++ b/modules/mukurtu_submissions/tests/src/Kernel/NotifyEmailNotificationTest.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace Drupal\Tests\mukurtu_submissions\Kernel;
 
 use Drupal\Core\Test\AssertMailTrait;
-use Drupal\message\Entity\Message;
 use Drupal\Tests\message\Kernel\MessageTemplateCreateTrait;
+use Drupal\message\Entity\Message;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests mukurtu_submissions_send_email_notifications() - the notify_emails
@@ -21,9 +22,8 @@ use Drupal\Tests\message\Kernel\MessageTemplateCreateTrait;
  * heavier message_subscribe/mukurtu_notifications stack
  * MukurtuSubmissionsKernelTestBase deliberately excludes; this send path
  * only needs 'message' itself.
- *
- * @group mukurtu_submissions
  */
+#[Group('mukurtu_submissions')]
 class NotifyEmailNotificationTest extends MukurtuSubmissionsKernelTestBase {
 
   use AssertMailTrait;

--- a/modules/mukurtu_submissions/tests/src/Kernel/NotifyReviewerUserSelectionTest.php
+++ b/modules/mukurtu_submissions/tests/src/Kernel/NotifyReviewerUserSelectionTest.php
@@ -5,14 +5,14 @@ declare(strict_types=1);
 namespace Drupal\Tests\mukurtu_submissions\Kernel;
 
 use Drupal\user\Entity\User;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests that the "Additional reviewers to notify" autocomplete never
  * offers Anonymous or the hidden submissions service account - neither
  * is a real reviewer a site builder would ever want to notify.
- *
- * @group mukurtu_submissions
  */
+#[Group('mukurtu_submissions')]
 class NotifyReviewerUserSelectionTest extends MukurtuSubmissionsKernelTestBase {
 
   /**

--- a/modules/mukurtu_submissions/tests/src/Kernel/ParagraphSubmissionFormTest.php
+++ b/modules/mukurtu_submissions/tests/src/Kernel/ParagraphSubmissionFormTest.php
@@ -16,6 +16,7 @@ use Drupal\node\Entity\Node;
 use Drupal\paragraphs\Entity\Paragraph;
 use Drupal\paragraphs\Entity\ParagraphsType;
 use Drupal\user\Entity\Role;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests that a media (or entity_browser) field nested inside a paragraph -
@@ -32,9 +33,8 @@ use Drupal\user\Entity\Role;
  * the target bundle's own top-level fields, so a paragraph-nested field kept
  * whatever its "default" display used (normally the full Media Library
  * modal) - unusable by an anonymous visitor, who lacks "view media" access.
- *
- * @group mukurtu_submissions
  */
+#[Group('mukurtu_submissions')]
 class ParagraphSubmissionFormTest extends MukurtuSubmissionsKernelTestBase {
 
   /**

--- a/modules/mukurtu_submissions/tests/src/Kernel/PublicSubmissionFormTest.php
+++ b/modules/mukurtu_submissions/tests/src/Kernel/PublicSubmissionFormTest.php
@@ -5,16 +5,16 @@ declare(strict_types=1);
 namespace Drupal\Tests\mukurtu_submissions\Kernel;
 
 use Drupal\Core\Form\FormState;
-use Drupal\mukurtu_submissions\Form\PublicSubmissionForm;
 use Drupal\Tests\content_moderation\Traits\ContentModerationTestTrait;
 use Drupal\Tests\mukurtu_protocol\Kernel\ProtocolAwareEntityTestBase;
+use Drupal\mukurtu_submissions\Form\PublicSubmissionForm;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests PublicSubmissionForm, the public/anonymous-facing form behind
  * /submit/{entity_type_id}/{bundle}.
- *
- * @group mukurtu_submissions
  */
+#[Group('mukurtu_submissions')]
 class PublicSubmissionFormTest extends ProtocolAwareEntityTestBase {
 
   use ContentModerationTestTrait;

--- a/modules/mukurtu_submissions/tests/src/Kernel/PublicSubmissionFormUnmoderatedSaveTest.php
+++ b/modules/mukurtu_submissions/tests/src/Kernel/PublicSubmissionFormUnmoderatedSaveTest.php
@@ -5,14 +5,15 @@ declare(strict_types=1);
 namespace Drupal\Tests\mukurtu_submissions\Kernel;
 
 use Drupal\Core\Form\FormState;
+use Drupal\KernelTests\Core\Entity\EntityKernelTestBase;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;
-use Drupal\KernelTests\Core\Entity\EntityKernelTestBase;
 use Drupal\message\Entity\MessageTemplate;
 use Drupal\mukurtu_submissions\Form\PublicSubmissionForm;
 use Drupal\node\Entity\Node;
 use Drupal\node\Entity\NodeType;
 use Drupal\user\Entity\User;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Covers PublicSubmissionForm's save path: the resulting node ends up
@@ -28,9 +29,8 @@ use Drupal\user\Entity\User;
  * automatically. The moderation-state pinning itself, and the Cultural
  * Protocol field's exclusion from the built form, are covered separately
  * by PublicSubmissionFormTest.
- *
- * @group mukurtu_submissions
  */
+#[Group('mukurtu_submissions')]
 class PublicSubmissionFormUnmoderatedSaveTest extends EntityKernelTestBase {
 
   /**

--- a/modules/mukurtu_submissions/tests/src/Kernel/PublishingWorkflowIntegrationTest.php
+++ b/modules/mukurtu_submissions/tests/src/Kernel/PublishingWorkflowIntegrationTest.php
@@ -7,6 +7,8 @@ namespace Drupal\Tests\mukurtu_submissions\Kernel;
 use Drupal\Core\Entity\Entity\EntityFormMode;
 use Drupal\Core\Form\FormState;
 use Drupal\Core\Serialization\Yaml;
+use Drupal\Tests\content_moderation\Traits\ContentModerationTestTrait;
+use Drupal\Tests\mukurtu_protocol\Kernel\ProtocolAwareEntityTestBase;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\mukurtu_protocol\Plugin\Field\FieldType\CulturalProtocolItem;
@@ -14,10 +16,9 @@ use Drupal\mukurtu_submissions\Entity\SubmissionSettings;
 use Drupal\mukurtu_submissions\Form\PublicSubmissionForm;
 use Drupal\mukurtu_workflows\Form\ReviewStateForm;
 use Drupal\node\Entity\Node;
-use Drupal\Tests\content_moderation\Traits\ContentModerationTestTrait;
-use Drupal\Tests\mukurtu_protocol\Kernel\ProtocolAwareEntityTestBase;
 use Drupal\user\Entity\Role;
 use Drupal\workflows\Entity\Workflow;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Verifies a visitor's submission can actually be driven end to end -
@@ -35,9 +36,8 @@ use Drupal\workflows\Entity\Workflow;
  * unconnected to mukurtu_submissions - this test is the missing link: the
  * same logic, reached via PublicSubmissionForm's own node creation, using
  * the actual config a site ships with.
- *
- * @group mukurtu_submissions
  */
+#[Group('mukurtu_submissions')]
 class PublishingWorkflowIntegrationTest extends ProtocolAwareEntityTestBase {
 
   use ContentModerationTestTrait;

--- a/modules/mukurtu_submissions/tests/src/Kernel/ReviewerPermissionSyncTest.php
+++ b/modules/mukurtu_submissions/tests/src/Kernel/ReviewerPermissionSyncTest.php
@@ -6,15 +6,15 @@ namespace Drupal\Tests\mukurtu_submissions\Kernel;
 
 use Drupal\mukurtu_submissions\Entity\SubmissionSettings;
 use Drupal\user\Entity\Role;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests that "edit any {bundle} content" / "delete any {bundle} content"
  * are granted dynamically to reviewer roles when a settings entity for
  * that bundle is enabled - previously this only ever happened for
  * digital_heritage, hardcoded at install time.
- *
- * @group mukurtu_submissions
  */
+#[Group('mukurtu_submissions')]
 class ReviewerPermissionSyncTest extends MukurtuSubmissionsKernelTestBase {
 
   protected function createReviewerRole(): Role {

--- a/modules/mukurtu_submissions/tests/src/Kernel/ServiceAccountVisibilityTest.php
+++ b/modules/mukurtu_submissions/tests/src/Kernel/ServiceAccountVisibilityTest.php
@@ -9,6 +9,8 @@ use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\mukurtu_core\MukurtuUserListBuilder;
 use Drupal\user\Entity\User;
 use Drupal\views\Entity\View;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests that the "Submission Forms" service account never confuses an
@@ -27,9 +29,8 @@ use Drupal\views\Entity\View;
  * hard dependencies MukurtuSubmissionsKernelTestBase deliberately
  * excludes; the field's *behavior*, not the rest of mukurtu_core, is what's
  * under test.
- *
- * @group mukurtu_submissions
  */
+#[Group('mukurtu_submissions')]
 class ServiceAccountVisibilityTest extends MukurtuSubmissionsKernelTestBase {
 
   /**
@@ -101,8 +102,8 @@ class ServiceAccountVisibilityTest extends MukurtuSubmissionsKernelTestBase {
   }
 
   /**
-   * @dataProvider providePeopleViewIds
    */
+  #[DataProvider('providePeopleViewIds')]
   public function testViewsQueryAlterExcludesServiceAccount(string $view_id): void {
     $service_account = User::create(['name' => 'Submission Forms', 'status' => 0]);
     $service_account->save();

--- a/modules/mukurtu_submissions/tests/src/Kernel/SubmissionAccessCheckTest.php
+++ b/modules/mukurtu_submissions/tests/src/Kernel/SubmissionAccessCheckTest.php
@@ -9,15 +9,15 @@ use Drupal\mukurtu_submissions\Access\SubmissionAccessCheck;
 use Drupal\mukurtu_submissions\Entity\SubmissionSettings;
 use Drupal\user\Entity\Role;
 use Drupal\user\UserInterface;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests SubmissionAccessCheck::access() directly against every branch -
  * none of this module's other kernel tests exercise this class at all,
  * they only cover the role-permission layer one step removed from it
  * (e.g. ReviewerPermissionSyncTest, EntityBrowserPermissionSyncTest).
- *
- * @group mukurtu_submissions
  */
+#[Group('mukurtu_submissions')]
 class SubmissionAccessCheckTest extends MukurtuSubmissionsKernelTestBase {
 
   const PERMISSION = 'submit node ' . self::TEST_BUNDLE . ' content';

--- a/modules/mukurtu_submissions/tests/src/Kernel/SubmissionReceivedNotificationRenderingTest.php
+++ b/modules/mukurtu_submissions/tests/src/Kernel/SubmissionReceivedNotificationRenderingTest.php
@@ -10,6 +10,7 @@ use Drupal\filter\Entity\FilterFormat;
 use Drupal\message\Entity\Message;
 use Drupal\message\Entity\MessageTemplate;
 use Drupal\node\Entity\Node;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Regression guard for the mukurtu_submission_received template's link
@@ -39,9 +40,8 @@ use Drupal\node\Entity\Node;
  * the bug is in core's own filter_html behavior, not anything
  * mukurtu_html-specific, so this stays independent of that format's own
  * config.
- *
- * @group mukurtu_submissions
  */
+#[Group('mukurtu_submissions')]
 class SubmissionReceivedNotificationRenderingTest extends MukurtuSubmissionsKernelTestBase {
 
   /**

--- a/modules/mukurtu_submissions/tests/src/Kernel/SubmissionReviewStatusSyncTest.php
+++ b/modules/mukurtu_submissions/tests/src/Kernel/SubmissionReviewStatusSyncTest.php
@@ -5,19 +5,19 @@ declare(strict_types=1);
 namespace Drupal\Tests\mukurtu_submissions\Kernel;
 
 use Drupal\KernelTests\Core\Entity\EntityKernelTestBase;
+use Drupal\Tests\content_moderation\Traits\ContentModerationTestTrait;
 use Drupal\mukurtu_submissions\Entity\SubmissionInterface;
 use Drupal\node\Entity\Node;
 use Drupal\node\Entity\NodeType;
-use Drupal\Tests\content_moderation\Traits\ContentModerationTestTrait;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests mukurtu_submissions_node_update(), which keeps a mukurtu_submission
  * entity's review_status in sync with its node's moderation state so the
  * Pending Submissions queue (filtered on review_status = pending) actually
  * empties once a reviewer publishes the submission.
- *
- * @group mukurtu_submissions
  */
+#[Group('mukurtu_submissions')]
 class SubmissionReviewStatusSyncTest extends EntityKernelTestBase {
 
   use ContentModerationTestTrait;

--- a/modules/mukurtu_submissions/tests/src/Kernel/SubmissionSettingsCollectionFormTest.php
+++ b/modules/mukurtu_submissions/tests/src/Kernel/SubmissionSettingsCollectionFormTest.php
@@ -7,14 +7,14 @@ namespace Drupal\Tests\mukurtu_submissions\Kernel;
 use Drupal\Core\Form\FormState;
 use Drupal\mukurtu_submissions\Form\SubmissionSettingsCollectionForm;
 use Drupal\user\Entity\User;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests the "Submission Forms" collection page, which now combines the
  * per-content-type submission settings list with the notify_uids setting
  * on one page/route instead of two.
- *
- * @group mukurtu_submissions
  */
+#[Group('mukurtu_submissions')]
 class SubmissionSettingsCollectionFormTest extends MukurtuSubmissionsKernelTestBase {
 
   /**

--- a/modules/mukurtu_submissions/tests/src/Kernel/SubmissionsNamingUpdateTest.php
+++ b/modules/mukurtu_submissions/tests/src/Kernel/SubmissionsNamingUpdateTest.php
@@ -5,15 +5,15 @@ declare(strict_types=1);
 namespace Drupal\Tests\mukurtu_submissions\Kernel;
 
 use Drupal\user\Entity\User;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests the "Public Submissions" -> "Submission Forms" naming cleanup:
  * permission titles still resolve under their unchanged machine names, and
  * mukurtu_submissions_update_40002() only renames a service account whose
  * name still matches the old default.
- *
- * @group mukurtu_submissions
  */
+#[Group('mukurtu_submissions')]
 class SubmissionsNamingUpdateTest extends MukurtuSubmissionsKernelTestBase {
 
   /**

--- a/modules/mukurtu_submissions/tests/src/Kernel/ThankYouMessageTest.php
+++ b/modules/mukurtu_submissions/tests/src/Kernel/ThankYouMessageTest.php
@@ -6,14 +6,14 @@ namespace Drupal\Tests\mukurtu_submissions\Kernel;
 
 use Drupal\mukurtu_submissions\Controller\ThankYouController;
 use Drupal\mukurtu_submissions\Entity\SubmissionSettings;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests that the thank-you page renders a configured custom message when
  * one is set, falls back to the generic message otherwise, and carries the
  * settings entity's cache tags so edits to it invalidate the cached page.
- *
- * @group mukurtu_submissions
  */
+#[Group('mukurtu_submissions')]
 class ThankYouMessageTest extends MukurtuSubmissionsKernelTestBase {
 
   protected function viewThankYouPage(): array {

--- a/modules/mukurtu_submissions/tests/src/Unit/SubmissionWidgetOverrideTest.php
+++ b/modules/mukurtu_submissions/tests/src/Unit/SubmissionWidgetOverrideTest.php
@@ -11,6 +11,7 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Tests\UnitTestCase;
 use Drupal\mukurtu_submissions\SubmissionFormDisplayManager;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests that the public submission form always gets an accessible widget
@@ -18,8 +19,8 @@ use Drupal\mukurtu_submissions\SubmissionFormDisplayManager;
  * form display uses.
  *
  * @see \Drupal\mukurtu_submissions\SubmissionFormDisplayManager::applySubmissionWidgetOverride()
- * @group mukurtu_submissions
  */
+#[Group('mukurtu_submissions')]
 class SubmissionWidgetOverrideTest extends UnitTestCase {
 
   /**

--- a/modules/mukurtu_taxonomy/tests/src/Kernel/TaxonomyReferencesViewLanguageFallbackTest.php
+++ b/modules/mukurtu_taxonomy/tests/src/Kernel/TaxonomyReferencesViewLanguageFallbackTest.php
@@ -6,6 +6,7 @@ namespace Drupal\Tests\mukurtu_taxonomy\Kernel;
 
 use Drupal\Core\Config\FileStorage;
 use Drupal\KernelTests\KernelTestBase;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests mukurtu_taxonomy_update_40020().
@@ -17,8 +18,8 @@ use Drupal\KernelTests\KernelTestBase;
  * and that running it twice is a no-op.
  *
  * @see \mukurtu_taxonomy_update_40020()
- * @group mukurtu_taxonomy
  */
+#[Group('mukurtu_taxonomy')]
 class TaxonomyReferencesViewLanguageFallbackTest extends KernelTestBase {
 
   /**

--- a/modules/mukurtu_taxonomy/tests/src/Kernel/TaxonomyTermViewLanguageFallbackTest.php
+++ b/modules/mukurtu_taxonomy/tests/src/Kernel/TaxonomyTermViewLanguageFallbackTest.php
@@ -6,6 +6,7 @@ namespace Drupal\Tests\mukurtu_taxonomy\Kernel;
 
 use Drupal\Core\Config\FileStorage;
 use Drupal\KernelTests\KernelTestBase;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests mukurtu_taxonomy_update_40019().
@@ -15,8 +16,8 @@ use Drupal\KernelTests\KernelTestBase;
  * confirms it fills them back in - and that running it twice is a no-op.
  *
  * @see \mukurtu_taxonomy_update_40019()
- * @group mukurtu_taxonomy
  */
+#[Group('mukurtu_taxonomy')]
 class TaxonomyTermViewLanguageFallbackTest extends KernelTestBase {
 
   /**

--- a/modules/mukurtu_workflows/tests/src/Kernel/ReviewStateFormTest.php
+++ b/modules/mukurtu_workflows/tests/src/Kernel/ReviewStateFormTest.php
@@ -5,11 +5,12 @@ declare(strict_types=1);
 namespace Drupal\Tests\mukurtu_workflows\Kernel;
 
 use Drupal\Core\Form\FormState;
-use Drupal\mukurtu_protocol\Plugin\Field\FieldType\CulturalProtocolItem;
-use Drupal\node\Entity\Node;
 use Drupal\Tests\content_moderation\Traits\ContentModerationTestTrait;
 use Drupal\Tests\mukurtu_protocol\Kernel\ProtocolAwareEntityTestBase;
+use Drupal\mukurtu_protocol\Plugin\Field\FieldType\CulturalProtocolItem;
+use Drupal\node\Entity\Node;
 use Drupal\user\Entity\Role;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests that ReviewStateForm enforces the same required-field validation
@@ -20,9 +21,8 @@ use Drupal\user\Entity\Role;
  * bypassing EntityFormDisplay entirely - a plain save never validates on
  * its own, so without an explicit validate() call, a node could reach the
  * "published" moderation state without a required Cultural Protocol.
- *
- * @group mukurtu_workflows
  */
+#[Group('mukurtu_workflows')]
 class ReviewStateFormTest extends ProtocolAwareEntityTestBase {
 
   use ContentModerationTestTrait;

--- a/modules/mukurtu_workflows/tests/src/Kernel/WorkflowOverviewViewLanguageFallbackTest.php
+++ b/modules/mukurtu_workflows/tests/src/Kernel/WorkflowOverviewViewLanguageFallbackTest.php
@@ -6,6 +6,7 @@ namespace Drupal\Tests\mukurtu_workflows\Kernel;
 
 use Drupal\Core\Config\FileStorage;
 use Drupal\KernelTests\KernelTestBase;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests mukurtu_workflows_update_40007().
@@ -15,8 +16,8 @@ use Drupal\KernelTests\KernelTestBase;
  * confirms it fills them back in - and that running it twice is a no-op.
  *
  * @see \mukurtu_workflows_update_40007()
- * @group mukurtu_workflows
  */
+#[Group('mukurtu_workflows')]
 class WorkflowOverviewViewLanguageFallbackTest extends KernelTestBase {
 
   /**

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -57,56 +57,6 @@
     <testsuite name="kernel">
       <directory>web/profiles/mukurtu/modules/**/tests/src/Kernel</directory>
     </testsuite>
-    <testsuite name="kernel">
-      <directory>web/profiles/mukurtu/modules/mukurtu_collection/tests/src/Kernel</directory>
-    </testsuite>
-    <testsuite name="kernel">
-      <directory>web/profiles/mukurtu/modules/mukurtu_import/tests/src/Kernel</directory>
-    </testsuite>
-    <testsuite name="kernel">
-      <directory>web/profiles/mukurtu/modules/mukurtu_export/tests/src/Kernel</directory>
-    </testsuite>
-    <testsuite name="kernel">
-      <directory>web/profiles/mukurtu/modules/mukurtu_drafts/tests/src/Kernel</directory>
-    </testsuite>
-    <testsuite name="kernel">
-      <directory>web/profiles/mukurtu/modules/original_date/tests/src/Kernel</directory>
-    </testsuite>
-    <testsuite name="kernel">
-      <directory>web/profiles/mukurtu/modules/mukurtu_local_contexts/tests/src/Kernel</directory>
-    </testsuite>
-    <testsuite name="kernel">
-      <directory>web/profiles/mukurtu/modules/mukurtu_migrate/tests/src/Kernel</directory>
-    </testsuite>
-    <testsuite name="kernel">
-      <directory>web/profiles/mukurtu/modules/mukurtu_landing_page/tests/src/Kernel</directory>
-    </testsuite>
-    <testsuite name="kernel">
-      <directory>web/profiles/mukurtu/modules/mukurtu_browse/tests/src/Kernel</directory>
-      <directory>web/profiles/mukurtu/modules/mukurtu_core/tests/src/Kernel</directory>
-    </testsuite>
-    <testsuite name="kernel">
-      <directory>web/profiles/mukurtu/modules/mukurtu_dictionary/tests/src/Kernel</directory>
-    </testsuite>
-    <testsuite name="kernel">
-      <directory>web/profiles/mukurtu/modules/mukurtu_digital_heritage/tests/src/Kernel</directory>
-    </testsuite>
-    <testsuite name="kernel">
-      <directory>web/profiles/mukurtu/modules/mukurtu_person/tests/src/Kernel</directory>
-    </testsuite>
-    <testsuite name="kernel">
-      <directory>web/profiles/mukurtu/modules/mukurtu_place/tests/src/Kernel</directory>
-    </testsuite>
-    <testsuite name="kernel">
-      <directory>web/profiles/mukurtu/modules/mukurtu_notifications/tests/src/Kernel</directory>
-    </testsuite>
-    <testsuite name="kernel">
-      <directory>web/profiles/mukurtu/modules/mukurtu_gin_custom/tests/src/Kernel</directory>
-    </testsuite>
-    <testsuite name="kernel">
-      <directory>web/profiles/mukurtu/modules/mukurtu_solr/tests/src/Kernel</directory>
-      <directory>web/profiles/mukurtu/modules/mukurtu_submissions/tests/src/Kernel</directory>
-    </testsuite>
     <testsuite name="unit">
       <directory>web/profiles/mukurtu/modules/**/tests/src/Unit</directory>
     </testsuite>


### PR DESCRIPTION
## Summary

CI's "Mukurtu Tests" step has been failing (exit 1) even when every test passes, on `main` and on unrelated PRs (e.g. #2026) alike. All 811+ tests pass with zero failures/errors, but `phpunit.xml` sets `failOnWarning="true"`, and the suite had accumulated:

- **152 PHPUnit Warnings** and **516 PHPUnit Deprecations** — legacy `@group`/`@dataProvider`/`@covers`/`@coversDefaultClass` doc-comment metadata that PHPUnit 12 will stop supporting. This follows the same migration already merged in #1842 and #1953, extended to the remaining files.
- **4 native PHP deprecations**:
  - Two `renderInIsolation()` calls in `mukurtu_submissions.module` passed a method-call result directly to a by-reference parameter ("Only variables should be passed by reference"). Fixed by assigning to a variable first.
  - Three `fgetcsv()`/`fputcsv()`/`str_getcsv()` calls were missing the now-required `$escape` parameter. Fixed by passing the current default explicitly, matching #1841.

No test behavior changes: this is a mechanical metadata migration plus two narrowly-scoped deprecation fixes. Verified locally (`~/ddev/multilingual`) that the full kernel suite's `PHPUnit Warnings`/`PHPUnit Deprecations` counts drop to 0. A full local kernel run (805 tests) shows 8 errors and 1 failure remaining, all confirmed pre-existing and unrelated to this change (stale `entity_browser` "single" widget plugin in the local dev site's vendor install, and an unrelated `DashboardLinkCleanupTest` permission assertion) — reproduced identically against the unmodified files on `main`.

## Pre-merge checklist:

- [x] I have checked for and if required, created update hooks. (N/A — no schema/config changes)
- [x] I have run an accessibility check, and resolved any issues. (N/A — no UI changes)
- [x] I have recompiled SCSS if required. (N/A — no SCSS changes)
- [x] I have updated or created CI/CD tests, if required. (N/A — this PR fixes the CI test infrastructure itself)
- [x] I have updated from `main` and resolved any merge conflicts.
- [x] If this PR's base branch is not `main`, I understand it needs to be retargeted once that base branch's own PR merges (see [docs/stacked-prs.md](../docs/stacked-prs.md)). (N/A — based on `main`)
- [ ] I have verified that all expected checks pass. (Verified locally; a small number of pre-existing, unrelated local-environment failures could not be verified against the GitHub Actions runner directly — see summary above)
- [x] I have run the pr-expert-review skill and resolved all relevant issues.
- [x] If I added a content entity bundle, I added its `language.content_settings` and base field overrides to `mukurtu_multilingual` (see `docs/content-language-policy.md`). If I added or changed a view, I applied the content language policy in that doc. (N/A)
