### PR TITLE
Fix stale config.installer proxy in ModuleInstaller's Optional/SiteOptional passes

### DIFF
--- a/patches/module-installer-stale-config-installer-proxy.patch
+++ b/patches/module-installer-stale-config-installer-proxy.patch
@@ -9,7 +9,13 @@
 # kernel" errors when ClassResolver tries to resolve OOP hook classes.
 #
 # Fix: re-fetch \Drupal::service('config.installer') each loop iteration so a
-# fresh proxy from the current container is always used.
+# fresh proxy from the current container is always used. This must cover the
+# Optional and SiteOptional passes too, not just InstallEntities: they run after
+# the same per-module hook_install() invocations that can trigger a rebuild, and
+# reusing the single $config_installer fetched before InstallEntities left them
+# just as exposed to a stale proxy (in fact, with $config_installer's only
+# assignment removed by this patch's own InstallEntities fix, leaving these two
+# loops unpatched would reference an undefined variable entirely).
 #
 # Upstream: this fix should be filed against Drupal core at
 # https://www.drupal.org/project/drupal/issues — search for
@@ -33,7 +39,7 @@
 
        // Set the schema version to the number of the last update provided by
        // the module, or the minimum core schema version.
-@@ -442,10 +441,11 @@
+@@ -439,30 +438,33 @@
      // requires the library discovery cache to be rebuilt.
      \Drupal::service('library.discovery')->clear();
 
@@ -48,11 +54,18 @@
 
        // Allow the module to perform install tasks.
        $this->invoke($module, 'install', [$sync_status]);
-@@ -458,14 +458,14 @@
+
+       // Record the fact that it was installed.
+       \Drupal::logger('system')->info('%module module installed.', ['%module' => $module]);
+     }
+
+     // Install optional configuration from modules once all the modules have
      // been properly installed. This is often where soft dependencies lie.
      // @todo This code fixes \Drupal\Tests\help\Functional\HelpTest::testHelp().
      foreach ($module_list as $module) {
 -      $config_installer->installDefaultConfig('module', $module, DefaultConfigMode::Optional);
++      // Re-fetch config.installer each iteration; see the InstallEntities pass
++      // above for why a cached proxy is unsafe here too.
 +      \Drupal::service('config.installer')->installDefaultConfig('module', $module, DefaultConfigMode::Optional);
      }
      // Install optional configuration from other modules once all the modules
@@ -63,5 +76,3 @@
 -      $config_installer->installDefaultConfig('module', $module, DefaultConfigMode::SiteOptional);
 +      \Drupal::service('config.installer')->installDefaultConfig('module', $module, DefaultConfigMode::SiteOptional);
      }
-
-     if (count($module_list) > 1) {


### PR DESCRIPTION
## Summary
- Extends the existing hand-written core patch `patches/module-installer-stale-config-installer-proxy.patch` (applied to `drupal/core` via `composer.json`'s `extra.patches`) to also re-fetch `\Drupal::service('config.installer')` fresh on each iteration of `ModuleInstaller::doInstall()`'s `Optional` and `SiteOptional` passes, matching the fix already applied to the earlier `InstallSimple`/`InstallEntities` passes.
- The old patch removed the only assignment to `$config_installer` (as part of fixing `InstallEntities`) but left the two later loops still referencing that now-undefined variable — a real bug in the patch itself, independent of the container-rebuild issue it was meant to fix.
- Root-caused while investigating why PR #2099's Tugboat preview rejected `admin`/`admin` login: the build log showed `drush site-install` crashing with `ContainerBuilder: You have requested a synthetic service ("kernel")` immediately after `install_profile_themes`, before the admin account ever gets created. Recently-bumped modules (`drupal/genpass` ^3.0 in #2100, `drupal/tagify` ^2.0 in #2102) migrated to Drupal's OOP `#[Hook]` system, and the `mukurtu` profile's own `hook_install()` (`mukurtu_install()`) loads/saves several config entities in the same install batch — exercising this previously-dormant stale-proxy code path for the first time.
- This isn't specific to #2099: Tugboat always deletes `composer.lock` and does a fresh `composer update --prefer-stable`, so every currently-open PR's preview resolves the same dependency set and should hit the same crash.

## Test plan
- [x] Verified the patch applies cleanly against the vendored `drupal/core` 11.4.4 source via `patch -p1 --dry-run` and `patch -p1`.
- [x] Confirmed the resulting `ModuleInstaller.php` passes `php -l` (no syntax errors).
- [ ] **Not completed in this environment**: a live `drush site-install` end-to-end run (this repo's bare profile checkout can't run a full Drupal install locally - see prior sandbox notes). This PR's own Tugboat preview build is the first real end-to-end check: watch for the build to complete past `install_finished` and confirm `admin`/`admin` login works (the `playwright-tests` GitHub Actions job's login step is a ready-made automated check for this).

## Pre-merge checklist
- [x] I have checked for and if required, created update hooks. (Not applicable: this only changes a vendor patch file, no Drupal config/schema changes.)
- [x] I have run an accessibility check, and resolved any issues. (Not applicable: no user-facing markup/CSS changed.)
- [x] I have recompiled SCSS if required. (Not applicable: no SCSS touched.)
- [x] I have updated or created CI/CD tests, if required. (Not applicable: this is a fix to a vendor patch exercised by every site install; existing Tugboat/Playwright CI is the verification path.)
- [x] I have updated from `main` and resolved any merge conflicts.
- [x] If this PR's base branch is not `main`, I understand it needs to be retargeted once that base branch's own PR merges. (Base is `main`.)
- [ ] I have verified that all expected checks pass. (Pending this PR's own Tugboat build/Playwright run.)
- [ ] I have run the pr-expert-review skill and resolved all relevant issues.
- [x] If I added a content entity bundle... (Not applicable.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)