### PR TITLE
Document workaround for composer update patch-download failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,5 +129,19 @@ We recommend iterating through each skipped version rather than jumping versions
     - If there is an issue restore from the last backup.
 8. When you have caught the site up to the latest release, change the version number in composer.json back to an asterisk `(*)`.
 
+### Troubleshooting: "patch file could not be downloaded" during an update
+
+If `composer update mukurtu/* -W` fails with an error like:
+```
+The "web/profiles/mukurtu/patches/<some-patch>.patch" file could not be downloaded: Failed to open stream: No such file or directory
+```
+the release you're updating to added a new patch file that isn't present in your site's current (older) copy of the profile yet. Composer needs that file to patch an existing package before it finishes updating the Mukurtu profile itself, so it can't find it on disk.
+
+To resolve it:
+1. Note the patch filename from the error message.
+2. Download that file from the `patches/` directory of the [release tag you're updating to](https://github.com/MukurtuCMS/Mukurtu-CMS/tags) on GitHub.
+3. Save it into `web/profiles/mukurtu/patches/` in your site, keeping the same filename.
+4. Re-run `composer install`. If a different patch file is reported missing, repeat steps 1-3 for it.
+
 ## Contributing
 Mukurtu CMS v4 is under active development. Code contribution and feedback is welcome, and can be submitted in [our issues](https://github.com/MukurtuCMS/Mukurtu-CMS/issues) or you can contact us at [support@mukurtu.org](mailto:support@mukurtu.org).


### PR DESCRIPTION
## Summary
- Adds a README troubleshooting note for a `composer update mukurtu/* -W` failure: `The "web/profiles/mukurtu/patches/<patch>.patch" file could not be downloaded`.
- Root cause: when a release adds a new patch file targeting a third-party package (e.g. drupal/core), composer tries to apply it before the profile's own updated files (which contain the new patch) are extracted to disk on an in-place upgrade from an older version. This affects the standard documented update path in this README, not just this instance.
- Discovered live while updating a local site from `4.0.0-beta35` to `4.0.0-beta36`.
- Docs-only change; no code, config, or test changes required.

## Test plan
- [x] Verified the added markdown renders correctly (fenced code blocks, list, link).
- [x] N/A: update hooks, SCSS, accessibility, CI/tests (docs-only change).

## Pre-merge checklist:

- [x] I have checked for and if required, created update hooks. (N/A, docs-only)
- [x] I have run an accessibility check, and resolved any issues. (N/A, docs-only)
- [x] I have recompiled SCSS if required. (N/A, docs-only)
- [x] I have updated or created CI/CD tests, if required. (N/A, docs-only)
- [x] I have updated from `main` and resolved any merge conflicts.
- [x] If this PR's base branch is not `main`, I understand it needs to be retargeted once that base branch's own PR merges. (N/A, base is main)
- [ ] I have verified that all expected checks pass.
- [ ] I have run the pr-expert-review skill and resolved all relevant issues. (Skipped: single-file, 14-line README addition; flagged to requester)
- [x] If I added a content entity bundle... (N/A, docs-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)