### PR TITLE
Bump drupal/tagify to ^2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -74,7 +74,7 @@
         "drupal/search_api": "*",
         "drupal/search_api_glossary": "*",
         "drupal/search_api_solr": "^4.3",
-        "drupal/tagify": "^1.2",
+        "drupal/tagify": "^2.0",
         "drupal/term_merge": "^2.0@beta",
         "drupal/term_merge_manager": "^2.0",
         "drupal/token": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a1de3d6e1ccd6695b155bf61ca4b7a04",
+    "content-hash": "48de89bcc74ce59f145b8508a2baac01",
     "packages": [
         {
             "name": "altcha-org/altcha",
@@ -5377,23 +5377,23 @@
         },
         {
             "name": "drupal/tagify",
-            "version": "1.2.53",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/tagify.git",
-                "reference": "1.2.53"
+                "reference": "2.0.2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/tagify-1.2.53.zip",
-                "reference": "1.2.53",
-                "shasum": "99ce29f5643b4e7965623819dcd69059a9a16e96"
+                "url": "https://ftp.drupal.org/files/projects/tagify-2.0.2.zip",
+                "reference": "2.0.2",
+                "shasum": "4e8adc37dcfa52516b1d6471268c106ae94de19f"
             },
             "require": {
-                "drupal/core": "^8.8 || ^9 || ^10 || ^11"
+                "drupal/core": "^10.3 || ^11 || ^12"
             },
             "require-dev": {
-                "drupal/better_exposed_filters": "^7.0",
+                "drupal/better_exposed_filters": "^7.1",
                 "drupal/facets": "^2.0",
                 "drupal/iconify_icons": "*",
                 "drupal/search_api": "^1.31",
@@ -5403,8 +5403,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "1.2.53",
-                    "datestamp": "1781686801",
+                    "version": "2.0.2",
+                    "datestamp": "1781686703",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"


### PR DESCRIPTION
## Summary
- Bumps `drupal/tagify` `1.2.53` -> `2.0.2` (constraint `^1.2` -> `^2.0`), part of the deferred dependency sweep tracked in #2087.
- This is by far the deepest Mukurtu coupling of the bumps done for #2087 so far:
  - The `tagify_entity_reference_autocomplete_widget` field widget plugin is used across roughly 60 field/bundle `config/install` YAML entries spanning 8 custom modules (`mukurtu_collection`, `mukurtu_dictionary`, `mukurtu_media`, `mukurtu_place`, `mukurtu_digital_heritage`, `mukurtu_person`, `mukurtu_submissions`, and consumed via `mukurtu_protocol`'s dependency).
  - The `entity_autocomplete_tagify` form element type is used directly (with a hard-coded `tagify/gin` library attach and `json_decode()` of the submitted value) in 3 custom forms: `PersonalCollectionAddItemForm`, `MukurtuAddItemToCollectionForm`, `MukurtuAddWordToListForm`.
  - `modules/mukurtu_core/js/mukurtu-tagify-override.js` and `modules/mukurtu_gin_custom/js/mukurtu-tagify-focus.js` reach directly into the Tagify JS instance's internals (`element.__tagify`, `instance.settings.delimiters`, `.tagify__input`/`.tagify__tag`/`.tagify__dropdown` class names), and `themes/mukurtu_v4`'s `_textfield.scss` styles against tagify's own CSS internals.
  - `modules/mukurtu_core/mukurtu_core.install`'s `mukurtu_core_update_40005()` sets `tagify.settings:set_default_widget` via the config API.
- Verified via static diff against the vendored 1.2.53 source and the downloaded 2.0.2 release tarball (same testing constraint noted in #2099/#2100: composer install isn't runnable at this repo's root, and the local DDEV sandbox couldn't be started in this environment - see Test plan) that every one of those surfaces is unchanged:
  - The widget plugin ID (`tagify_entity_reference_autocomplete_widget`) and form element ID (`entity_autocomplete_tagify`) are identical, as is the `valueCallback()` method body (only a return-type hint was added).
  - `config/schema/tagify.schema.yml` and `config/install/tagify.settings.yml` are byte-identical between versions, so the ~60 existing field configs and `mukurtu_core_update_40005()`'s config key remain valid - no update hook needed.
  - `match_operator`/`suggestions_dropdown` widget settings were refactored into PHP backed enums (`MatchOperator`, `SuggestionsDropdown`), but their docblocks explicitly note they're backed by the exact same persisted values, confirmed directly: `STARTS_WITH`/`CONTAINS` and `0`/`1`.
  - The bundled Tagify JS library itself stays pinned at **4.35.4**, loaded from the same cdnjs URL - completely unchanged, so Mukurtu's direct coupling to its instance API and CSS class names is unaffected. Drupal's own JS wrapper (`tagify.js`) was refactored to drop the `core/jquery` dependency and extract shared helpers into a new `tagify.helpers.js` library, but the `add`/`remove`/`change`/`dropdown:show` event wiring Mukurtu's overrides listen to is byte-identical.
  - A latent bug in `EntityAutocompleteTagify::getTagifyDefaultValue()` was fixed upstream: `parent_name` for hierarchical taxonomy terms was being attached to the wrong array level and never actually applied (a dead `getEntityType() == 'taxonomy_term'` object-to-string comparison). This is a minor behavioral improvement (adds a new per-tag data key for hierarchical terms), not a regression risk.
- No patches in `extra.patches` target `drupal/tagify`.

## Test plan
- [x] `composer validate --no-check-all --strict` passes (only the same pre-existing "no license specified" warning noted in prior PRs in this series).
- [x] `composer audit` reports no security vulnerability advisories.
- [x] `composer.lock` diff confirmed to touch only `drupal/tagify` itself - no other packages moved.
- [x] `scripts/lint/multilingual-guardrails.sh` passes (no UI strings touched).
- [ ] **Not completed**: a live functional and accessibility check in a running site - the local DDEV sandbox (`~/ddev/multilingual`) could not be started in this environment (Rosetta/ARM64 mismatch, unrelated to this change; same limitation noted in #2099/#2100). Given the depth of coupling here, a reviewer with a working local environment should specifically check: the tag widget on a content type using `field_keywords`/`field_contributor`/etc., the three custom "add to collection/word list" forms, adding/removing tags with keyboard-only navigation (per #2087's explicit call to re-run the accessibility check on tag widgets), and the Gin-sidebar dropdown styling. CI's `testing` job builds a full site via `mukurtu/mukurtu-template:dev-main` and should be checked once it runs.

## Pre-merge checklist
- [x] I have checked for and if required, created update hooks. (Not required: `tagify.settings` and widget-settings config schema/defaults are unchanged between 1.2.53 and 2.0.2.)
- [ ] I have run an accessibility check, and resolved any issues. (No Mukurtu markup/CSS changed by this PR itself, and the bundled Tagify JS/CSS is unchanged at 4.35.4; see Test plan for the outstanding live keyboard-navigation check #2087 specifically calls for.)
- [x] I have recompiled SCSS if required. (Not applicable: no SCSS touched - `_textfield.scss`'s tagify styling was verified against 2.0.2's unchanged `tagify.css`.)
- [ ] I have updated or created CI/CD tests, if required.
- [x] I have updated from `main` and resolved any merge conflicts.
- [x] If this PR's base branch is not `main`, I understand it needs to be retargeted once that base branch's own PR merges. (Base is `main`.)
- [ ] I have verified that all expected checks pass.
- [x] I have run the pr-expert-review skill and resolved all relevant issues.
- [x] If I added a content entity bundle... (Not applicable.)

Part of #2087.

🤖 Generated with [Claude Code](https://claude.com/claude-code)