### PR TITLE
Collect profile-root tests in the PHPUnit testsuites (#2125)

### DIFF
--- a/phpunit.ddev.xml
+++ b/phpunit.ddev.xml
@@ -56,12 +56,15 @@
   <testsuites>
     <testsuite name="kernel">
       <directory>/var/www/html/web/profiles/mukurtu/modules/**/tests/src/Kernel</directory>
+      <directory>/var/www/html/web/profiles/mukurtu/tests/src/Kernel</directory>
     </testsuite>
     <testsuite name="unit">
       <directory>/var/www/html/web/profiles/mukurtu/modules/**/tests/src/Unit</directory>
+      <directory>/var/www/html/web/profiles/mukurtu/tests/src/Unit</directory>
     </testsuite>
     <testsuite name="functional">
       <directory>/var/www/html/web/profiles/mukurtu/modules/**/tests/src/Functional</directory>
+      <directory>/var/www/html/web/profiles/mukurtu/tests/src/Functional</directory>
     </testsuite>
   </testsuites>
   <!-- Settings for coverage reports. -->

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -56,12 +56,15 @@
   <testsuites>
     <testsuite name="kernel">
       <directory>web/profiles/mukurtu/modules/**/tests/src/Kernel</directory>
+      <directory>web/profiles/mukurtu/tests/src/Kernel</directory>
     </testsuite>
     <testsuite name="unit">
       <directory>web/profiles/mukurtu/modules/**/tests/src/Unit</directory>
+      <directory>web/profiles/mukurtu/tests/src/Unit</directory>
     </testsuite>
     <testsuite name="functional">
       <directory>web/profiles/mukurtu/modules/**/tests/src/Functional</directory>
+      <directory>web/profiles/mukurtu/tests/src/Functional</directory>
     </testsuite>
   </testsuites>
   <!-- Settings for coverage reports. -->

--- a/tests/src/Functional/.gitkeep
+++ b/tests/src/Functional/.gitkeep
@@ -1,0 +1,4 @@
+Keeps this directory in git so phpunit.xml's <directory> entry for it resolves.
+PHPUnit fails the whole testsuite with `Test directory "..." not found` if a
+configured directory is missing, so the profile-root Unit and Functional
+directories have to exist even while they are empty.

--- a/tests/src/Kernel/FeedbackFormRecipientInstallTest.php
+++ b/tests/src/Kernel/FeedbackFormRecipientInstallTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Drupal\Tests\mukurtu_core\Kernel;
+namespace Drupal\Tests\mukurtu\Kernel;
 
 use Drupal\Core\Form\FormState;
 use Drupal\KernelTests\KernelTestBase;
@@ -17,14 +17,10 @@ use PHPUnit\Framework\Attributes\Group;
  * system.site:mail is still empty while mukurtu_install() executes. The
  * behaviour therefore hangs off install_configure_form's submit handler.
  *
- * This test lives in mukurtu_core rather than at the profile root because
- * phpunit.xml's testsuites only scan modules/&#42;&#42;/tests/src, so a
- * profile-level test directory would never run in CI.
- *
  * @see mukurtu_install_configure_form_submit()
  * @see mukurtu_core_update_40123()
  */
-#[Group('mukurtu_core')]
+#[Group('mukurtu')]
 class FeedbackFormRecipientInstallTest extends KernelTestBase {
 
   /**
@@ -42,12 +38,11 @@ class FeedbackFormRecipientInstallTest extends KernelTestBase {
   protected function setUp(): void {
     parent::setUp();
 
-    // Derive the profile directory from a known module inside it. The profile
-    // extension list is not reliable here: kernel tests run with no active
-    // install profile.
-    $module_path = \Drupal::service('extension.list.module')->getPath('mukurtu_core');
-    $profile_path = dirname($module_path, 2);
-    require_once \Drupal::root() . '/' . $profile_path . '/mukurtu.profile';
+    // This test file lives at <profile>/tests/src/Kernel, so the profile root
+    // is four levels up. Resolved from __DIR__ rather than through the profile
+    // extension list, which is not reliable here: kernel tests run with no
+    // active install profile.
+    require_once dirname(__DIR__, 3) . '/mukurtu.profile';
 
     $this->installConfig(['system']);
   }

--- a/tests/src/Unit/.gitkeep
+++ b/tests/src/Unit/.gitkeep
@@ -1,0 +1,4 @@
+Keeps this directory in git so phpunit.xml's <directory> entry for it resolves.
+PHPUnit fails the whole testsuite with `Test directory "..." not found` if a
+configured directory is missing, so the profile-root Unit and Functional
+directories have to exist even while they are empty.


### PR DESCRIPTION
Closes #2125. Stacked on #2126.

Every testsuite `<directory>` in `phpunit.xml` was rooted at `modules/**`, so a PHPUnit test placed at the profile root was never collected. CI runs `--testsuite kernel` and `--testsuite unit`, so such a test would sit in the repo silently passing without ever executing.

`phpunit.ddev.xml` had the same gap. The issue only mentioned `phpunit.xml`; both are fixed here.

## The open question in the issue is answered

The issue flagged that profile PSR-4 test namespace registration "is not necessarily set up the way a module's is" and was the part most likely to need work. It needs none. Core's `core/tests/bootstrap.php` scans `$root . '/profiles'` alongside `$root . '/modules'` (line 60) and registers `Drupal\Tests\<extension>\` for any extension that has a `tests/src` directory (line 95). The profile simply had no `tests/src`, so nothing was registered. Creating it is sufficient.

Verified rather than assumed:

```
$ phpunit --testsuite kernel --list-tests | grep FeedbackFormRecipientInstall
 - Drupal\Tests\mukurtu\Kernel\FeedbackFormRecipientInstallTest::testSubmitUsesSubmittedSiteMail
 - Drupal\Tests\mukurtu\Kernel\FeedbackFormRecipientInstallTest::testSubmitFallsBackToSiteConfig
 - Drupal\Tests\mukurtu\Kernel\FeedbackFormRecipientInstallTest::testSubmitIsNoOpWithoutAnySiteMail
 - Drupal\Tests\mukurtu\Kernel\FeedbackFormRecipientInstallTest::testSubmitIsNoOpWithoutFeedbackForm
 - Drupal\Tests\mukurtu\Kernel\FeedbackFormRecipientInstallTest::testFormAlterAppendsSubmitHandler
```

Those are reachable only through the new directory entry, since every pre-existing entry is `modules/**`.

## The test move

`FeedbackFormRecipientInstallTest` moves from `mukurtu_core` to the profile root, which is where it belonged: it `require_once`s `mukurtu.profile` and exercises nothing in `mukurtu_core`. It was only in `mukurtu_core` so that CI would run it, with a docblock apologising for the location. That note is now gone, the namespace is `Drupal\Tests\mukurtu\Kernel`, the group is `mukurtu`, and the profile root is resolved from `__DIR__` instead of walking up from a module path.

## Correction: PHPUnit does not tolerate a missing directory

My first commit added `Unit` and `Functional` entries for directories that did not exist, on the claim that PHPUnit tolerates that. **It does not.** On 11.5.56 it aborts the whole testsuite:

```
Test directory "/var/www/html/web/profiles/mukurtu/tests/src/Unit" not found
exit status 2
```

CI caught it on the `unit` job. I had verified only `--testsuite kernel` locally, and the profile-root `Kernel` directory was the one that already had files in it, so the gap went unnoticed. The second commit creates both directories with a `.gitkeep` explaining why they cannot be deleted. An empty directory is fine; only a missing one fails.

## Verification

- All three suites now resolve: `unit` **57 tests passing**, `kernel` **998 tests collected** (full run: 998 tests, 27886 assertions, exit 0), `functional` still collecting the existing `mukurtu_protocol` tests. The 1 deprecation and 22 PHPUnit deprecations in the kernel run are pre-existing; none reference the moved test.
- The moved test on its own: 5 tests, 5 passing, collected from its new location.
- `multilingual-guardrails.sh` passes in strict mode.
- No SCSS, CSS, JS or Twig touched.

## Pre-merge checklist:

- [x] I have checked for and if required, created update hooks.
- [x] I have run an accessibility check, and resolved any issues.
- [x] I have recompiled SCSS if required.
- [x] I have updated or created CI/CD tests, if required.
- [x] I have updated from `main` and resolved any merge conflicts.
- [x] If this PR's base branch is not `main`, I understand it needs to be retargeted once that base branch's own PR merges (see [docs/stacked-prs.md](../docs/stacked-prs.md)).
- [x] I have verified that all expected checks pass.
- [x] I have run the pr-expert-review skill and resolved all relevant issues.
- [x] If I added a content entity bundle, I added its `language.content_settings` and base field overrides to `mukurtu_multilingual` (see `docs/content-language-policy.md`). If I added or changed a view, I applied the content language policy in that doc.

Checklist notes: no update hooks are needed, this is test infrastructure with no config or data impact. No accessibility surface: the change is two XML config files and a file move. No SCSS to recompile. **Base branch is `2123-4-0-0-release-readiness` (#2126), not `main`** - it needs retargeting once #2126 merges. All checks pass: Multilingual guardrails, check, Tugboat, and Mukurtu v4 - PHP 8.4 (kernel + unit).





