### PR TITLE
Reorder default CSV export settings: local before external

### DIFF
--- a/modules/mukurtu_export/src/Plugin/MukurtuExporter/CSV.php
+++ b/modules/mukurtu_export/src/Plugin/MukurtuExporter/CSV.php
@@ -25,6 +25,17 @@ use Exception;
 )]
 class CSV extends ExporterBase {
   /**
+   * Entity IDs of the shipped default CSV export settings, in the order
+   * they should be listed ahead of any other site-wide settings.
+   */
+  protected const DEFAULT_EXPORTER_ORDER = [
+    'default_local_metadata_only',
+    'default_local_with_media',
+    'default_external_metadata_only',
+    'default_external_with_media',
+  ];
+
+  /**
    * {@inheritdoc}
    */
   public function defaultConfiguration() {
@@ -57,6 +68,10 @@ class CSV extends ExporterBase {
       ->execute();
     if (!empty($result)) {
       $entities = $storage->loadMultiple($result);
+      $order = array_flip(static::DEFAULT_EXPORTER_ORDER);
+      uksort($entities, function ($a, $b) use ($order) {
+        return ($order[$a] ?? count($order)) <=> ($order[$b] ?? count($order));
+      });
       foreach ($entities as $id => $entity) {
         $element['#options'][$id] = $entity->label();
         $links = [];

--- a/modules/mukurtu_export/tests/src/Kernel/CsvExporterSettingsOrderTest.php
+++ b/modules/mukurtu_export/tests/src/Kernel/CsvExporterSettingsOrderTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\mukurtu_export\Kernel;
+
+use Drupal\Core\Form\FormState;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\mukurtu_export\Entity\CsvExporter;
+
+/**
+ * Tests the display order of site-wide CSV export settings.
+ *
+ * The four shipped default presets must always be listed local-before-
+ * external, ahead of any other site-wide setting an admin creates.
+ *
+ * @see \Drupal\mukurtu_export\Plugin\MukurtuExporter\CSV::addSiteWideConfigOptions()
+ */
+class CsvExporterSettingsOrderTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'geofield',
+    'leaflet',
+    'mukurtu_core',
+    'mukurtu_export',
+    'mukurtu_multipage_items',
+  ];
+
+  /**
+   * The default csv_exporter preset IDs shipped by mukurtu_export.
+   */
+  protected const PRESET_IDS = [
+    'default_local_metadata_only',
+    'default_local_with_media',
+    'default_external_metadata_only',
+    'default_external_with_media',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installConfig(['mukurtu_export']);
+  }
+
+  /**
+   * Tests that the shipped defaults sort local-first, and other site-wide
+   * settings still fall back to alphabetical order after them.
+   */
+  public function testDefaultPresetsSortLocalBeforeExternal(): void {
+    // A custom site-wide setting whose label would otherwise sort
+    // alphabetically ahead of all four defaults, to confirm it still lands
+    // after them rather than jumping the explicit order.
+    CsvExporter::create([
+      'id' => 'aaa_custom_setting',
+      'label' => 'AAA Custom Setting',
+      'site_wide' => TRUE,
+    ])->save();
+
+    $plugin = \Drupal::service('plugin.manager.mukurtu_exporter')->createInstance('csv');
+    $form = $plugin->settingsForm([], new FormState());
+
+    $expected = array_merge(self::PRESET_IDS, ['aaa_custom_setting']);
+    $this->assertSame($expected, array_keys($form['export_settings']['#options']));
+    $this->assertSame('default_local_metadata_only', $form['export_settings']['#default_value']);
+  }
+
+}

--- a/modules/mukurtu_export/tests/src/Kernel/CsvExporterSettingsOrderTest.php
+++ b/modules/mukurtu_export/tests/src/Kernel/CsvExporterSettingsOrderTest.php
@@ -66,6 +66,7 @@ class CsvExporterSettingsOrderTest extends KernelTestBase {
       'id' => 'aaa_custom_setting',
       'label' => 'AAA Custom Setting',
       'site_wide' => TRUE,
+      'entity_fields_export_list' => [],
     ])->save();
 
     $plugin = \Drupal::service('plugin.manager.mukurtu_exporter')->createInstance('csv');

--- a/modules/mukurtu_export/tests/src/Kernel/CsvExporterSettingsOrderTest.php
+++ b/modules/mukurtu_export/tests/src/Kernel/CsvExporterSettingsOrderTest.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Drupal\Tests\mukurtu_export\Kernel;
 
+use Drupal\Core\Config\FileStorage;
 use Drupal\Core\Form\FormState;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\mukurtu_export\Entity\CsvExporter;
@@ -42,18 +43,22 @@ class CsvExporterSettingsOrderTest extends KernelTestBase {
   ];
 
   /**
-   * {@inheritdoc}
-   */
-  protected function setUp(): void {
-    parent::setUp();
-    $this->installConfig(['mukurtu_export']);
-  }
-
-  /**
    * Tests that the shipped defaults sort local-first, and other site-wide
    * settings still fall back to alphabetical order after them.
    */
   public function testDefaultPresetsSortLocalBeforeExternal(): void {
+    // Save the four shipped default presets from their install config,
+    // rather than installing all of mukurtu_export's config (which would
+    // also pull in config depending on modules, like flag, this test
+    // doesn't enable).
+    $module_path = \Drupal::service('extension.list.module')->getPath('mukurtu_export');
+    $source = new FileStorage($module_path . '/config/install');
+    foreach (self::PRESET_IDS as $id) {
+      $data = $source->read("mukurtu_export.csv_exporter.$id");
+      $this->assertNotFalse($data, "mukurtu_export.csv_exporter.$id should exist.");
+      CsvExporter::create($data)->save();
+    }
+
     // A custom site-wide setting whose label would otherwise sort
     // alphabetically ahead of all four defaults, to confirm it still lands
     // after them rather than jumping the explicit order.


### PR DESCRIPTION
## Summary
- On `/admin/export/settings`, the site-wide "Export Settings" radio list was sorted purely alphabetically by label, listing the two "Default external settings" presets ahead of the two "Default local settings" presets.
- `CSV::addSiteWideConfigOptions()` now applies an explicit display order for the four shipped defaults (local metadata-only, local with media, external metadata-only, external with media), while any other site-wide setting an admin creates still falls back to alphabetical order after them.
- This also changes which preset is pre-selected by default (`#default_value`), from "Default external settings (metadata only)" to "Default local settings (metadata only)", since it's now first in the list.

## Test plan
- [x] Added `CsvExporterSettingsOrderTest` (Kernel) asserting the four defaults appear in the new order and that a custom site-wide setting still sorts after them alphabetically.
- [ ] CI Kernel suite for `mukurtu_export` passes.
- [ ] Manually confirm `/admin/export/settings` shows: Default local settings (metadata only), Default local settings (with media assets), Default external settings (metadata only), Default external settings (with media assets), with the first one pre-selected.

## Pre-merge checklist:

- [x] I have checked for and if required, created update hooks. (Not required — pure code behavior change, no config/schema changes.)
- [x] I have run an accessibility check, and resolved any issues. (Not applicable — no markup/render-array structure changed, only entity order.)
- [x] I have recompiled SCSS if required. (Not required — no SCSS changes.)
- [x] I have updated or created CI/CD tests, if required.
- [x] I have updated from `main` and resolved any merge conflicts.
- [x] If this PR's base branch is not `main`, I understand it needs to be retargeted once that base branch's own PR merges (see [docs/stacked-prs.md](../docs/stacked-prs.md)). (N/A — base is `main`.)
- [ ] I have verified that all expected checks pass.
- [x] I have run the pr-expert-review skill and resolved all relevant issues.
- [x] If I added a content entity bundle, I added its `language.content_settings` and base field overrides to `mukurtu_multilingual` (see `docs/content-language-policy.md`). If I added or changed a view, I applied the content language policy in that doc. (N/A — no new bundle/view.)