### PR TITLE
Force fresh vendor install every Tugboat build to keep patches applied

### DIFF
--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -64,6 +64,23 @@ services:
           chown www-data:www-data web/sites/default/settings.php
           # Update composer dependencies.
           rm composer.lock
+          # Force a fresh install of every patched package, not just an
+          # incremental update. Tugboat previews run in a persistent
+          # container that carries vendor/ forward across every build on
+          # the same PR, so composer only reinstalls (and re-patches) a
+          # package when its *locked version* changes. A package whose
+          # version never changes across the PR's lifetime - most notably
+          # drupal/core, which stays pinned below - never gets its patches
+          # (re)applied, silently drifting from whatever composer.json's
+          # extra.patches currently specifies. Removing vendor/ here makes
+          # every build fully reinstall from the freshly written lock file,
+          # so patches are always verified and reapplied regardless of
+          # whether this is a brand-new preview or one that has been
+          # rebuilding the same PR for weeks (see
+          # patches/module-installer-stale-config-installer-proxy.patch,
+          # which sat un-reapplied on one long-lived preview for exactly
+          # this reason).
+          rm -rf vendor
           # Patch the template's composer.json to require Drupal 11.4.x and
           # ignore the symfony/polyfill-intl-idn advisory. composer config
           # does not support setting audit.ignore keys, so patch directly.


### PR DESCRIPTION
## Summary
- Adds `rm -rf vendor` alongside the existing `rm composer.lock` in `.tugboat/config.yml`'s `build` phase, before `composer update`.
- Tugboat previews run in a persistent container whose `vendor/` carries forward across every build on the same PR. Composer only reinstalls (and re-applies `extra.patches` for) a package when its *locked version* changes - a package whose version never changes across a PR's lifetime never gets its patches (re)applied, silently drifting from whatever `composer.json` currently specifies.
- This is exactly what caused PR #2099's Tugboat preview to keep rejecting `admin`/`admin` login even after #2105 fixed the underlying `ModuleInstaller` bug: that preview's container predated the fix, `drupal/core` never showed up in any build's "updates" list (still pinned to `11.4.4` the whole time), so its patched-vs-unpatched state was frozen at whenever the container was first created - only a full manual container rebuild (via Tugboat's dashboard) picked up the fix.
- Forcing a full `vendor/` reinstall every build makes patch application deterministic: every build always reflects the current `composer.json`/`patches/*.patch`, whether it's a preview's first build or its five-hundredth.

## Test plan
- [x] Validated `.tugboat/config.yml` is still well-formed YAML.
- [ ] **Not completed in this environment**: this can only really be verified by watching this PR's own Tugboat build - confirm it completes successfully and takes a similar/acceptable amount of build time despite the added full reinstall (Composer's local package cache should make this fast; it isn't a fresh network download per package).

## Pre-merge checklist
- [x] I have checked for and if required, created update hooks. (Not applicable: build-script-only change, no Drupal config/schema.)
- [x] I have run an accessibility check, and resolved any issues. (Not applicable: no user-facing markup/CSS changed.)
- [x] I have recompiled SCSS if required. (Not applicable: no SCSS touched.)
- [x] I have updated or created CI/CD tests, if required. (Not applicable: this *is* the CI/CD build script; existing Tugboat build + Playwright login test are the verification path.)
- [x] I have updated from `main` and resolved any merge conflicts.
- [x] If this PR's base branch is not `main`, I understand it needs to be retargeted once that base branch's own PR merges. (Base is `main`.)
- [ ] I have verified that all expected checks pass. (Pending this PR's own Tugboat build.)
- [ ] I have run the pr-expert-review skill and resolved all relevant issues.
- [x] If I added a content entity bundle... (Not applicable.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)