### PR TITLE
Fix CSV export crash on Layout Builder section fields

### DIFF
--- a/modules/mukurtu_export/src/Entity/CsvExporter.php
+++ b/modules/mukurtu_export/src/Entity/CsvExporter.php
@@ -471,6 +471,13 @@ class CsvExporter extends ConfigEntityBase implements EntityOwnerInterface {
         continue;
       }
 
+      // Layout Builder's per-entity section field stores structured
+      // Section objects, not exportable scalar/reference data -- skip it
+      // like a computed field rather than offering it as a mappable column.
+      if ($field_def->getType() === 'layout_section') {
+        continue;
+      }
+
       // Passwords and internal login bookkeeping fields must never be
       // exportable. Keep in sync with ImportFormTrait::getFieldDefinitions()'s
       // equivalent exclusion in modules/mukurtu_import.

--- a/modules/mukurtu_export/src/EventSubscriber/CsvEntityFieldExportEventSubscriber.php
+++ b/modules/mukurtu_export/src/EventSubscriber/CsvEntityFieldExportEventSubscriber.php
@@ -132,11 +132,25 @@ class CsvEntityFieldExportEventSubscriber implements EventSubscriberInterface {
       return $this->exportTimestamp($event, $field);
     }
 
+    // Layout Builder's per-entity section field stores structured Section
+    // objects with no meaningful flat CSV representation. New export
+    // configs no longer offer this field (see CsvExporter::getMappedFields()),
+    // but a config saved before that exclusion existed may still have it
+    // mapped, so guard here too rather than letting it reach the default
+    // handling below.
+    if ($fieldType == 'layout_section') {
+      $event->setValue([]);
+      return;
+    }
+
     // Default handling.
     $values = $entity->get($field_name)->getValue();
     $exportValue = [];
     foreach ($values as $value) {
-      $exportValue[] = is_array($value) ? reset($value) : $value;
+      $extracted = is_array($value) ? reset($value) : $value;
+      // Guard against field types whose getValue() returns a non-scalar
+      // (e.g. an object) that implode() in CSV::export() cannot stringify.
+      $exportValue[] = is_scalar($extracted) ? $extracted : '';
     }
     $event->setValue($exportValue);
   }

--- a/modules/mukurtu_export/tests/src/Kernel/CsvExportLayoutBuilderFieldTest.php
+++ b/modules/mukurtu_export/tests/src/Kernel/CsvExportLayoutBuilderFieldTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\mukurtu_export\Kernel;
+
+use Drupal\layout_builder\Entity\LayoutBuilderEntityViewDisplay;
+use Drupal\layout_builder\Plugin\SectionStorage\OverridesSectionStorage;
+use Drupal\layout_builder\Section;
+use Drupal\mukurtu_export\Entity\CsvExporter;
+use Drupal\mukurtu_export\Event\EntityFieldExportEvent;
+use Drupal\node\Entity\Node;
+
+/**
+ * Test that a bundle's Layout Builder section field doesn't crash CSV export
+ * (the field stores structured Section objects, not exportable scalar data).
+ */
+class CsvExportLayoutBuilderFieldTest extends CsvExportFieldTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'layout_builder',
+    'layout_discovery',
+  ];
+
+  protected $node;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    // LayoutBuilderEntityViewDisplay::postSave() looks up reusable
+    // block_content entities; the entity type must exist even though this
+    // test doesn't create any.
+    $this->installEntitySchema('block_content');
+
+    LayoutBuilderEntityViewDisplay::create([
+      'targetEntityType' => 'node',
+      'bundle' => 'protocol_aware_content',
+      'mode' => 'default',
+      'status' => TRUE,
+    ])
+      ->enableLayoutBuilder()
+      ->setOverridable()
+      ->save();
+
+    $node = Node::create([
+      'title' => 'Testing Layout Builder Export',
+      'type' => 'protocol_aware_content',
+      'status' => TRUE,
+      'uid' => $this->currentUser->id(),
+      OverridesSectionStorage::FIELD_NAME => [
+        ['section' => new Section('layout_onecol')],
+      ],
+    ]);
+    $node->setSharingSetting('any');
+    $node->setProtocols([$this->protocol]);
+    $node->save();
+    $this->node = $node;
+  }
+
+  /**
+   * Exporting the section field must not crash (issue found via PR #2103
+   * testing: implode() cannot stringify the field's Section objects).
+   */
+  public function testLayoutBuilderFieldExportDoesNotCrash() {
+    $event = new EntityFieldExportEvent('csv', $this->node, OverridesSectionStorage::FIELD_NAME, $this->context);
+    $this->fieldExporter->exportField($event);
+    $this->assertSame([], $event->getValue());
+  }
+
+  /**
+   * New export configs should not offer the section field as mappable,
+   * since it has no meaningful flat CSV representation.
+   */
+  public function testLayoutBuilderFieldExcludedFromMappedFields() {
+    $exporter = CsvExporter::create([
+      'id' => 'test_layout_builder_exporter',
+      'label' => 'Test Layout Builder Exporter',
+    ]);
+
+    $fieldNames = array_column($exporter->getMappedFields('node', 'protocol_aware_content'), 'field_name');
+    $this->assertNotContains(OverridesSectionStorage::FIELD_NAME, $fieldNames);
+  }
+
+}


### PR DESCRIPTION
layout_builder__layout has field type layout_section, whose getValue() returns raw Drupal\layout_builder\Section objects. The generic CSV export field handler's implode() couldn't stringify that, so bulk exporting any bundle with Layout Builder overrides enabled (e.g. landing_page) threw a fatal error and left /admin/export/results inaccessible (its access check depends on a session key the failed batch never populated).

Exclude the field from new export configs' mappable field list, and guard the default field-export handler against any non-scalar value so existing configs with it already mapped stop crashing too.

## Pre-merge checklist:

- [ ] I have checked for and if required, created update hooks.
- [ ] I have run an accessibility check, and resolved any issues.
- [ ] I have recompiled SCSS if required.
- [ ] I have updated or created CI/CD tests, if required.
- [ ] I have updated from `main` and resolved any merge conflicts.
- [ ] If this PR's base branch is not `main`, I understand it needs to be retargeted once that base branch's own PR merges (see [docs/stacked-prs.md](../docs/stacked-prs.md)).
- [ ] I have verified that all expected checks pass.
- [ ] I have run the pr-expert-review skill and resolved all relevant issues.
- [ ] If I added a content entity bundle, I added its `language.content_settings` and base field overrides to `mukurtu_multilingual` (see `docs/content-language-policy.md`). If I added or changed a view, I applied the content language policy in that doc.

