### PR TITLE
Fix hardcoded, untranslated, redundant branding link

### DIFF
--- a/themes/mukurtu_v4/templates/block/block--mukurtu-v4-branding.html.twig
+++ b/themes/mukurtu_v4/templates/block/block--mukurtu-v4-branding.html.twig
@@ -30,7 +30,7 @@
   {{ title_prefix }}
   {{ title_suffix }}
   {% block content %}
-    <a href="/" title="Link to Home.">
+    <a href="{{ path('<front>') }}" rel="home">
       {{ content }}
     </a>
   {% endblock %}


### PR DESCRIPTION
## Summary

- The site branding link in `themes/mukurtu_v4/templates/block/block--mukurtu-v4-branding.html.twig` used a hardcoded `href="/"`, which breaks on subdirectory installs and ignores the configured front page. Now uses `{{ path('<front>') }}`.
- Removed the redundant, untranslated `title="Link to Home."` attribute. The block instance only enables the site logo, and core's `SystemBrandingBlock` already gives that logo `alt="Home"`, so the link's accessible name was already correct and the `title` was a duplicate announcement risk for screen readers.
- Added `rel="home"`, matching Drupal core's own default branding block markup (e.g. Olivero's `block--system-branding-block.html.twig`).

Fixes #2184

## Pre-merge checklist:

- [x] I have checked for and if required, created update hooks. (Not required — Twig-only change, no config/schema/entity changes.)
- [x] I have run an accessibility check, and resolved any issues.
- [x] I have recompiled SCSS if required. (Not required — no SCSS changes.)
- [x] I have updated or created CI/CD tests, if required. (Not required — no testable logic changed.)
- [x] I have updated from `main` and resolved any merge conflicts.
- [ ] If this PR's base branch is not `main`, I understand it needs to be retargeted once that base branch's own PR merges (see [docs/stacked-prs.md](../docs/stacked-prs.md)). (N/A — based on `main`.)
- [ ] I have verified that all expected checks pass.
- [x] I have run the pr-expert-review skill and resolved all relevant issues.
- [ ] If I added a content entity bundle, I added its `language.content_settings` and base field overrides to `mukurtu_multilingual` (see `docs/content-language-policy.md`). If I added or changed a view, I applied the content language policy in that doc. (N/A — no new bundle/view.)

## Test plan

- [ ] Load the site homepage and confirm the branding logo link navigates to the front page.
- [ ] Inspect the rendered `<a>` tag to confirm no `title` attribute remains and `href` resolves via `path('<front>')`.
- [ ] Confirm with a screen reader or accessibility tooling that the link's accessible name is "Home" with no duplicate announcement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)