### PR TITLE
Make landing page Layout Builder block headings translatable

### DIFF
--- a/modules/mukurtu_landing_page/config/install/core.entity_view_display.node.landing_page.default.yml
+++ b/modules/mukurtu_landing_page/config/install/core.entity_view_display.node.landing_page.default.yml
@@ -12,6 +12,81 @@ third_party_settings:
   layout_builder:
     enabled: true
     allow_custom: true
+    sections:
+      -
+        layout_id: layout_onecol
+        layout_settings: {  }
+        components:
+          bccc8859-099e-4a39-9abc-59fceae3a7d0:
+            uuid: bccc8859-099e-4a39-9abc-59fceae3a7d0
+            region: content
+            configuration:
+              # The 'block_content:' UUID suffix is patched to the real hero
+              # block_content entity at install time, same as the featured
+              # component's block_id/block_revision_id below.
+              id: 'block_content:00000000-0000-0000-0000-000000000000'
+              label: 'Welcome to Your Mukurtu CMS Site'
+              label_display: '1'
+              provider: block_content
+            weight: 0
+            additional: {  }
+          ac4c7245-7c5e-4384-98bb-73dd2ff5d505:
+            uuid: ac4c7245-7c5e-4384-98bb-73dd2ff5d505
+            region: content
+            configuration:
+              id: 'inline_block:featured_content'
+              label: 'Featured Content'
+              label_display: '1'
+              provider: layout_builder
+              view_mode: full
+              # 0 is never a real entity/revision ID, so this can't collide
+              # with an existing block_content entity before it's patched to
+              # the real featured_content block at install time by
+              # DefaultLandingPage::createDefaultLandingPage() (and by the
+              # mukurtu_landing_page update hook for existing sites) - see
+              # InlineBlockEntityOperations::removeUnusedForEntityOnSave(),
+              # which treats a stale, colliding revision_id as an orphaned
+              # inline block to garbage-collect on the next display save.
+              block_id: 0
+              block_revision_id: 0
+              block_serialized: null
+            weight: 1
+            additional: {  }
+          24dc6e76-d1de-4736-8b2c-f58331932643:
+            uuid: 24dc6e76-d1de-4736-8b2c-f58331932643
+            region: content
+            configuration:
+              id: 'views_block:mukurtu_categories-browse_by_category_block'
+              label: 'Browse by Category'
+              label_display: '1'
+              provider: views
+              views_label: ''
+              items_per_page: none
+            weight: 2
+            additional: {  }
+          21fa15de-16b2-4e28-8d1d-4eba8e1edc27:
+            uuid: 21fa15de-16b2-4e28-8d1d-4eba8e1edc27
+            region: content
+            configuration:
+              id: mukurtu_browse_by_community
+              label: 'Browse by Community'
+              label_display: '1'
+              provider: mukurtu_protocol
+            weight: 3
+            additional: {  }
+          74f31657-bb6b-44d1-b100-3b2f8c945509:
+            uuid: 74f31657-bb6b-44d1-b100-3b2f8c945509
+            region: content
+            configuration:
+              id: 'views_block:mukurtu_browse_by_map-map_block'
+              label: 'Browse by Map'
+              label_display: '1'
+              provider: views
+              views_label: ''
+              items_per_page: none
+            weight: 4
+            additional: {  }
+        third_party_settings: {  }
   layout_builder_restrictions:
     allowed_block_categories:
       - 'Chaos Tools'

--- a/modules/mukurtu_landing_page/mukurtu_landing_page.install
+++ b/modules/mukurtu_landing_page/mukurtu_landing_page.install
@@ -1,4 +1,7 @@
 <?php
+
+use Drupal\Core\Config\FileStorage;
+
 /**
  * Implements hook_update_last_removed().
  *
@@ -13,4 +16,58 @@
  */
 function mukurtu_landing_page_update_last_removed(): int {
   return 40006;
+}
+
+/**
+ * Ships translatable landing page block headings; existing homepages keep their current layout until reverted to defaults.
+ */
+function mukurtu_landing_page_update_40201(): string {
+  $config_factory = \Drupal::configFactory();
+  $display_config = $config_factory->getEditable('core.entity_view_display.' . \Drupal\mukurtu_landing_page\DefaultLandingPage::DISPLAY_ID);
+  if ($display_config->isNew()) {
+    return t('No landing_page default display found; nothing to update.');
+  }
+
+  $module_path = \Drupal::service('extension.list.module')->getPath('mukurtu_landing_page');
+  $shipped = (new FileStorage($module_path . '/config/install'))
+    ->read('core.entity_view_display.node.landing_page.default');
+  $sections = $shipped['third_party_settings']['layout_builder']['sections'] ?? [];
+  if (empty($sections[0]['components'])) {
+    return t('Shipped landing_page display config has no Layout Builder sections; nothing to update.');
+  }
+
+  // Point the shipped hero/featured components at this site's own blocks
+  // (tracked since the original install), not the fresh-install placeholders.
+  $state_uuids = \Drupal::state()->get('mukurtu_landing_page.default_blocks', []);
+  $block_storage = \Drupal::entityTypeManager()->getStorage('block_content');
+  $unresolved = [];
+
+  $hero_uuid = $state_uuids['hero'] ?? NULL;
+  $hero_block = $hero_uuid ? current($block_storage->loadByProperties(['uuid' => $hero_uuid])) : NULL;
+  if ($hero_block) {
+    $sections[0]['components'][\Drupal\mukurtu_landing_page\DefaultLandingPage::HERO_COMPONENT_UUID]['configuration']['id'] = 'block_content:' . $hero_block->uuid();
+  }
+  else {
+    $unresolved[] = 'hero';
+  }
+
+  $featured_uuid = $state_uuids['featured'] ?? NULL;
+  $featured_block = $featured_uuid ? current($block_storage->loadByProperties(['uuid' => $featured_uuid])) : NULL;
+  if ($featured_block) {
+    $sections[0]['components'][\Drupal\mukurtu_landing_page\DefaultLandingPage::FEATURED_COMPONENT_UUID]['configuration']['block_id'] = (int) $featured_block->id();
+    $sections[0]['components'][\Drupal\mukurtu_landing_page\DefaultLandingPage::FEATURED_COMPONENT_UUID]['configuration']['block_revision_id'] = (int) $featured_block->getRevisionId();
+  }
+  else {
+    $unresolved[] = 'featured';
+  }
+
+  $display_config
+    ->set('third_party_settings.layout_builder.sections', $sections)
+    ->save();
+
+  if ($unresolved) {
+    return t('Landing page display defaults updated, but could not resolve this site\'s own %blocks block(s) - check core.entity_view_display.node.landing_page.default manually. Existing homepage nodes are unaffected; use "Revert to defaults" on a node\'s Layout tab to pick up the new translatable headings.', ['%blocks' => implode(', ', $unresolved)]);
+  }
+
+  return t('Landing page display defaults updated with translatable block headings. Existing homepage nodes keep their current layout; use "Revert to defaults" on a node\'s Layout tab to pick up the change.');
 }

--- a/modules/mukurtu_landing_page/src/DefaultLandingPage.php
+++ b/modules/mukurtu_landing_page/src/DefaultLandingPage.php
@@ -6,9 +6,6 @@ namespace Drupal\mukurtu_landing_page;
 
 use Drupal\block_content\Entity\BlockContent;
 use Drupal\node\Entity\Node;
-use Drupal\layout_builder\Section;
-use Drupal\layout_builder\SectionComponent;
-use Drupal\Component\Uuid\Php;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\State\StateInterface;
@@ -27,6 +24,31 @@ class DefaultLandingPage {
    * State key used to track the UUIDs of the default landing page blocks.
    */
   private const STATE_KEY = 'mukurtu_landing_page.default_blocks';
+
+  /**
+   * The display config whose Layout Builder defaults hold the homepage layout.
+   *
+   * The section/component labels live here (not on the homepage node's own
+   * override field) specifically so they are reachable by Configuration
+   * Translation - see mukurtu_multilingual.config_translation.yml.
+   */
+  public const DISPLAY_ID = 'node.landing_page.default';
+
+  /**
+   * UUID of the hero component shipped in the display's default section.
+   *
+   * Public so mukurtu_landing_page_update_40201() can patch the same shipped
+   * component on existing sites.
+   */
+  public const HERO_COMPONENT_UUID = 'bccc8859-099e-4a39-9abc-59fceae3a7d0';
+
+  /**
+   * UUID of the featured content component shipped in the default section.
+   *
+   * Public so mukurtu_landing_page_update_40201() can patch the same shipped
+   * component on existing sites.
+   */
+  public const FEATURED_COMPONENT_UUID = 'ac4c7245-7c5e-4384-98bb-73dd2ff5d505';
 
   /**
    * Constructs a DefaultLandingPage object.
@@ -179,7 +201,9 @@ class DefaultLandingPage {
 
     // Footer block is now managed by config/install/block.block.mukurtu_footer_1.yml
 
-    // Create default landing page and set it as homepage.
+    // Create default landing page and set it as homepage. Its Layout Builder
+    // content is not stored on the node - see
+    // updateDisplayDefaultBlockReferences() below.
     $homepage_node = Node::create([
       'type' => 'landing_page', // Use basic page temporarily to test access
       'title' => 'Mukurtu Homepage',
@@ -190,92 +214,14 @@ class DefaultLandingPage {
     ]);
     $homepage_node->save();
 
-    // Add existing blocks to Layout Builder.
-    $uuid_generator = new Php();
-
-    // Create section components for the existing blocks
-    $hero_component = new SectionComponent(
-      $uuid_generator->generate(), // UUID for this component
-      'content', // Region name (layout_onecol has 'content' region)
-      [
-        'id' => 'block_content:' . $hero_block_uuid, // Reference to the block content
-        'label' => 'Welcome to Your Mukurtu CMS Site',
-        'label_display' => 1, // Display the title
-        'provider' => 'block_content',
-      ]
-    );
-    $hero_component->setWeight(0); // First block
-
-    // Placed as a Layout Builder inline block (not a reusable "Content block")
-    // so its "Configure" dialog embeds the block entity form, exposing the
-    // "Select Content" entity browser. Reusable placements only expose the
-    // title/label.
-    $featured_component = new SectionComponent(
-      $uuid_generator->generate(),
-      'content',
-      [
-        'id' => 'inline_block:featured_content',
-        'label' => 'Featured Content',
-        'label_display' => 1,
-        'provider' => 'layout_builder',
-        'view_mode' => 'full',
-        'block_id' => (int) $featured_block_content->id(),
-        'block_revision_id' => (int) $featured_block_content->getRevisionId(),
-        'block_serialized' => NULL,
-      ]
-    );
-    $featured_component->setWeight(1); // Second block
-
-    $categories_component = new SectionComponent(
-      $uuid_generator->generate(),
-      'content',
-      [
-        'id' => 'views_block:mukurtu_categories-browse_by_category_block',
-        'label' => 'Browse by Category',
-        'label_display' => 1,
-        'provider' => 'views',
-        'views_label' => '',
-        'items_per_page' => 'none',
-      ]
-    );
-    $categories_component->setWeight(2); // Third block
-
-    $community_component = new SectionComponent(
-      $uuid_generator->generate(),
-      'content',
-      [
-        'id' => 'mukurtu_browse_by_community',
-        'label' => 'Browse by Community',
-        'label_display' => 1,
-        'provider' => 'mukurtu_protocol',
-      ]
-    );
-    $community_component->setWeight(3); // Fourth block
-
-    $map_component = new SectionComponent(
-      $uuid_generator->generate(),
-      'content',
-      [
-        'id' => 'views_block:mukurtu_browse_by_map-map_block',
-        'label' => 'Browse by Map',
-        'label_display' => 1,
-        'provider' => 'views',
-        'views_label' => '',
-        'items_per_page' => 'none',
-      ]
-    );
-    $map_component->setWeight(4); // Fifth block
-
-    // Create a section using single column layout
-    $section = new Section(
-      'layout_onecol', // Layout plugin ID
-      [], // Layout settings (empty for default)
-      [$hero_component, $featured_component, $categories_component, $community_component, $map_component] // Components array
-    );
-
-    // Set the layout on the node
-    $homepage_node->set('layout_builder__layout', [$section]);
-    $homepage_node->save();
+    // The homepage's block headings ("Featured Content", "Browse by
+    // Category", etc.) are shipped as this bundle's shared Layout Builder
+    // defaults (core.entity_view_display.node.landing_page.default.yml),
+    // not written onto the node's own override field, so they are reachable
+    // by Configuration Translation. Only the block_content references below
+    // are dynamic (created above); patch them onto the already-installed
+    // display config.
+    $this->updateDisplayDefaultBlockReferences($hero_block_uuid, $featured_block_content);
 
     // Record the inline block's usage against the homepage node. The layout
     // config already carries a block_revision_id, so Layout Builder's own
@@ -289,6 +235,44 @@ class DefaultLandingPage {
       ->save();
 
     return $homepage_node;
+  }
+
+  /**
+   * Patches the display's shipped default section with real block references.
+   *
+   * The hero and featured components' labels/placement are shipped as static
+   * config (core.entity_view_display.node.landing_page.default.yml), but
+   * their block_content references can only be known once those entities
+   * exist. This is idempotent: it always overwrites the same shipped
+   * component entries, so calling createDefaultLandingPage() again (e.g.
+   * after a migration) does not duplicate or drift the display's sections.
+   *
+   * @param string $hero_block_uuid
+   *   UUID of the hero image_with_description block_content entity.
+   * @param \Drupal\block_content\Entity\BlockContent $featured_block_content
+   *   The non-reusable featured_content block_content entity.
+   */
+  protected function updateDisplayDefaultBlockReferences(string $hero_block_uuid, BlockContent $featured_block_content): void {
+    /** @var \Drupal\layout_builder\Entity\LayoutBuilderEntityViewDisplay|null $display */
+    $display = $this->entityTypeManager->getStorage('entity_view_display')->load(self::DISPLAY_ID);
+    if (!$display || !$display->getSections()) {
+      return;
+    }
+
+    $section = $display->getSection(0);
+    $hero_component = $section->getComponent(self::HERO_COMPONENT_UUID);
+    $featured_component = $section->getComponent(self::FEATURED_COMPONENT_UUID);
+
+    $hero_config = $hero_component->get('configuration');
+    $hero_config['id'] = 'block_content:' . $hero_block_uuid;
+    $hero_component->setConfiguration($hero_config);
+
+    $featured_config = $featured_component->get('configuration');
+    $featured_config['block_id'] = (int) $featured_block_content->id();
+    $featured_config['block_revision_id'] = (int) $featured_block_content->getRevisionId();
+    $featured_component->setConfiguration($featured_config);
+
+    $display->save();
   }
 
 }

--- a/modules/mukurtu_landing_page/tests/src/Kernel/DefaultLandingPageTest.php
+++ b/modules/mukurtu_landing_page/tests/src/Kernel/DefaultLandingPageTest.php
@@ -4,8 +4,15 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\mukurtu_landing_page\Kernel;
 
+use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Config\FileStorage;
+use Drupal\Core\Plugin\Context\Context;
+use Drupal\Core\Plugin\Context\ContextDefinition;
+use Drupal\Core\Plugin\Context\EntityContext;
 use Drupal\KernelTests\KernelTestBase;
+use Drupal\language\Entity\ConfigurableLanguage;
+use Drupal\mukurtu_landing_page\DefaultLandingPage;
+use Drupal\node\Entity\Node;
 use PHPUnit\Framework\Attributes\Group;
 
 /**
@@ -29,7 +36,9 @@ class DefaultLandingPageTest extends KernelTestBase {
     'block',
     'block_content',
     'layout_builder',
+    'layout_builder_restrictions',
     'layout_discovery',
+    'views',
     'path',
     'path_alias',
     'menu_ui',
@@ -110,6 +119,11 @@ class DefaultLandingPageTest extends KernelTestBase {
     $landing_page_storage = new FileStorage($this->root . '/profiles/mukurtu/modules/mukurtu_landing_page/config/install');
     $this->importConfigEntity($landing_page_storage, 'node.type.landing_page', 'node_type');
     $this->importConfigEntity($landing_page_storage, 'field.field.node.landing_page.layout_builder__layout', 'field_config');
+
+    // The display carries the shipped Layout Builder default section (the
+    // block headings this test suite is about) - createDefaultLandingPage()
+    // patches its hero/featured components rather than writing to the node.
+    $this->importConfigEntity($landing_page_storage, 'core.entity_view_display.node.landing_page.default', 'entity_view_display');
   }
 
   /**
@@ -141,20 +155,32 @@ class DefaultLandingPageTest extends KernelTestBase {
   }
 
   /**
-   * Extracts block_content UUIDs referenced by a landing page's layout.
+   * Loads the landing page display's shipped Layout Builder sections.
    *
-   * @param \Drupal\node\NodeInterface $node
-   *   The landing page node.
+   * @return \Drupal\layout_builder\Section[]
+   *   The display's 'layout_builder.sections' third-party setting, hydrated
+   *   into Section objects (as the entity API returns them at runtime -
+   *   unlike \Drupal\Core\Config\Config::get(), which would return the raw
+   *   array form actually stored in config).
+   */
+  protected function getDisplaySections(): array {
+    $storage = $this->container->get('entity_type.manager')->getStorage('entity_view_display');
+    $storage->resetCache(['node.landing_page.default']);
+    /** @var \Drupal\layout_builder\Entity\LayoutBuilderEntityViewDisplay $display */
+    $display = $storage->load('node.landing_page.default');
+    return $display->getSections();
+  }
+
+  /**
+   * Extracts block_content UUIDs referenced by the landing page display.
    *
    * @return array
-   *   The block_content UUIDs referenced by the node's Layout Builder
-   *   section, keyed by component UUID.
+   *   The block_content UUIDs referenced by the display's shipped Layout
+   *   Builder section, keyed by component UUID.
    */
-  protected function getBlockUuidsFromLayout($node): array {
+  protected function getBlockUuidsFromLayout(): array {
     $uuids = [];
-    /** @var \Drupal\layout_builder\Section[] $sections */
-    $sections = $node->get('layout_builder__layout')->getSections();
-    foreach ($sections as $section) {
+    foreach ($this->getDisplaySections() as $section) {
       foreach ($section->getComponents() as $component) {
         $id = $component->get('configuration')['id'] ?? '';
         if (str_starts_with($id, 'block_content:')) {
@@ -166,20 +192,15 @@ class DefaultLandingPageTest extends KernelTestBase {
   }
 
   /**
-   * Extracts inline block component configurations from a landing page layout.
-   *
-   * @param \Drupal\node\NodeInterface $node
-   *   The landing page node.
+   * Extracts inline block component configurations from the display.
    *
    * @return array
    *   Component configuration arrays for every 'inline_block:*' component,
    *   keyed by component UUID.
    */
-  protected function getInlineComponentsFromLayout($node): array {
+  protected function getInlineComponentsFromLayout(): array {
     $components = [];
-    /** @var \Drupal\layout_builder\Section[] $sections */
-    $sections = $node->get('layout_builder__layout')->getSections();
-    foreach ($sections as $section) {
+    foreach ($this->getDisplaySections() as $section) {
       foreach ($section->getComponents() as $component) {
         $configuration = $component->get('configuration');
         if (str_starts_with($configuration['id'] ?? '', 'inline_block:')) {
@@ -217,7 +238,7 @@ class DefaultLandingPageTest extends KernelTestBase {
     $first_node = $service->createDefaultLandingPage();
     $this->assertNotNull($first_node);
 
-    $first_block_uuids = $this->getBlockUuidsFromLayout($first_node);
+    $first_block_uuids = $this->getBlockUuidsFromLayout();
     $this->assertNotEmpty($first_block_uuids);
 
     $first_block_storage = $this->container->get('entity_type.manager')->getStorage('block_content');
@@ -227,7 +248,9 @@ class DefaultLandingPageTest extends KernelTestBase {
     $second_node = $service->createDefaultLandingPage();
     $this->assertNotNull($second_node);
 
-    // A new landing page node is created each time - that is expected.
+    // A new landing page node is created each time - that is expected. The
+    // shared display's Layout Builder defaults are patched in place, not
+    // duplicated, regardless of how many homepage nodes get created.
     $this->assertNotSame($first_node->id(), $second_node->id());
 
     $second_block_storage = $this->container->get('entity_type.manager')->getStorage('block_content');
@@ -236,7 +259,7 @@ class DefaultLandingPageTest extends KernelTestBase {
     $second_count = count($second_block_storage->loadMultiple());
     $this->assertSame(4, $second_count, 'The second call must not create duplicate block_content entities.');
 
-    $second_block_uuids = $this->getBlockUuidsFromLayout($second_node);
+    $second_block_uuids = $this->getBlockUuidsFromLayout();
     $this->assertNotEmpty($second_block_uuids);
 
     // The set of reusable block_content UUIDs referenced must be identical -
@@ -245,9 +268,12 @@ class DefaultLandingPageTest extends KernelTestBase {
     sort($second_block_uuids);
     $this->assertSame($first_block_uuids, $second_block_uuids);
 
+    // The display's shipped section is never duplicated across calls.
+    $this->assertCount(1, $this->getDisplaySections());
+
     // Featured Content is placed as a non-reusable inline block, so its
     // "Configure" dialog embeds the block form (the "Select Content" browser).
-    $first_inline = $this->getInlineComponentsFromLayout($first_node);
+    $first_inline = $this->getInlineComponentsFromLayout();
     $this->assertCount(1, $first_inline);
     $featured_config = reset($first_inline);
     $this->assertSame('inline_block:featured_content', $featured_config['id']);
@@ -264,7 +290,7 @@ class DefaultLandingPageTest extends KernelTestBase {
     $this->assertFalse($featured_revision->isReusable());
 
     // The second call reuses the same featured block.
-    $second_inline = $this->getInlineComponentsFromLayout($second_node);
+    $second_inline = $this->getInlineComponentsFromLayout();
     $this->assertCount(1, $second_inline);
     $this->assertSame($featured_uuid, $this->resolveInlineBlockUuid(reset($second_inline)));
 
@@ -282,8 +308,8 @@ class DefaultLandingPageTest extends KernelTestBase {
     /** @var \Drupal\mukurtu_landing_page\DefaultLandingPage $service */
     $service = \Drupal::service('mukurtu_landing_page.default_landing_page');
 
-    $first_node = $service->createDefaultLandingPage();
-    $first_block_uuids = $this->getBlockUuidsFromLayout($first_node);
+    $service->createDefaultLandingPage();
+    $first_block_uuids = $this->getBlockUuidsFromLayout();
 
     /** @var \Drupal\block_content\BlockContentStorageInterface $block_storage */
     $block_storage = $this->container->get('entity_type.manager')->getStorage('block_content');
@@ -298,13 +324,13 @@ class DefaultLandingPageTest extends KernelTestBase {
     $block_storage->resetCache();
     $this->assertCount(3, $block_storage->loadMultiple());
 
-    $second_node = $service->createDefaultLandingPage();
+    $service->createDefaultLandingPage();
     $block_storage->resetCache();
 
     // The deleted block was recreated, not duplicated - back to 4 total.
     $this->assertCount(4, $block_storage->loadMultiple());
 
-    $second_block_uuids = $this->getBlockUuidsFromLayout($second_node);
+    $second_block_uuids = $this->getBlockUuidsFromLayout();
 
     // The untouched reusable blocks kept their original UUIDs (reused).
     $untouched_first = array_diff($first_block_uuids, [$deleted_uuid]);
@@ -320,9 +346,73 @@ class DefaultLandingPageTest extends KernelTestBase {
     $this->assertFalse($new_featured_block->isReusable(), 'The recreated Featured Content block must be non-reusable.');
 
     // The layout's inline Featured Content component references the new block.
-    $second_inline = $this->getInlineComponentsFromLayout($second_node);
+    $second_inline = $this->getInlineComponentsFromLayout();
     $this->assertCount(1, $second_inline);
     $this->assertSame($new_featured_block->uuid(), $this->resolveInlineBlockUuid(reset($second_inline)));
+  }
+
+  /**
+   * Tests that the display's block headings are reachable by Config Translation.
+   */
+  public function testDisplayLabelsAreTranslatable(): void {
+    $this->container->get('module_installer')->install(['language', 'config_translation']);
+    ConfigurableLanguage::createFromLangcode('fr')->save();
+
+    /** @var \Drupal\mukurtu_landing_page\DefaultLandingPage $service */
+    $service = \Drupal::service('mukurtu_landing_page.default_landing_page');
+    $service->createDefaultLandingPage();
+
+    \Drupal::languageManager()->getLanguageConfigOverride('fr', 'core.entity_view_display.node.landing_page.default')
+      ->set('third_party_settings.layout_builder.sections.0.components.' . DefaultLandingPage::FEATURED_COMPONENT_UUID . '.configuration.label', 'Contenu en vedette')
+      ->save();
+
+    $storage = \Drupal::entityTypeManager()->getStorage('entity_view_display');
+    $original_language = \Drupal::languageManager()->getConfigOverrideLanguage();
+    \Drupal::languageManager()->setConfigOverrideLanguage(\Drupal::languageManager()->getLanguage('fr'));
+    $storage->resetCache(['node.landing_page.default']);
+    /** @var \Drupal\layout_builder\Entity\LayoutBuilderEntityViewDisplay $translated_display */
+    $translated_display = $storage->load('node.landing_page.default');
+    $translated_label = $translated_display->getSection(0)
+      ->getComponent(DefaultLandingPage::FEATURED_COMPONENT_UUID)
+      ->get('configuration')['label'] ?? NULL;
+    \Drupal::languageManager()->setConfigOverrideLanguage($original_language);
+    $storage->resetCache(['node.landing_page.default']);
+
+    $this->assertSame('Contenu en vedette', $translated_label, 'A language config override for the display changes the rendered label.');
+  }
+
+  /**
+   * Tests that a fresh, un-overridden landing_page node shows the defaults.
+   */
+  public function testUnoverriddenNodeUsesDisplayDefaults(): void {
+    /** @var \Drupal\mukurtu_landing_page\DefaultLandingPage $service */
+    $service = \Drupal::service('mukurtu_landing_page.default_landing_page');
+    // Populate the display's defaults (and their block_content references)
+    // without creating a node via the service, by calling it once and then
+    // creating an entirely separate, plain landing_page node.
+    $service->createDefaultLandingPage();
+
+    $plain_node = Node::create([
+      'type' => 'landing_page',
+      'title' => 'A custom landing page',
+      'status' => TRUE,
+      'uid' => 1,
+    ]);
+    $plain_node->save();
+
+    // The node's own override field is empty - it was never written to.
+    $this->assertTrue($plain_node->get('layout_builder__layout')->isEmpty());
+
+    $display = \Drupal::entityTypeManager()->getStorage('entity_view_display')->load('node.landing_page.default');
+    $section_storage = \Drupal::service('plugin.manager.layout_builder.section_storage')
+      ->findByContext([
+        'entity' => EntityContext::fromEntity($plain_node),
+        'display' => EntityContext::fromEntity($display),
+        'view_mode' => new Context(new ContextDefinition('string'), 'default'),
+      ], new CacheableMetadata());
+    $this->assertNotNull($section_storage, 'A section storage is found for an un-overridden landing_page node.');
+    $this->assertGreaterThan(0, $section_storage->count(), 'The un-overridden node falls back to the display defaults rather than showing a blank layout.');
+    $this->assertSame('Featured Content', $section_storage->getSection(0)->getComponent(DefaultLandingPage::FEATURED_COMPONENT_UUID)->get('configuration')['label']);
   }
 
 }

--- a/modules/mukurtu_multilingual/mukurtu_multilingual.config_translation.yml
+++ b/modules/mukurtu_multilingual/mukurtu_multilingual.config_translation.yml
@@ -1,0 +1,7 @@
+mukurtu_landing_page_layout:
+  title: 'Landing page layout'
+  class: '\Drupal\mukurtu_multilingual\LandingPageLayoutConfigMapper'
+  base_route_name: 'entity.entity_view_display.node.default'
+  names:
+    - core.entity_view_display.node.landing_page.default
+  weight: 20

--- a/modules/mukurtu_multilingual/src/LandingPageLayoutConfigMapper.php
+++ b/modules/mukurtu_multilingual/src/LandingPageLayoutConfigMapper.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\mukurtu_multilingual;
+
+use Drupal\config_translation\ConfigNamesMapper;
+
+/**
+ * Config translation mapper for the landing page's Layout Builder defaults.
+ *
+ * The landing_page display config is not reachable by Configuration
+ * Translation's generic entity-type discovery, since entity_view_display has
+ * no 'edit-form' link template. This mapper attaches translation routes to
+ * Field UI's existing "Manage display" page instead
+ * (entity.entity_view_display.node.default), which needs the {node_type}
+ * route parameter supplied explicitly.
+ */
+class LandingPageLayoutConfigMapper extends ConfigNamesMapper {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getBaseRouteParameters() {
+    return ['node_type' => 'landing_page'];
+  }
+
+}


### PR DESCRIPTION
## Summary

Fixes #2183. The default homepage's Layout Builder block headings ("Featured Content", "Browse by Category", "Browse by Community", "Browse by Map", and the hero) were hardcoded English strings baked directly into the homepage node's own Layout Builder override field, with no way to translate them.

**Root cause, narrower than it first looks:** `landing_page` already has content translation enabled (via an existing imperative override in `mukurtu_multilingual.install`). The actual blocker is that Layout Builder's per-node "Overrides" storage cannot be translated at all — confirmed via Drupal core's own kernel test (`layout_builder/tests/src/Kernel/TranslatableFieldTest.php::testSectionsClearedOnCreateTranslation()`), which explicitly wipes a node's Layout Builder override data whenever a new translation is created. So enabling translation on that field would not have worked.

**Fix:** move this Layout Builder section from the homepage node's own field into the `landing_page` bundle's shared Layout Builder *display defaults* (`core.entity_view_display.node.landing_page.default.yml`) — a config entity whose component labels Configuration Translation already recognizes as translatable via schema. Since Drupal core doesn't expose a "Translate" tab for `entity_view_display` config entities out of the box, this adds a small custom Config Translation mapper (`modules/mukurtu_multilingual`) that attaches translation routes to the existing Field UI "Manage display" page instead.

- `modules/mukurtu_landing_page/config/install/core.entity_view_display.node.landing_page.default.yml`: ships the 5-component default section (previously only ever written by code, never in config).
- `modules/mukurtu_landing_page/src/DefaultLandingPage.php`: no longer writes a `Section` onto the homepage node; instead patches the display's shipped hero/featured components with their real `block_content` references once those blocks exist (idempotent across repeated calls, e.g. after a migration).
- `modules/mukurtu_multilingual/mukurtu_multilingual.config_translation.yml` + `src/LandingPageLayoutConfigMapper.php`: new Config Translation mapper exposing the "Translate" tab on `/admin/structure/types/manage/landing_page/display/default`.
- `modules/mukurtu_landing_page/mukurtu_landing_page.install`: update hook for existing sites — ships the new display config without touching any existing site's own homepage node override (per this repo's update-hooks guidance about not clobbering site customization); resolves the *site's own* tracked hero/featured blocks, not the fresh-install placeholders.
- Kernel tests updated (helpers now read from the display instead of the node) plus two new tests: one round-tripping a language config override to prove the labels are actually translatable, one confirming a fresh, un-overridden `landing_page` node correctly falls back to rendering the display's defaults.

**Note:** any *other* `landing_page` node a site builder creates (not just the homepage) now starts pre-populated with this same 5-component starter layout instead of blank, since it inherits the shared display defaults until customized — an inherent, intentional consequence of this approach.

This was extensively verified beyond the kernel tests: a full DDEV site install (fresh-install path), the real Config Translation admin UI (Translate tab discoverable, add-translation form correctly lists all 5 labels, a real French translation was submitted and persisted), and the update hook run against a schema-rolled-back site simulating an existing install.

## Pre-merge checklist:

- [x] I have checked for and if required, created update hooks. (`mukurtu_landing_page_update_40201`, verified against a simulated existing site.)
- [x] I have run an accessibility check, and resolved any issues. (No markup/template changes; rendered output for English is unaffected — net improvement for other languages.)
- [x] I have recompiled SCSS if required. (Not required — no SCSS changes.)
- [x] I have updated or created CI/CD tests, if required. (Kernel tests updated + 2 new, all passing.)
- [x] I have updated from `main` and resolved any merge conflicts.
- [ ] If this PR's base branch is not `main`, I understand it needs to be retargeted once that base branch's own PR merges (see [docs/stacked-prs.md](../docs/stacked-prs.md)). (N/A — based on `main`.)
- [ ] I have verified that all expected checks pass.
- [x] I have run the pr-expert-review skill and resolved all relevant issues.
- [ ] If I added a content entity bundle, I added its `language.content_settings` and base field overrides to `mukurtu_multilingual` (see `docs/content-language-policy.md`). If I added or changed a view, I applied the content language policy in that doc. (N/A — no new bundle/view; this PR extends the existing `landing_page` bundle's multilingual support.)

## Test plan

- [x] Kernel tests pass (`DefaultLandingPageTest`, 4/4).
- [x] Fresh site install succeeds and produces the correct final display state (verified via `drush site:install`).
- [x] The "Translate" local task appears at `/admin/structure/types/manage/landing_page/display/default`, and submitting a French translation for a label persists and is retrievable via a language config override.
- [x] Simulated an existing site (rolled back the module's schema version) and confirmed `drush updatedb` correctly re-associates the site's own hero/featured blocks rather than the fresh-install placeholders, and does not touch the existing homepage node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)