### PR TITLE
Add an update hook numbering lint and rewrite the hook docs (#2123)

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -8,7 +8,7 @@ on:
     types: [opened, synchronize, reopened]
 jobs:
   lint:
-    name: Multilingual guardrails
+    name: Lint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -16,6 +16,11 @@ jobs:
 
       - name: Check for untranslated UI strings
         run: ./scripts/lint/multilingual-guardrails.sh
+        env:
+          MUKURTU_LINT_STRICT: '1'
+
+      - name: Check update hook numbering
+        run: ./scripts/lint/update-hook-numbering.sh
         env:
           MUKURTU_LINT_STRICT: '1'
 

--- a/docs/update-hooks.md
+++ b/docs/update-hooks.md
@@ -75,25 +75,61 @@ already past everything the removed hooks did.
 Sites must reach the predecessor release before they can take the release that
 removed the hooks, since the intervening updates no longer exist to run.
 
-### Core does not enforce this
+### What core does and does not do about a site that is too far behind
 
-This is the part that surprises people, so it is worth stating plainly.
-`hook_update_last_removed()` does **not** stop a site that is too far behind.
+Core reports it, but does not reliably stop it. Both halves matter, and the
+difference is easy to get wrong.
 
-Core reads it in only two places: `ModuleInstaller::install()`, to seed a fresh
-install, and `_update_fix_missing_schema()`, when a schema entry is missing
-entirely. `update_get_update_list()` simply lists updates above the site's
-installed version, and once the hooks are gone there is nothing to list. A site
-several releases behind therefore reports **"no pending updates"** and carries
-on running against stale configuration, rather than being stopped.
+**Core does detect it, in the update phase.**
+`SystemRequirementsHooks::checkRequirements()` walks every installed module,
+calls its `hook_update_last_removed()`, and returns an error-severity
+requirement for each one whose installed schema version is lower:
 
-Blocking such a site needs an explicit `hook_update_requirements()` returning
-`REQUIREMENT_ERROR`. That one core does honour, from both `update.php` and
-`drush updb`, via `update_check_requirements()`.
+> Unsupported schema version: Mukurtu Core
+> The installed version of the Mukurtu Core module is too old to update. Update
+> to an intermediate version first (last removed version: 40123, installed
+> version: 40122).
 
-Note also that `requirements` is on core's deny list for attribute-based hooks
-and must stay procedural in a `.install` file, while `runtime_requirements` is
-not and can be a `#[Hook]` class under `src/Hook/`.
+So a project does not need its own hook to get this detected. What a project's
+own `hook_update_requirements()` adds is a single consolidated message that can
+name the specific release to update to first, which core's generic wording
+cannot.
+
+**Core does not detect it at runtime.** That check is gated on
+`$phase == 'update'`, so nothing appears on the status report. A site that
+updates its code and never runs `updb` gets no indication at all. Covering that
+needs a `hook_runtime_requirements()` of your own.
+
+**An error-severity requirement does not stop `drush updb -y`.** This is the
+one that bites in practice. Drush treats it as a confirmable prompt, not a
+failure (`UpdateDBCommands.php`):
+
+```php
+if (!$this->updateCheckRequirements()) {
+    if (!$this->io()->confirm(dt('Requirements check reports errors. Do you wish to continue?'))) {
+        throw new UserAbortException();
+    }
+}
+```
+
+Verified behaviour on a real site left behind by a strip:
+
+| Command | Outcome |
+| --- | --- |
+| `drush updatedb -y` | errors printed, then "No pending updates", exit 0 |
+| `drush updatedb` non-interactive | same |
+| `drush updatedb --no` | "Cancelled", exit 1 |
+
+Since `-y` is what every deployment script and our own `.tugboat/config.yml`
+use, treat the requirement as a loud warning rather than a gate, and rely on the
+runtime check to keep the problem visible afterwards.
+
+**Attribute-hook rules.** `requirements` is on core's deny list for
+attribute-based hooks (`HookCollectorPass::checkForProceduralOnlyHooks()` throws
+a `LogicException`) and must stay procedural in a `.install` file. Neither
+`update_requirements` nor `runtime_requirements` is on that list, so both may be
+`#[Hook]` classes under `src/Hook/`. Update-phase code is still safer left
+procedural, since it runs while the container may not reflect the code on disk.
 
 ## Further reading
 

--- a/docs/update-hooks.md
+++ b/docs/update-hooks.md
@@ -1,36 +1,99 @@
-# Update Hooks
+# Update hooks
 
-Update hooks are necessary to push certain changes to when updating existing sites. For example:
+Update hooks push changes to sites that already exist. For example:
 
-- Schema Changes: Adding, updating, or deleting tables/fields via hook_schema() in the .install file.
-- Configuration Updates: Updating default configuration values that have changed in a new version of the module.
-- Data Migration/Manipulation: Updating, restructuring, or migrating existing data to a new format, particularly using the $sandbox for large datasets.
+- Schema changes: adding, updating or deleting tables and fields declared via
+  `hook_schema()` in the `.install` file.
+- Configuration updates: changing default configuration values that shipped in
+  an earlier version of the module.
+- Data migration: restructuring or migrating existing data, using `$sandbox`
+  for anything large enough to need batching.
 - https://www.drupal.org/docs/drupal-apis/update-api/introduction-to-the-update-api-for-drupal-8
 
-Basically if a file in `modules/module_name/config/install` is added or changed, an update hook is likely required. There are other cases as well.
+Basically, if a file under `modules/<module>/config/install` is added or
+changed, an update hook is probably required. There are other cases too.
 
-We need to be cautious about changes that:
+**A hook never runs on a fresh install.** Drupal seeds a newly installed
+module's schema version to its highest available update number without invoking
+any of them, so a change made only in a hook reaches existing sites and never
+new ones. Whatever end state the hook produces has to be in `config/install` as
+well, or the two diverge permanently.
+
+Be cautious about changes that:
 
 - Modify site content.
 - May clobber intentional site configuration.
 
-Sometimes changes are minor enough, or may affect common config changes that they should not be hooked, and are suitable to be recommended in update documentation instead. Eg: changing the weight/placement of forms in fields
+Some changes are minor enough, or touch config that sites commonly customise,
+that they are better recommended in release notes than forced by a hook. For
+example, changing the weight or placement of fields on a form.
 
-## Update hook placement
+## Placement
 
-- Update hooks should be placed in the corresponding `/modules/module_name/module_name.install` file.
-- If there isn't a clear module to use, include the hook in `/modules/mukurtu_core/mukurtu_core.install`.
-- Do not place update hooks in `mukurtu.install`.
-- Place hooks at the END of the document.
-- Make sure you don't accidentally duplicate a hook update number within the same file.
+- Put the hook in the matching `modules/<module>/<module>.install`.
+- If there is no clear module, use `modules/mukurtu_core/mukurtu_core.install`.
+- Do not put update hooks in `mukurtu.install`.
+- Add them at the END of the file.
+- Never reuse a number already present in that file.
 
-## Update hook naming
+## Numbering
 
-Use the function hook_update_N naming convention: https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Core%21Extension%21module.api.php/function/hook_update_N/11.x
+Use Drupal's [`hook_update_N`](https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Core%21Extension%21module.api.php/function/hook_update_N/11.x)
+convention: the module name, then a number whose first three digits are the
+major/minor/patch version and whose last two increment per hook within that
+module. The first `mukurtu_core` hook for 4.0.0 was `mukurtu_core_update_40001`.
 
-Include the name of the module (`mukurtu_core_update`), followed by the three digits to indicate major/minor/patch numbering (`400`), and the last two digits are increased sequentially for each hook within the module (`01`)
+Two rules constrain the number, both enforced by
+[`scripts/lint/update-hook-numbering.sh`](../scripts/lint/update-hook-numbering.sh)
+in CI:
 
-For example, the first update hook created within `mukurtu_core` will be `mukurtu_core_update_40001`.
+1. **It must not repeat a number already in the file.** Drupal runs only one of
+   a duplicated pair, so the other silently never executes.
+2. **It must be greater than the module's `hook_update_last_removed()`**, if the
+   module has one. Anything at or below that value is dead code that looks
+   live, for the reasons in the next section.
+
+### The two-digit sequence can overflow
+
+The scheme assumes fewer than 100 hooks per version. `mukurtu_core` exceeded
+that during 4.0.0 and ran to `mukurtu_core_update_40122`, consuming the whole
+`401xx` band that 4.0.1 would otherwise have used. So the number is not always
+derivable from the version.
+
+Check the file's existing maximum before picking a number, rather than assuming
+the version tells you. The lint will catch a number that is too low, but it
+cannot tell you which one you meant.
+
+## Removing update hooks
+
+Hooks accumulate. A release may clear them out by deleting every
+`hook_update_N()` from a module and adding a `hook_update_last_removed()`
+returning the highest number that release's predecessor shipped. Drupal then
+seeds fresh installs at that number, so a new site is correctly treated as
+already past everything the removed hooks did.
+
+Sites must reach the predecessor release before they can take the release that
+removed the hooks, since the intervening updates no longer exist to run.
+
+### Core does not enforce this
+
+This is the part that surprises people, so it is worth stating plainly.
+`hook_update_last_removed()` does **not** stop a site that is too far behind.
+
+Core reads it in only two places: `ModuleInstaller::install()`, to seed a fresh
+install, and `_update_fix_missing_schema()`, when a schema entry is missing
+entirely. `update_get_update_list()` simply lists updates above the site's
+installed version, and once the hooks are gone there is nothing to list. A site
+several releases behind therefore reports **"no pending updates"** and carries
+on running against stale configuration, rather than being stopped.
+
+Blocking such a site needs an explicit `hook_update_requirements()` returning
+`REQUIREMENT_ERROR`. That one core does honour, from both `update.php` and
+`drush updb`, via `update_check_requirements()`.
+
+Note also that `requirements` is on core's deny list for attribute-based hooks
+and must stay procedural in a `.install` file, while `runtime_requirements` is
+not and can be a `#[Hook]` class under `src/Hook/`.
 
 ## Further reading
 
@@ -41,5 +104,5 @@ For example, the first update hook created within `mukurtu_core` will be `mukurt
 
 ## To-do
 
-- Read more into how users can maintain select config changes that conflict with updates.
-- Plan a post-4.0 clean up of stale update hooks (we will likely remove all existing hooks in the first tagged release after 4.0.1 and then start fresh, to minimize redundant code while allowing anyone operating in the beta environment to receive updates to 4.0.0).
+- Read more into how users can maintain select config changes that conflict with
+  updates.

--- a/scripts/lint/update-hook-numbering.sh
+++ b/scripts/lint/update-hook-numbering.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+#
+# Checks hook_update_N() numbering across the profile and its modules.
+#
+# Two rules, both of which have already caused real problems:
+#
+#   1. No number may repeat within a file. Drupal silently runs only one of a
+#      duplicated pair, so the other never executes on any site.
+#
+#   2. Every number must be greater than that module's
+#      hook_update_last_removed(). Numbers at or below it are never run:
+#      update_get_update_list() only lists updates above a site's installed
+#      schema version, and a fresh install is seeded at last_removed. A hook
+#      numbered too low is dead code that looks live.
+#
+# See docs/update-hooks.md for the numbering scheme.
+#
+# Controlled by MUKURTU_LINT_STRICT: unset/0 = report only (exit 0),
+# 1 = fail the build on any violation.
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+STRICT="${MUKURTU_LINT_STRICT:-0}"
+EXIT_CODE=0
+
+HOOK_PATTERN="^function [a-z_]+_update_[0-9]+\("
+LAST_REMOVED_PATTERN="^function [a-z_]+_update_last_removed\("
+
+# --- Self-test: prove the patterns match their own fixtures before trusting
+# them against the real tree, mirroring multilingual-guardrails.sh. A pattern
+# that silently matches nothing would make this lint report success forever.
+self_test() {
+  local pattern="$1" fixture="$2" label="$3"
+  if ! printf '%s\n' "$fixture" | grep -Eq -e "$pattern"; then
+    echo "FATAL: lint pattern for '$label' does not match its own fixture." >&2
+    echo "  pattern: $pattern" >&2
+    echo "  fixture: $fixture" >&2
+    exit 1
+  fi
+}
+
+self_test "$HOOK_PATTERN" "function mukurtu_core_update_40123(): void {" "hook_update_N declaration"
+self_test "$LAST_REMOVED_PATTERN" "function mukurtu_core_update_last_removed(): int {" "hook_update_last_removed declaration"
+
+# Every .install file in the profile, including the profile's own.
+install_files() {
+  find . -name '*.install' \
+    -not -path './web/*' \
+    -not -path './vendor/*' \
+    -not -path './node_modules/*' \
+    -not -path './*/tests/*' \
+    | sort
+}
+
+report() {
+  local message="$1"
+  echo "$message"
+  if [ "$STRICT" = "1" ]; then
+    EXIT_CODE=1
+  fi
+}
+
+echo "== Mukurtu update hook numbering =="
+echo "(mode: $([ "$STRICT" = "1" ] && echo enforcing || echo warn-only))"
+echo
+
+DUPLICATE_VIOLATIONS=0
+BASELINE_VIOLATIONS=0
+CHECKED=0
+
+while IFS= read -r file; do
+  numbers=$(grep -oE "$HOOK_PATTERN" "$file" 2>/dev/null | grep -oE '_update_[0-9]+' | grep -oE '[0-9]+' || true)
+  [ -z "$numbers" ] && continue
+  CHECKED=$((CHECKED + 1))
+
+  # Rule 1: no repeats within the file.
+  dupes=$(printf '%s\n' "$numbers" | sort | uniq -d)
+  if [ -n "$dupes" ]; then
+    report "DUPLICATE numbers in $file:"
+    printf '%s\n' "$dupes" | sed 's/^/    /'
+    DUPLICATE_VIOLATIONS=$((DUPLICATE_VIOLATIONS + 1))
+  fi
+
+  # Rule 2: every number must exceed hook_update_last_removed(), when present.
+  # The return value is read from the function body rather than assumed.
+  last_removed=$(awk '
+    /^function [a-z_]+_update_last_removed\(/ { inside = 1; next }
+    inside && match($0, /return[[:space:]]+[0-9]+/) {
+      s = substr($0, RSTART, RLENGTH); gsub(/[^0-9]/, "", s); print s; exit
+    }
+    inside && /^}/ { exit }
+  ' "$file")
+
+  if [ -n "$last_removed" ]; then
+    while IFS= read -r n; do
+      [ -z "$n" ] && continue
+      if [ "$n" -le "$last_removed" ]; then
+        report "DEAD HOOK in $file: _update_$n is not greater than last_removed ($last_removed), so it will never run"
+        BASELINE_VIOLATIONS=$((BASELINE_VIOLATIONS + 1))
+      fi
+    done <<< "$numbers"
+  fi
+done < <(install_files)
+
+echo "Checked $CHECKED file(s) containing update hooks."
+if [ "$DUPLICATE_VIOLATIONS" = "0" ]; then
+  echo "OK: no duplicate hook numbers within a file."
+fi
+if [ "$BASELINE_VIOLATIONS" = "0" ]; then
+  echo "OK: no hook numbered at or below its module's last_removed."
+fi
+
+if [ "$EXIT_CODE" != "0" ]; then
+  echo >&2
+  echo "Renumber the hooks above. A new hook must be higher than every existing" >&2
+  echo "number in its file and higher than the module's last_removed()." >&2
+  echo "See docs/update-hooks.md." >&2
+fi
+
+exit "$EXIT_CODE"


### PR DESCRIPTION
First of two PRs for the 4.0.1 hook strip. This one is deliberately small: it lands the *rules* so they can be reviewed before the bulk change deletes 520 hooks.

## The lint

`scripts/lint/update-hook-numbering.sh` enforces two rules, both of which have already bitten this project:

1. **No number repeats within a file.** Drupal runs only one of a duplicated pair, so the other silently never executes. `mukurtu_core.install` still carries a comment about an incident of exactly this.
2. **Every number exceeds the module's `hook_update_last_removed()`**, when it has one. Anything at or below that value never runs, because `update_get_update_list()` only lists updates above a site's installed version and a fresh install is seeded at `last_removed`. Dead code that looks live.

It follows `multilingual-guardrails.sh`: same `MUKURTU_LINT_STRICT` switch, and the same self-test that proves each pattern matches its own fixture before the script is trusted against the tree.

### Verified it can actually fail

Rule 2 **cannot fire on `main` yet**, because no module declares `last_removed`. So "OK" from a run against the real tree proves nothing about it, and testing against fixtures was the only way to know it works:

```
fixture: duplicate 40002, plus last_removed 40123 with hooks 40100 / 40123 / 40124

DEAD HOOK ... _update_40100 is not greater than last_removed (40123)
DEAD HOOK ... _update_40123 is not greater than last_removed (40123)
DUPLICATE numbers in ...: 40002
exit=1 under MUKURTU_LINT_STRICT=1
```

`_update_40124` correctly passes, and the boundary case (equal to `last_removed`) is treated as dead, matching Drupal's semantics.

On `main` today it checks 28 files containing hooks and passes.

### The job rename

The lint job is renamed from "Multilingual guardrails" to **"Lint"**, since it now runs two. I checked before doing that: `main` has no branch protection and its only ruleset ("wait for Tugboat on main") is `enforcement: disabled`, so no required-check name breaks. It will show up as a new check name in the UI.

## The docs rewrite

`docs/update-hooks.md` kept its useful guidance but had gone stale and omitted the things that have cost the most time in this work:

- **A hook never runs on a fresh install.** Drupal seeds a new module's schema version to its highest available number without invoking any of them, so a change made only in a hook reaches existing sites and never new ones. The same end state has to be in `config/install` or the two diverge permanently.
- **The two-digit sequence can overflow.** `mukurtu_core` reached `40122` during 4.0.0, consuming the whole `401xx` band 4.0.1 would have used. The number is *not* derivable from the version; check the file's existing maximum.
- **How removal works, and that core does not enforce it.** Core reads `last_removed` in only two places (`ModuleInstaller::install()` and `_update_fix_missing_schema()`). A site too far behind reports **"no pending updates"** and runs on stale configuration rather than being stopped. Blocking one needs an explicit `hook_update_requirements()`, which core *does* honour from both `update.php` and `drush updb`.
- That `requirements` is on core's attribute-hook deny list and must stay procedural, while `runtime_requirements` is not.

The stale to-do about planning the post-4.0 cleanup is dropped, since this work is that plan.

## What is deliberately not here

The strip itself. Deleting the hooks breaks all **67** test files that call them, so hooks + `last_removed` + the too-old guard + test rework have to land together or CI fails. That is PR 2.

Baseline for it, recomputed from the `4.0.0` tag rather than reused from notes: **520 hooks across 28 modules**, `mukurtu_core` at **40123**, `mukurtu_footer` at **40003**.

One observation while writing the lint, not acted on: `mukurtu.install` currently holds 5 update hooks, which the docs say it should not. A placement rule would fail CI today, so I left it out of the lint. The strip removes them anyway.

## Pre-merge checklist:

- [x] I have checked for and if required, created update hooks.
- [x] I have run an accessibility check, and resolved any issues.
- [x] I have recompiled SCSS if required.
- [x] I have updated or created CI/CD tests, if required.
- [x] I have updated from `main` and resolved any merge conflicts.
- [x] If this PR's base branch is not `main`, I understand it needs to be retargeted once that base branch's own PR merges (see [docs/stacked-prs.md](../docs/stacked-prs.md)).
- [ ] I have verified that all expected checks pass.
- [x] I have run the pr-expert-review skill and resolved all relevant issues.
- [x] If I added a content entity bundle, I added its `language.content_settings` and base field overrides to `mukurtu_multilingual` (see `docs/content-language-policy.md`). If I added or changed a view, I applied the content language policy in that doc.

Checklist notes: no update hooks needed, this adds no config or data changes. No accessibility surface: a shell script, a docs file and a CI job. No SCSS. The lint is itself the CI addition, and it was verified against fixtures as above. Base branch is `main`.

> [!NOTE]
> This touches `.github/workflows/build-and-test.yml`, as does #2150. Different regions of the file (the `lint` job here, the install steps there), so they should auto-merge, but whichever lands second may want a glance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
