### PR TITLE
Convert self-referencing composer patches to pinned remote URLs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -131,12 +131,12 @@
             "drupal/core": [
                 {
                     "description": "Fix stale config.installer proxy after nested container rebuild during module install",
-                    "url": "web/profiles/mukurtu/patches/module-installer-stale-config-installer-proxy.patch",
+                    "url": "https://raw.githubusercontent.com/MukurtuCMS/Mukurtu-CMS/03c3074c9cfaef093456c2a0072ea4c772862bc9/patches/module-installer-stale-config-installer-proxy.patch",
                     "depth": 1
                 },
                 {
                     "description": "Fix stale module_handler proxy in ModuleInstaller::install()'s trailing hook_modules_installed() invocation",
-                    "url": "web/profiles/mukurtu/patches/module-installer-stale-module-handler-modules-installed.patch",
+                    "url": "https://raw.githubusercontent.com/MukurtuCMS/Mukurtu-CMS/877a97b4446a887fcbfeb7cd1fb5b867cc0fa034/patches/module-installer-stale-module-handler-modules-installed.patch",
                     "depth": 1
                 }
             ],
@@ -144,37 +144,37 @@
                 "Fix illegal choice on exposed sort error": "https://www.drupal.org/files/issues/2022-01-17/3259018-6-illegal-sort-choice.patch"
             },
             "drupal/paragraphs": {
-                "Ensure empty paragraphs register as empty": "web/profiles/mukurtu/patches/paragraphs-118.patch"
+                "Ensure empty paragraphs register as empty": "https://raw.githubusercontent.com/MukurtuCMS/Mukurtu-CMS/03c3074c9cfaef093456c2a0072ea4c772862bc9/patches/paragraphs-118.patch"
             },
             "drupal/media_entity_soundcloud": {
-                "Add support for secret URL embeds": "web/profiles/mukurtu/patches/media_entity_soundcloud-secret-token-3272077.patch"
+                "Add support for secret URL embeds": "https://raw.githubusercontent.com/MukurtuCMS/Mukurtu-CMS/03c3074c9cfaef093456c2a0072ea4c772862bc9/patches/media_entity_soundcloud-secret-token-3272077.patch"
             },
             "drupal/og": {
-                "Remove bulk option to remove a user's roles": "web/profiles/mukurtu/patches/832-disallow-og-role-removal.patch"
+                "Remove bulk option to remove a user's roles": "https://raw.githubusercontent.com/MukurtuCMS/Mukurtu-CMS/b9cc77302d1a471dbc1d5c5eb6921285d2da0806/patches/832-disallow-og-role-removal.patch"
             },
             "drupal/search_api_glossary": {
-                "TypeError: Cannot access offset of type string on string": "web/profiles/mukurtu/patches/search_api_glossary_type-error-3492668-8.patch",
-                "Fix implicit nullable param deprecation in Glossary::getPropertyDefinitions()": "web/profiles/mukurtu/patches/search_api_glossary-nullable-param-deprecation.patch"
+                "TypeError: Cannot access offset of type string on string": "https://raw.githubusercontent.com/MukurtuCMS/Mukurtu-CMS/b9cc77302d1a471dbc1d5c5eb6921285d2da0806/patches/search_api_glossary_type-error-3492668-8.patch",
+                "Fix implicit nullable param deprecation in Glossary::getPropertyDefinitions()": "https://raw.githubusercontent.com/MukurtuCMS/Mukurtu-CMS/b9cc77302d1a471dbc1d5c5eb6921285d2da0806/patches/search_api_glossary-nullable-param-deprecation.patch"
             },
             "drupal/message_ui": {
-                "Fix implicit nullable param deprecation in SaveMessage::access()": "web/profiles/mukurtu/patches/message_ui-nullable-param-deprecation.patch",
-                "Fix invalid '#group' display option written into entity_form_display config schema": "web/profiles/mukurtu/patches/message_ui-invalid-group-display-option.patch",
-                "Fix invalid 'field_name' component option written into entity_form_display config schema": "web/profiles/mukurtu/patches/message_ui-invalid-field-name-component-option.patch"
+                "Fix implicit nullable param deprecation in SaveMessage::access()": "https://raw.githubusercontent.com/MukurtuCMS/Mukurtu-CMS/b9cc77302d1a471dbc1d5c5eb6921285d2da0806/patches/message_ui-nullable-param-deprecation.patch",
+                "Fix invalid '#group' display option written into entity_form_display config schema": "https://raw.githubusercontent.com/MukurtuCMS/Mukurtu-CMS/af7ea5f9c535dbcc685e785d8fd7168d464563a9/patches/message_ui-invalid-group-display-option.patch",
+                "Fix invalid 'field_name' component option written into entity_form_display config schema": "https://raw.githubusercontent.com/MukurtuCMS/Mukurtu-CMS/af7ea5f9c535dbcc685e785d8fd7168d464563a9/patches/message_ui-invalid-field-name-component-option.patch"
             },
             "drupal/admin_theme": {
-                "Fix implicit nullable param deprecation in AdminThemeAdminContext::isAdminRoute()": "web/profiles/mukurtu/patches/admin_theme-nullable-param-deprecation.patch"
+                "Fix implicit nullable param deprecation in AdminThemeAdminContext::isAdminRoute()": "https://raw.githubusercontent.com/MukurtuCMS/Mukurtu-CMS/b9cc77302d1a471dbc1d5c5eb6921285d2da0806/patches/admin_theme-nullable-param-deprecation.patch"
             },
             "drupal/field_group": {
-                "Fix EntityViewDisplay/EntityFormDisplay::load() incompatibility with Drupal 11.3.x": "web/profiles/mukurtu/patches/field_group-entity-load-11-3.patch"
+                "Fix EntityViewDisplay/EntityFormDisplay::load() incompatibility with Drupal 11.3.x": "https://raw.githubusercontent.com/MukurtuCMS/Mukurtu-CMS/b9cc77302d1a471dbc1d5c5eb6921285d2da0806/patches/field_group-entity-load-11-3.patch"
             },
             "drupal/pathauto": {
-                "Fix missing source_module on PHP 8 MigrateSource attribute": "web/profiles/mukurtu/patches/pathauto-source-module-missing-php8-attribute.patch"
+                "Fix missing source_module on PHP 8 MigrateSource attribute": "https://raw.githubusercontent.com/MukurtuCMS/Mukurtu-CMS/03c3074c9cfaef093456c2a0072ea4c772862bc9/patches/pathauto-source-module-missing-php8-attribute.patch"
             },
             "drupal/flat_taxonomy": {
-                "Fix null vocabulary crash in presave hook during migration": "web/profiles/mukurtu/patches/flat-taxonomy-null-vocabulary-presave.patch"
+                "Fix null vocabulary crash in presave hook during migration": "https://raw.githubusercontent.com/MukurtuCMS/Mukurtu-CMS/b9cc77302d1a471dbc1d5c5eb6921285d2da0806/patches/flat-taxonomy-null-vocabulary-presave.patch"
             },
             "drupal/migrate_source_csv": {
-                "Replace deprecated createFromStream() with from() for league/csv 9.27+": "web/profiles/mukurtu/patches/migrate_source_csv-createFromStream-deprecated-9.27.patch"
+                "Replace deprecated createFromStream() with from() for league/csv 9.27+": "https://raw.githubusercontent.com/MukurtuCMS/Mukurtu-CMS/b9cc77302d1a471dbc1d5c5eb6921285d2da0806/patches/migrate_source_csv-createFromStream-deprecated-9.27.patch"
             }
         }
     }

--- a/docs/composer-patches.md
+++ b/docs/composer-patches.md
@@ -1,0 +1,42 @@
+# Composer patches
+
+Every patch this profile applies to a third-party package (drupal/core, pathauto,
+media_entity_soundcloud, etc.) is declared in this repo's own `composer.json`, under
+`extra.patches`.
+
+## Always use a pinned remote URL, never a local path
+
+A patch's `url` must be an absolute, pinned URL — for example a
+`raw.githubusercontent.com` link at a specific commit SHA:
+
+```
+https://raw.githubusercontent.com/MukurtuCMS/Mukurtu-CMS/<commit-sha>/patches/<file>.patch
+```
+
+Never a path relative to this repo (e.g. `web/profiles/mukurtu/patches/<file>.patch`).
+
+**Why:** this profile's own patch files are declared with paths relative to the site
+root, not to itself. When a release adds a *new* patch, an in-place
+`composer update mukurtu/* -W` on an already-installed site applies that patch to its
+target package *before* this profile's own package update finishes extracting to disk
+— so a local-path URL points at a file that doesn't exist yet, and the update fails
+with "file could not be downloaded". A pinned remote URL sidesteps this entirely,
+since Composer can download the patch over HTTP regardless of what's extracted
+locally. See the README's "Troubleshooting" section for the failure this caused before
+this convention existed.
+
+## Adding a new patch
+
+1. In your PR, add the `.patch` file under `patches/` and the `composer.json` entry
+   pointing at that PR branch's own last commit SHA (already resolvable via
+   `raw.githubusercontent.com` once pushed to GitHub, even before merge).
+2. After merging to `main`, check whether the merge preserved that commit SHA. If not
+   (e.g. a squash merge), push one small follow-up commit updating just that entry's
+   `url` to the actual `main` merge-commit SHA — before any release tag containing this
+   change is cut.
+
+## Updating an existing patch
+
+Only change a patch's `url` when the patch file's *content* changes — point it at the
+new commit that changes the file. A patch that hasn't changed never needs its pin
+touched again, even across many later releases.


### PR DESCRIPTION
## Summary

Every third-party-package patch in `composer.json`'s `extra.patches` was declared with a local, project-relative path (`web/profiles/mukurtu/patches/*.patch`) — even though that path only resolves once this profile's own package has finished extracting to disk. When a release adds a *new* patch, an in-place `composer update mukurtu/* -W` (the README's documented update path) applies it to the target package *before* the profile's own update finishes extracting, so the file isn't there yet and the update fails:

```
The "web/profiles/mukurtu/patches/<patch>.patch" file could not be downloaded:
Failed to open stream: No such file or directory
```

This was first hit and diagnosed going 4.0.0-beta35 → beta36, and #2116 added a README troubleshooting note as a docs-only fix at the time, explicitly deferring the more invasive remote-URL conversion to avoid recurring per-release maintenance. It has now recurred on a later update, so this PR does the conversion.

- Repoints all 15 local-path patches at pinned `raw.githubusercontent.com/MukurtuCMS/Mukurtu-CMS/<commit-sha>/patches/<file>.patch` URLs, using the commit that introduced/last changed each file. Composer-patches downloads these over HTTP regardless of what's extracted locally, eliminating the ordering bug for any patch added from this point forward.
- The SHA-pinning approach means **existing patches never need their pin touched again** — only a patch whose file content actually changes needs a new pin. This addresses the original "recurring maintenance" concern from #2116.
- Adds `docs/composer-patches.md` documenting the convention (why pinned remote URLs, and the two-step process for pinning a brand-new patch once its PR is merged).
- README's existing manual-workaround troubleshooting section (#2116) is left in place as a fallback/historical reference.

No patch content changed, and no Drupal config/schema/code is touched.

## Test plan

- [x] `composer validate` passes (pre-existing warnings only, unrelated to this change)
- [x] All 16 patch URLs (15 new + 1 pre-existing remote) verified to resolve with HTTP 200
- [x] Confirmed with a real `composer install` against a throwaway test package that `cweagans/composer-patches` successfully **downloads** from a pinned `raw.githubusercontent.com` URL (no "could not be downloaded" error) — it only failed at the unrelated apply step, as expected, since the test patch's content targets Drupal core, not the throwaway package
- [ ] No CI/Kernel test coverage added — this is a build-tooling change (patch source URLs) with no testable Drupal runtime behavior

## Pre-merge checklist:

- [x] I have checked for and if required, created update hooks. *(not applicable — no Drupal config/schema change)*
- [x] I have run an accessibility check, and resolved any issues. *(not applicable — no UI change)*
- [x] I have recompiled SCSS if required. *(not applicable — no SCSS change)*
- [x] I have updated or created CI/CD tests, if required. *(not applicable — see test plan)*
- [x] I have updated from `main` and resolved any merge conflicts.
- [x] If this PR's base branch is not `main`, I understand it needs to be retargeted once that base branch's own PR merges. *(base is `main`)*
- [ ] I have verified that all expected checks pass.
- [x] I have run the pr-expert-review skill and resolved all relevant issues.
- [x] If I added a content entity bundle... *(not applicable)*

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>