### PR TITLE
Fix fatal error on taxonomy vocabulary manage pages (OverviewTerms entity form)

### DIFF
--- a/modules/mukurtu_taxonomy/src/Controller/MukurtuCategoryManageController.php
+++ b/modules/mukurtu_taxonomy/src/Controller/MukurtuCategoryManageController.php
@@ -15,8 +15,14 @@ class MukurtuCategoryManageController extends ControllerBase {
     $vocabulary = $this->entityTypeManager()->getStorage('taxonomy_vocabulary')->load('category');
 
     if ($vocabulary) {
-      // Render the taxonomy overview form.
-      $build[] = $this->formBuilder()->getForm('Drupal\taxonomy\Form\OverviewTerms', $vocabulary);
+      // Render the taxonomy overview form. OverviewTerms is the vocabulary
+      // entity type's "overview" form handler, so it needs the vocabulary set
+      // as its entity (for getFormId()/getBaseFormId()) as well as passed
+      // through as a build argument (for its buildForm() signature).
+      $overviewForm = $this->entityTypeManager()
+        ->getFormObject('taxonomy_vocabulary', 'overview')
+        ->setEntity($vocabulary);
+      $build[] = $this->formBuilder()->getForm($overviewForm, $vocabulary);
 
       // Render the form to add a new category.
       $newCategoryTerm = Term::create([

--- a/modules/mukurtu_taxonomy/src/Controller/MukurtuManageTaxonomyController.php
+++ b/modules/mukurtu_taxonomy/src/Controller/MukurtuManageTaxonomyController.php
@@ -30,8 +30,14 @@ class MukurtuManageTaxonomyController extends ControllerBase {
     $vocabulary = $this->entityTypeManager()->getStorage('taxonomy_vocabulary')->load($taxonomy_vocabulary);
 
     if ($vocabulary) {
-      // Render the taxonomy overview form.
-      $build[] = $this->formBuilder()->getForm('Drupal\taxonomy\Form\OverviewTerms', $vocabulary);
+      // Render the taxonomy overview form. OverviewTerms is the vocabulary
+      // entity type's "overview" form handler, so it needs the vocabulary set
+      // as its entity (for getFormId()/getBaseFormId()) as well as passed
+      // through as a build argument (for its buildForm() signature).
+      $overviewForm = $this->entityTypeManager()
+        ->getFormObject('taxonomy_vocabulary', 'overview')
+        ->setEntity($vocabulary);
+      $build[] = $this->formBuilder()->getForm($overviewForm, $vocabulary);
 
       // Render the form to add a new term.
       $newTerm = Term::create([

--- a/modules/mukurtu_taxonomy/tests/src/Kernel/MukurtuCategoryManageControllerTest.php
+++ b/modules/mukurtu_taxonomy/tests/src/Kernel/MukurtuCategoryManageControllerTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\mukurtu_taxonomy\Kernel;
+
+use Drupal\KernelTests\Core\Entity\EntityKernelTestBase;
+use Drupal\mukurtu_taxonomy\Controller\MukurtuCategoryManageController;
+use Drupal\taxonomy\Entity\Term;
+use Drupal\taxonomy\Entity\Vocabulary;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Tests that the Manage Categories page renders without a fatal error.
+ *
+ * `OverviewTerms` (the "category" vocabulary's `'overview'` form handler) was
+ * refactored in Drupal core to extend `EntityForm`, tied to the vocabulary
+ * entity. `MukurtuCategoryManageController::content()` still called it with
+ * the older `formBuilder()->getForm('...OverviewTerms', $vocabulary)`
+ * convention, which never sets `$this->entity` on the form object. That left
+ * `EntityForm::getBaseFormId()`/`getFormId()` calling `getEntityTypeId()` on a
+ * null entity, fatally erroring the page before the "Add a new category" form
+ * could even render - unconditionally, not just on an empty vocabulary.
+ *
+ * `mukurtu_taxonomy`'s full dependency chain (media, entity_browser, facets,
+ * mukurtu_protocol, mukurtu_search, ...) isn't needed to exercise the
+ * controller directly, so it's required here rather than enabled, mirroring
+ * `StaticTaxonomyNameFieldRestoreTest`.
+ *
+ * @see \Drupal\mukurtu_taxonomy\Controller\MukurtuCategoryManageController::content()
+ */
+#[Group('mukurtu_taxonomy')]
+class MukurtuCategoryManageControllerTest extends EntityKernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = ['taxonomy', 'field', 'text', 'filter'];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->installEntitySchema('taxonomy_term');
+    $this->installConfig(['taxonomy']);
+
+    Vocabulary::create(['vid' => 'category', 'name' => 'Category'])->save();
+
+    $module_path = \Drupal::service('extension.list.module')->getPath('mukurtu_taxonomy');
+    require_once $module_path . '/src/Controller/MukurtuCategoryManageController.php';
+  }
+
+  /**
+   * Builds and renders the page, asserting it does not fatally error.
+   */
+  private function assertPageRendersWithoutError(): array {
+    $controller = MukurtuCategoryManageController::create($this->container);
+    $build = $controller->content();
+
+    $this->assertArrayHasKey(0, $build, 'Vocabulary overview form was built.');
+    $this->assertArrayHasKey('add_category', $build, '"Add a new category" form was built.');
+
+    $rendered = (string) \Drupal::service('renderer')->renderInIsolation($build);
+    $this->assertNotEmpty($rendered);
+
+    return $build;
+  }
+
+  /**
+   * The page renders when the "category" vocabulary has no terms yet.
+   */
+  public function testRendersWithEmptyVocabulary(): void {
+    $this->assertPageRendersWithoutError();
+  }
+
+  /**
+   * The page renders the same way once categories already exist.
+   */
+  public function testRendersWithExistingTerms(): void {
+    Term::create(['vid' => 'category', 'name' => 'General'])->save();
+    $this->assertPageRendersWithoutError();
+  }
+
+}

--- a/modules/mukurtu_taxonomy/tests/src/Kernel/MukurtuManageTaxonomyControllerTest.php
+++ b/modules/mukurtu_taxonomy/tests/src/Kernel/MukurtuManageTaxonomyControllerTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\mukurtu_taxonomy\Kernel;
+
+use Drupal\KernelTests\Core\Entity\EntityKernelTestBase;
+use Drupal\mukurtu_taxonomy\Controller\MukurtuManageTaxonomyController;
+use Drupal\taxonomy\Entity\Term;
+use Drupal\taxonomy\Entity\Vocabulary;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Tests that the generic Manage Taxonomy page renders without a fatal error.
+ *
+ * Same bug as `MukurtuCategoryManageControllerTest`, in the sibling
+ * controller used for non-category vocabularies: `OverviewTerms` is now the
+ * vocabulary entity type's `'overview'` form handler (an `EntityForm`), so
+ * calling it via the older `formBuilder()->getForm('...OverviewTerms',
+ * $vocabulary)` convention left its entity null and fatally errored
+ * `getBaseFormId()`.
+ *
+ * @see \Drupal\mukurtu_taxonomy\Controller\MukurtuManageTaxonomyController::content()
+ */
+#[Group('mukurtu_taxonomy')]
+class MukurtuManageTaxonomyControllerTest extends EntityKernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = ['taxonomy', 'field', 'text', 'filter'];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->installEntitySchema('taxonomy_term');
+    $this->installConfig(['taxonomy']);
+
+    Vocabulary::create(['vid' => 'keywords', 'name' => 'Keywords'])->save();
+
+    $module_path = \Drupal::service('extension.list.module')->getPath('mukurtu_taxonomy');
+    require_once $module_path . '/src/Controller/MukurtuManageTaxonomyController.php';
+  }
+
+  /**
+   * Builds and renders the page, asserting it does not fatally error.
+   */
+  private function assertPageRendersWithoutError(): array {
+    $controller = MukurtuManageTaxonomyController::create($this->container);
+    $build = $controller->content('keywords');
+
+    $this->assertArrayHasKey(0, $build, 'Vocabulary overview form was built.');
+    $this->assertArrayHasKey('add_term', $build, '"Add a new term" form was built.');
+
+    $rendered = (string) \Drupal::service('renderer')->renderInIsolation($build);
+    $this->assertNotEmpty($rendered);
+
+    return $build;
+  }
+
+  /**
+   * The page renders when the vocabulary has no terms yet.
+   */
+  public function testRendersWithEmptyVocabulary(): void {
+    $this->assertPageRendersWithoutError();
+  }
+
+  /**
+   * The page renders the same way once terms already exist.
+   */
+  public function testRendersWithExistingTerms(): void {
+    Term::create(['vid' => 'keywords', 'name' => 'Existing term'])->save();
+    $this->assertPageRendersWithoutError();
+  }
+
+}


### PR DESCRIPTION
## Summary

- Drupal core refactored `\Drupal\taxonomy\Form\OverviewTerms` into the `taxonomy_vocabulary` entity type's `'overview'` form handler (an `EntityForm`), so it now requires `setEntity()` to be called before use, and the vocabulary passed through as a build argument for its `buildForm()` signature.
- `MukurtuCategoryManageController::content()` and the sibling `MukurtuManageTaxonomyController::content()` still called it with the older `formBuilder()->getForm('...OverviewTerms', $vocabulary)` convention, which never sets `$this->entity`. That left `EntityForm::getBaseFormId()`/`getFormId()` calling `getEntityTypeId()` on a null entity, fatally erroring the page **every time it's visited**, regardless of whether the vocabulary already has terms.
- Both controllers are fixed the same way: `getFormObject('taxonomy_vocabulary', 'overview')->setEntity($vocabulary)`, then `getForm($form_object, $vocabulary)` so the vocabulary also reaches `buildForm()`'s `$taxonomy_vocabulary` parameter.
- Reported by a teammate session doing a fresh install for documentation screenshots; confirmed and reproduced directly against a real site via `drush php:eval` before and after the fix (see commit messages for the exact traces).

## Test plan

- [x] Added `MukurtuCategoryManageControllerTest` (Kernel) and `MukurtuManageTaxonomyControllerTest` (Kernel), each covering both an empty and a populated vocabulary.
- [x] Confirmed both new tests fail with the exact reported `Call to a member function getEntityTypeId() on null` error against the pre-fix code, and pass against the fix.
- [x] Ran the full `mukurtu_taxonomy` kernel test group (33 tests) — all pass, no regressions.
- [x] `phpcs` clean on both new test files (pre-existing "missing class doc comment" notices on the two controller files predate this change and are out of scope).
- [x] No update hook needed — pure controller logic fix, no schema/config changes.

## Pre-merge checklist:

- [x] I have checked for and if required, created update hooks. (Not required — no schema/config changes.)
- [x] I have run an accessibility check, and resolved any issues. (No markup/UI changes — the underlying core form is unchanged; this only fixes the fatal error preventing it from rendering at all.)
- [ ] I have recompiled SCSS if required. (Not applicable — no SCSS changes.)
- [x] I have updated or created CI/CD tests, if required.
- [x] I have updated from `main` and resolved any merge conflicts.
- [x] If this PR's base branch is not `main`, I understand it needs to be retargeted once that base branch's own PR merges (see docs/stacked-prs.md). (Base branch is `main`.)
- [ ] I have verified that all expected checks pass. (Pending CI.)
- [x] I have run the pr-expert-review skill and resolved all relevant issues.
- [x] If I added a content entity bundle, I added its `language.content_settings` and base field overrides to `mukurtu_multilingual`... (Not applicable — no content entity bundle added.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)