### PR TITLE
Point CI and Tugboat at the released template, and fix path-repo resolution

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -65,7 +65,7 @@ jobs:
       # version of mukurtu-cms, which will be replaced by the git checkout.
       - name: Install Mukurtu Template
         run: |
-          composer create mukurtu/mukurtu-template:dev-main . --no-install --no-interaction
+          composer create mukurtu/mukurtu-template:^4.0 . --no-install --no-interaction
           rm web/profiles/mukurtu -rf
 
       # Usually checkout is the first action, but we set up the mukurtu-template
@@ -77,7 +77,15 @@ jobs:
 
       - name: Install Mukurtu
         run: |
-          composer config repositories.local-dev path web/profiles/mukurtu
+          # The path repo must declare a version. mukurtu-template requires
+          # mukurtu/mukurtu ^4.0, and composer derives a path package's version
+          # from its git branch, giving dev-<branch> for a PR checkout. That
+          # cannot satisfy ^4.0, and a path repo is canonical, so composer
+          # refuses to fall back to the released package on Packagist and the
+          # whole install fails. The alias is a placeholder standing for "the
+          # 4.x checkout under test", high enough never to need bumping within
+          # this major.
+          composer config repositories.local-dev '{"type":"path","url":"web/profiles/mukurtu","options":{"versions":{"mukurtu/mukurtu":"4.9999.9999"}}}'
           composer install --no-interaction --optimize-autoloader
           cp ./web/profiles/mukurtu/phpunit.xml ./phpunit.xml
 

--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -36,14 +36,22 @@ services:
           chmod 755 ~
           mkdir ~/mukurtu
           cd ~/mukurtu
-          composer create mukurtu/mukurtu-template:dev-main .
+          composer create mukurtu/mukurtu-template:^4.0 .
           # Pin composer/installers to ^2.0 so the cached vendor directory already
           # has v2.x; this prevents PHP 8.x deprecation notices during build-phase
           # composer update runs (where v1.x would otherwise be the active plugin).
           php -r "\$d=json_decode(file_get_contents('composer.json'),true); \$d['require']['composer/installers']='^2.0'; file_put_contents('composer.json',json_encode(\$d,JSON_PRETTY_PRINT|JSON_UNESCAPED_SLASHES).PHP_EOL);"
           # Add our own local checkout repository instead. This will use the
           # local directory as the source, copying it into the final location.
-          composer config repositories.local-dev path $TUGBOAT_ROOT
+          # The path repo must declare a version. mukurtu-template requires
+          # mukurtu/mukurtu ^4.0, and composer derives a path package's version
+          # from its git branch, giving dev-<branch> for a preview checkout.
+          # That cannot satisfy ^4.0, and a path repo is canonical, so composer
+          # refuses to fall back to the released package on Packagist and the
+          # whole install fails. The alias is a placeholder standing for "the
+          # 4.x checkout under test", high enough never to need bumping within
+          # this major.
+          composer config repositories.local-dev "{\"type\":\"path\",\"url\":\"$TUGBOAT_ROOT\",\"options\":{\"versions\":{\"mukurtu/mukurtu\":\"4.9999.9999\"}}}"
           # Explicitly allow the symfony/runtime plugin (pulled in transitively
           # via drush 13.7.x) rather than relying solely on mukurtu-template's
           # own committed allow-plugins default, since this init phase runs


### PR DESCRIPTION
Post-4.0.0 follow-up. **The second half of this is a live breakage, not cleanup.**

## Install the tagged template

CI and Tugboat both ran `composer create mukurtu/mukurtu-template:dev-main`, validating against a moving branch rather than what users install. Both now use `^4.0`, matching `README.md` and the `mukurtu-template` 4.0.0 tag.

## Declare a version on the path repository

> [!IMPORTANT]
> **CI is broken on `main` right now**, as of mukurtu-template 4.0.0.

That release requires `mukurtu/mukurtu: ^4.0` under `minimum-stability: stable`. Both CI and Tugboat replace the packaged profile with a local checkout via a path repository, and composer derives a path package's version from its git branch, giving `dev-<branch>`. That cannot satisfy `^4.0`, and because a path repo is **canonical**, composer refuses to fall back to the released package:

```
Root composer.json requires mukurtu/mukurtu ^4.0, it is satisfiable by
mukurtu/mukurtu[4.0.0] from composer repo (https://repo.packagist.org) but
mukurtu/mukurtu[dev-main] from path repo (web/profiles/mukurtu) has higher
repository priority. The packages from the higher priority repository do not
match your constraint and are therefore not installable.
```

Every pull request would fail at the **Install Mukurtu** step.

The fix declares a version on the path repo:

```
composer config repositories.local-dev '{"type":"path","url":"web/profiles/mukurtu","options":{"versions":{"mukurtu/mukurtu":"4.9999.9999"}}}'
```

`4.9999.9999` is a placeholder standing for "the 4.x checkout under test" - high enough never to need bumping within this major, and obviously not a real release. The root keeps its genuine `^4.0` requirement, so CI still exercises the same constraint users get rather than papering over it.

Tugboat gets the same fix, with `$TUGBOAT_ROOT` in place of the checkout path.

## Verification

I replicated both sequences locally rather than inferring:

| | before | after |
| --- | --- | --- |
| CI (`composer install`) | fails, error above | resolves, `mukurtu/mukurtu 4.9999.9999` |
| Tugboat (`composer update`) | fails, error above | resolves, `mukurtu/mukurtu 4.9999.9999` |

`composer create` selects the released **template 4.0.0** in both. The Tugboat variant was tested with its exact escaped-quote form so `$TUGBOAT_ROOT` expansion is confirmed, and both YAML files parse.

## Unrelated, but worth flagging

`Tugboat Playwright Tests` was already failing on `main` in runs at 21:03 and 21:39, **before** the template merged at 21:44, so those failures are a separate pre-existing issue rather than caused by this. Not addressed here.

## Pre-merge checklist:

- [x] I have checked for and if required, created update hooks.
- [x] I have run an accessibility check, and resolved any issues.
- [x] I have recompiled SCSS if required.
- [x] I have updated or created CI/CD tests, if required.
- [x] I have updated from `main` and resolved any merge conflicts.
- [x] If this PR's base branch is not `main`, I understand it needs to be retargeted once that base branch's own PR merges (see [docs/stacked-prs.md](../docs/stacked-prs.md)).
- [ ] I have verified that all expected checks pass.
- [x] I have run the pr-expert-review skill and resolved all relevant issues.
- [x] If I added a content entity bundle, I added its `language.content_settings` and base field overrides to `mukurtu_multilingual` (see `docs/content-language-policy.md`). If I added or changed a view, I applied the content language policy in that doc.

Checklist notes: CI configuration only, so no update hooks, no PHP, no SCSS, and no accessibility surface. Base branch is `main`. **This PR's own CI passing is the verification** - it is the first run to exercise the fixed sequence, so a green "Install Mukurtu" step here is the proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
