### PR TITLE
Rewrite the README for a stable release (#2123)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@
 # Mukurtu CMS
 To learn more about Mukurtu CMS and the larger Mukurtu community, visit [mukurtu.org](https://mukurtu.org/).
 
-**Note: This version of Mukurtu CMS is currently under active development and is subject to daily change. Only use for testing and feedback purposes.**
-
 ## Requirements
 
 * The necessary database server, web server, and PHP installed that meet [modern Drupal requirements](https://www.drupal.org/docs/system-requirements)
@@ -40,7 +38,7 @@ mv composer.phar composer
 ```
 mkdir mukurtu
 cd mukurtu
-composer create-project mukurtu/mukurtu-template:dev-main .
+composer create-project mukurtu/mukurtu-template:^4.0 .
 ```
 * Set your web server to serve the "web" folder (e.g. `mukurtu4/web`)
 * Install Drupal as normal by opening the site in your web browser, the Mukurtu profile distribution will automatically be used.
@@ -75,59 +73,51 @@ sudo apt install poppler-utils
 
 ## Updating Mukurtu CMS
 
-1. Go to https://github.com/MukurtuCMS/Mukurtu-CMS to see what is the latest release.
-2. Compare that to the version your site is on.
-    -  Go to the  "Mukurtu Dashboard" Link in your site. Look for the "Site information" block.
-3. Note how many (if any) versions your site is behind.
- 
-### Updating if you are only one version behind
+1. Check the [latest release](https://github.com/MukurtuCMS/Mukurtu-CMS/releases).
+2. Compare it to the version your site is on. Follow the "Mukurtu Dashboard" link in your site and look for the "Site information" block.
+3. Read the release notes for each version between yours and the latest. Most releases can be applied directly, but some must be passed through rather than skipped, and the release notes will say so.
 
-1. Backup your site and database.
-2. From your Mukurtu 4 directory, run the update commands.
+### Updating
+
+Back up your site and database first. Then, from your Mukurtu directory:
+
 ```
-    # put the site into offline mode
+    # Put the site into maintenance mode.
     drush state:set system.maintenance_mode 1
     drush cr
 
-    # Make sure everything looks correct
+    # Check what will change.
     composer update mukurtu/* -W --dry-run
 
-    # If everything looks correct run it for real
+    # If everything looks correct, run it for real.
     composer update mukurtu/* -W
 
-    # update the database
+    # Apply any database updates.
     drush updb
 
-    # take the site out of offline mode
+    # Bring the site back online.
     drush state:set system.maintenance_mode 0
     drush cr
 
 ```
-### Updating if you are more than one version behind
 
-We recommend iterating through each skipped version rather than jumping versions.
+Test the site before announcing it is back. If anything is wrong, restore your backup.
 
-1. Backup your site and database.
-2. From your Mukurtu 4 directory, put your site into offline mode.
-    - `drush state:set system.maintenance_mode 0`
+### Updating through a specific version
+
+When the release notes say a version must be passed through, update to that version first rather than straight to the latest.
+
+1. Back up your site and database.
+2. Put the site into maintenance mode.
+    - `drush state:set system.maintenance_mode 1`
     - `drush cr`
-2. Edit your composer.json file.
-3. Look for this line: `"mukurtu/mukurtu": "*"`
-4. Change the asterisk to the next mukurtu version.
-    - For example if you are running 4.0.0-beta31 and the latest version is 4.0.0-beta35 change the asterisk to 4.0.0-beta32 (`"mukurtu/mukurtu": "4.0.0-beta32"`).
-5. Then run the update commands.
-    - Run a test update to make sure everything looks good.
-        - `composer update mukurtu/* -W --dry-run`
-    -  If everything looks correct run it for real.
-        - `composer update mukurtu/* -W`
-    - Update the database.
-        - `drush updb`
-6. Take the site out of offline mode.
-    - `drush state:set system.maintenance_mode 0`
-    - `drush cr`
-7. Test your site. If everything looks good repeat steps 1-6, the only thing that will change is that will update the line in composer.json to reflect the next beta version
-    - If there is an issue restore from the last backup.
-8. When you have caught the site up to the latest release, change the version number in composer.json back to an asterisk `(*)`.
+3. In your project's `composer.json`, pin the version you need to pass through.
+    - Look for the line `"mukurtu/mukurtu": "^4.0"`.
+    - Replace the constraint with that exact version, for example `"mukurtu/mukurtu": "4.0.0"`.
+4. Run the update commands from the section above.
+5. Test your site. If there is a problem, restore from your backup.
+6. Repeat steps 3 to 5 for each version you need to pass through.
+7. When your site has caught up, restore the constraint to `"mukurtu/mukurtu": "^4.0"` and update once more to reach the latest release.
 
 ### Troubleshooting: "patch file could not be downloaded" during an update
 
@@ -144,4 +134,8 @@ To resolve it:
 4. Re-run `composer install`. If a different patch file is reported missing, repeat steps 1-3 for it.
 
 ## Contributing
-Mukurtu CMS v4 is under active development. Code contribution and feedback is welcome, and can be submitted in [our issues](https://github.com/MukurtuCMS/Mukurtu-CMS/issues) or you can contact us at [support@mukurtu.org](mailto:support@mukurtu.org).
+Code contributions and feedback are welcome, and can be submitted in [our issues](https://github.com/MukurtuCMS/Mukurtu-CMS/issues) or you can contact us at [support@mukurtu.org](mailto:support@mukurtu.org).
+
+## License
+
+Mukurtu CMS is licensed under the [GNU General Public License v3 or later](LICENSE.txt).


### PR DESCRIPTION
Release-readiness work for the first public tag. Stacked on #2130.

Documentation only; no code, config or data changes.

## The banner is gone

The README opened with:

> **Note: This version of Mukurtu CMS is currently under active development and is subject to daily change. Only use for testing and feedback purposes.**

## Install instructions point at a release

`composer create-project mukurtu/mukurtu-template:dev-main .` becomes `:^4.0`. Telling every new production site to install from a moving branch is not viable for a stable release.

> [!IMPORTANT]
> **This makes the README dependent on the template being tagged** (MukurtuCMS/mukurtu-template#4). The template repo currently has **no tags at all**, so `^4.0` will not resolve until that lands.
>
> It is already a hard prerequisite for the 4.0.0 release, but it means this PR should not merge far ahead of that tag, or main's install instructions are temporarily wrong. Worth sequencing against the template work.

## The update section is rewritten

The old section had two subsections, "Updating if you are only one version behind" and "Updating if you are more than one version behind". The latter told readers to iterate through every skipped beta by hand, editing `composer.json` for each one:

> For example if you are running 4.0.0-beta31 and the latest version is 4.0.0-beta35 change the asterisk to 4.0.0-beta32

That made sense for a beta line with 37 tags. It does not for a stable release.

It is now **one** update procedure, plus a separate "Updating through a specific version" procedure for the cases where release notes say a version cannot be skipped. That second procedure is how the **4.0.0 to 4.0.1 step will be communicated** once the update-hook strip lands, so the shape is deliberate.

The version-comparison steps now also tell readers to read the release notes between their version and the latest, rather than just counting how many versions behind they are.

## A real bug fixed along the way

The section being replaced instructed readers to put the site into offline mode with:

```
drush state:set system.maintenance_mode 0
```

**Zero is off.** Anyone following that section literally never entered maintenance mode during an update. The rewritten procedure uses `1` to enter and `0` to leave.

## Smaller changes

- A **License** section pointing at `LICENSE.txt`, which exists as of #2130.
- Contributing drops the "Mukurtu CMS v4 is under active development" framing; the issue and support links are unchanged.

## Left alone deliberately

The **patch-download troubleshooting section** is unchanged and still correct. It tells readers to fetch missing patch files from the `patches/` directory of the release tag, which works because `patches/` is deliberately excluded from the `.gitattributes` `export-ignore` list added in #2130. GitHub's release archives are built with `git archive`, so `export-ignore` does apply to them — this was checked, not assumed.

Also unchanged: the requirements section still says "PHP 8.4 is supported" while `composer.json` declares no `php` constraint at all. That inconsistency belongs with the composer constraint cleanup, which is still outstanding and deliberately not in this stack yet.

## Pre-merge checklist:

- [x] I have checked for and if required, created update hooks.
- [x] I have run an accessibility check, and resolved any issues.
- [x] I have recompiled SCSS if required.
- [x] I have updated or created CI/CD tests, if required.
- [x] I have updated from `main` and resolved any merge conflicts.
- [x] If this PR's base branch is not `main`, I understand it needs to be retargeted once that base branch's own PR merges (see [docs/stacked-prs.md](../docs/stacked-prs.md)).
- [ ] I have verified that all expected checks pass.
- [x] I have run the pr-expert-review skill and resolved all relevant issues.
- [x] If I added a content entity bundle, I added its `language.content_settings` and base field overrides to `mukurtu_multilingual` (see `docs/content-language-policy.md`). If I added or changed a view, I applied the content language policy in that doc.

Checklist notes: documentation only, so no update hooks, no tests, and no SCSS. No accessibility surface — nothing rendered by the application changes. **Base branch is `2123-licensing-versioning-packaging` (#2130), not `main`** — retarget once #2126, #2127, #2128 and #2130 merge, in that order. Checks box unticked until CI reports.
